### PR TITLE
Implement goto state lookup

### DIFF
--- a/runtime/src/pure_parser.rs
+++ b/runtime/src/pure_parser.rs
@@ -1336,26 +1336,16 @@ impl Parser {
         }
     }
 
-    /// Get goto state after reduction
-    ///
-    /// NOTE: This function is not used in the pure-Rust parser implementation.
-    /// The GLR parser (parser_v4) determines goto states directly during parsing.
-    /// This function exists for API compatibility but is never invoked.
-    ///
-    /// If this function were to be called, it would panic to catch any misuse.
+    /// Look up the goto state for a non-terminal using the parse table.
+    /// Returns `0` when no transition exists, mirroring Tree-sitter's ABI.
     #[allow(dead_code)]
     fn get_goto_state(
         &self,
-        _language: &TSLanguage,
-        _state: TSStateId,
-        _symbol: TSSymbol,
+        language: &TSLanguage,
+        state: TSStateId,
+        symbol: TSSymbol,
     ) -> TSStateId {
-        // This function should never be called in the pure-Rust implementation
-        // The GLR parser (parser_v4) handles goto states internally
-        panic!(
-            "get_goto_state called on pure_parser::Parser - this is a bug! \
-             The GLR parser should handle goto states internally."
-        );
+        self.get_goto(language, state, symbol).unwrap_or(0)
     }
 
     /// Get expected symbols for error reporting
@@ -1692,5 +1682,113 @@ mod tests {
         let result = parser.parse_string("");
         assert!(result.root.is_none());
         assert!(!result.errors.is_empty());
+    }
+
+    #[test]
+    fn test_get_goto_handles_missing_entries() {
+        // Minimal language with a single token and no goto entries.
+        static PARSE_TABLE: [u16; 1] = [0];
+        static SMALL_PARSE_TABLE: [u16; 1] = [0];
+        static SMALL_PARSE_TABLE_MAP: [u32; 1] = [0];
+        static LANGUAGE: TSLanguage = TSLanguage {
+            version: TREE_SITTER_LANGUAGE_VERSION,
+            symbol_count: 1,
+            alias_count: 0,
+            token_count: 1,
+            external_token_count: 0,
+            state_count: 1,
+            large_state_count: 1,
+            production_id_count: 0,
+            field_count: 0,
+            max_alias_sequence_length: 0,
+            production_id_map: std::ptr::null(),
+            parse_table: PARSE_TABLE.as_ptr(),
+            small_parse_table: SMALL_PARSE_TABLE.as_ptr(),
+            small_parse_table_map: SMALL_PARSE_TABLE_MAP.as_ptr(),
+            parse_actions: std::ptr::null(),
+            symbol_names: std::ptr::null(),
+            field_names: std::ptr::null(),
+            field_map_slices: std::ptr::null(),
+            field_map_entries: std::ptr::null(),
+            symbol_metadata: std::ptr::null(),
+            public_symbol_map: std::ptr::null(),
+            alias_map: std::ptr::null(),
+            alias_sequences: std::ptr::null(),
+            lex_modes: std::ptr::null(),
+            lex_fn: None,
+            keyword_lex_fn: None,
+            keyword_capture_token: 0,
+            external_scanner: ExternalScanner::default(),
+            primary_state_ids: std::ptr::null(),
+            production_lhs_index: std::ptr::null(),
+            production_count: 0,
+            eof_symbol: 0,
+            rules: std::ptr::null(),
+            rule_count: 0,
+        };
+
+        let parser = Parser {
+            language: None,
+            stack: Vec::new(),
+            timeout_micros: 0,
+            cancellation_flag: None,
+            lexer: None,
+        };
+
+        // Symbol 0 is a token; there is no goto entry. The helper should
+        // return None instead of panicking.
+        assert!(parser.get_goto(&LANGUAGE, 0, 0).is_none());
+    }
+
+    #[test]
+    fn test_get_goto_state_returns_zero_when_missing() {
+        // Language with one token and one non-terminal but no goto entries.
+        static PARSE_TABLE: [u16; 2] = [0, 0];
+        static SMALL_PARSE_TABLE: [u16; 1] = [0];
+        static SMALL_PARSE_TABLE_MAP: [u32; 1] = [0];
+        static LEX_MODES: [TSLexState; 1] = [TSLexState {
+            lex_state: 0,
+            external_lex_state: 0,
+        }];
+        static LANGUAGE: TSLanguage = TSLanguage {
+            version: TREE_SITTER_LANGUAGE_VERSION,
+            symbol_count: 2,
+            alias_count: 0,
+            token_count: 1,
+            external_token_count: 0,
+            state_count: 1,
+            large_state_count: 1,
+            production_id_count: 0,
+            field_count: 0,
+            max_alias_sequence_length: 0,
+            production_id_map: std::ptr::null(),
+            parse_table: PARSE_TABLE.as_ptr(),
+            small_parse_table: SMALL_PARSE_TABLE.as_ptr(),
+            small_parse_table_map: SMALL_PARSE_TABLE_MAP.as_ptr(),
+            parse_actions: std::ptr::null(),
+            symbol_names: std::ptr::null(),
+            field_names: std::ptr::null(),
+            field_map_slices: std::ptr::null(),
+            field_map_entries: std::ptr::null(),
+            symbol_metadata: std::ptr::null(),
+            public_symbol_map: std::ptr::null(),
+            alias_map: std::ptr::null(),
+            alias_sequences: std::ptr::null(),
+            lex_modes: LEX_MODES.as_ptr(),
+            lex_fn: None,
+            keyword_lex_fn: None,
+            keyword_capture_token: 0,
+            external_scanner: ExternalScanner::default(),
+            primary_state_ids: std::ptr::null(),
+            production_lhs_index: std::ptr::null(),
+            production_count: 0,
+            eof_symbol: 0,
+            rules: std::ptr::null(),
+            rule_count: 0,
+        };
+
+        let parser = Parser::new();
+        // Symbol 1 is the lone non-terminal; with no table entry this should return 0.
+        assert_eq!(parser.get_goto_state(&LANGUAGE, 0, 1), 0);
     }
 }

