### PR TITLE
Implement grammar loading and parse table generation

### DIFF
--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -125,17 +125,22 @@ impl BetaTester {
     }
 
     /// Load a grammar from disk
-    fn load_grammar(&self, _path: &Path) -> Result<Grammar> {
-        // TODO: Implement grammar loading
-        // This would parse the rust-sitter grammar definition
-        unimplemented!("Grammar loading not yet implemented")
+    pub fn load_grammar(&self, path: &Path) -> Result<Grammar> {
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("Failed to read grammar file at {}", path.display()))?;
+
+        let grammar: Grammar = serde_json::from_str(&content)
+            .with_context(|| format!("Failed to parse grammar JSON from {}", path.display()))?;
+        Ok(grammar)
     }
 
     /// Generate parse table for grammar
-    fn generate_parse_table(&self, _grammar: &Grammar) -> Result<ParseTable> {
-        // TODO: Implement parse table generation
-        // This would use the GLR core to generate tables
-        unimplemented!("Parse table generation not yet implemented")
+    pub fn generate_parse_table(&self, grammar: &Grammar) -> Result<ParseTable> {
+        use rust_sitter_glr_core::{FirstFollowSets, build_lr1_automaton};
+
+        let ff = FirstFollowSets::compute(grammar);
+        let table = build_lr1_automaton(grammar, &ff).context("Failed to build LR(1) automaton")?;
+        Ok(table)
     }
 
     /// Test a single file

--- a/testing/tests/grammar_loading.rs
+++ b/testing/tests/grammar_loading.rs
@@ -1,0 +1,36 @@
+use rust_sitter_ir::builder::GrammarBuilder;
+use rust_sitter_testing::{BetaTester, TestConfig};
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn grammar_loads_and_generates_parse_table() {
+    // Build a simple grammar and write it to disk as JSON
+    let grammar = GrammarBuilder::new("test")
+        .token("NUMBER", r"\\d+")
+        .rule("expr", vec!["NUMBER"])
+        .start("expr")
+        .build();
+
+    let dir = tempdir().unwrap();
+    let grammar_path = dir.path().join("grammar.json");
+    fs::write(&grammar_path, serde_json::to_string(&grammar).unwrap()).unwrap();
+
+    let config = TestConfig {
+        grammar_path: grammar_path.clone(),
+        test_files: vec![],
+        tree_sitter_path: None,
+        compare_output: false,
+        benchmark: false,
+        external_scanner: None,
+    };
+
+    let tester = BetaTester::new(config);
+    let loaded = tester.load_grammar(&grammar_path).expect("grammar loads");
+    let table = tester
+        .generate_parse_table(&loaded)
+        .expect("parse table generation");
+
+    assert!(table.state_count > 0);
+    assert!(!table.action_table.is_empty());
+}


### PR DESCRIPTION
## Summary
- Support loading grammar definitions from JSON files in the testing framework
- Build parse tables using GLR core's LR(1) automaton generation
- Add integration test ensuring grammar loads and parse table is non-empty

## Testing
- `cargo fmt`
- `cargo test -p rust-sitter-testing`

------
https://chatgpt.com/codex/tasks/task_e_68ad542911a88333945bf25b9f3992c4