--- a/runtime/tests/smoke_glr.rs
+++ b/runtime/tests/smoke_glr.rs
@@ -5,34 +5,36 @@ use std::collections::BTreeMap;
 #[test]
 fn glr_smoke_table_construction() {
     // Test that we can construct a basic parse table without panic
-    // ERROR(0), 'x'(1), EOF(2), S(3)
-    let mut action = vec![vec![vec![]; 4]; 2];
+    // EOF(0), 'x'(1), S(2)
+    // ACTION table columns are [EOF, 'x']
+    let mut action = vec![vec![vec![]; 2]; 2];
     action[0][1].push(Action::Shift(StateId(1))); // on 'x' shift to 1
-    action[1][2].push(Action::Reduce(RuleId(0))); // on EOF reduce S -> 'x'
+    action[1][0].push(Action::Reduce(RuleId(0))); // on EOF reduce S -> 'x'
 
-    let mut gotos = vec![vec![StateId(65535); 4]; 2];
-    gotos[0][3] = StateId(1); // goto S after reduce (accept state)
+    // GOTO table columns are nonterminals [S]
+    let mut gotos = vec![vec![StateId(65535); 1]; 2];
+    gotos[0][0] = StateId(1); // goto S after reduce (accept state)
 
+    // Map terminals to ACTION table columns
     let mut sym2idx = BTreeMap::new();
-    for i in 0..4 {
-        sym2idx.insert(SymbolId(i), i as usize);
-    }
+    sym2idx.insert(SymbolId(0), 0); // EOF
+    sym2idx.insert(SymbolId(1), 1); // 'x'
 
     let table = ParseTable {
         action_table: action,
         goto_table: gotos,
         rules: vec![ParseRule {
-            lhs: SymbolId(3),
+            lhs: SymbolId(2),
             rhs_len: 1,
         }],
         state_count: 2,
-        symbol_count: 4,
+        symbol_count: 3,
         symbol_to_index: sym2idx,
-        index_to_symbol: vec![SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)],
-        token_count: 2, // 'x', EOF-1 (EOF is token_count)
+        index_to_symbol: vec![SymbolId(0), SymbolId(1)],
+        token_count: 1, // only 'x'
         external_token_count: 0,
-        eof_symbol: SymbolId(2),
-        start_symbol: SymbolId(3),
+        eof_symbol: SymbolId(0),
+        start_symbol: SymbolId(2),
         extras: vec![],
         external_scanner_states: vec![vec![false; 0]; 2],
         grammar: Grammar::default(),
@@ -49,17 +51,17 @@ fn glr_smoke_table_construction() {
         alias_sequences: vec![],
         field_names: vec![],
         field_map: BTreeMap::new(),
-        nonterminal_to_index: BTreeMap::from([(SymbolId(3), 3)]),
+        nonterminal_to_index: BTreeMap::from([(SymbolId(2), 0)]),
         goto_indexing: rust_sitter_glr_core::GotoIndexing::NonterminalMap,
         symbol_metadata: vec![],
     };
 
     // Basic sanity checks
     assert_eq!(table.state_count, 2);
-    assert_eq!(table.symbol_count, 4);
-    assert_eq!(table.token_count, 2);
-    assert_eq!(table.eof_symbol, SymbolId(2));
-    assert_eq!(table.start_symbol, SymbolId(3));
+    assert_eq!(table.symbol_count, 3);
+    assert_eq!(table.token_count, 1);
+    assert_eq!(table.eof_symbol, SymbolId(0));
+    assert_eq!(table.start_symbol, SymbolId(2));
 
     // Verify we can create a driver (doesn't parse anything, just checks construction)
     let _driver = rust_sitter_glr_core::Driver::new(&table);


### PR DESCRIPTION
## Summary
- add `get_goto_state` that consults parse-table data and returns 0 if no transition exists
- cover missing-goto case with a unit test

## Testing
- `cargo test -p rust-sitter --lib`
- `cargo test -p rust-sitter --test smoke_glr`


------
https://chatgpt.com/codex/tasks/task_e_68ad541807108333a335e8a7ec3dee7b