### PR TITLE
ci: gate windows benchmark compile tail

### DIFF
--- a/.github/workflows/pure-rust-ci.yml
+++ b/.github/workflows/pure-rust-ci.yml
@@ -69,11 +69,21 @@ jobs:
         echo "Benchmark compile check elapsed: $((SECONDS - start))s"
 
     - name: Run focused benchmark compile check (runtime only) on Windows
-      if: matrix.os == 'windows-latest' && github.event_name != 'pull_request'
+      if: matrix.os == 'windows-latest'
       run: |
+        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          echo "::notice::Skipping Windows benchmark compile check on pull_request events (non-blocking, no-signal path)."
+          echo "Benchmark compile check elapsed: skipped"
+          exit 0
+        fi
+
         start=$SECONDS
-        cargo bench -p adze --no-run
-        echo "Benchmark compile check elapsed: $((SECONDS - start))s"
+        cargo bench -p adze --bench simple_bench --no-run
+        elapsed=$((SECONDS - start))
+        echo "Benchmark compile check elapsed: ${elapsed}s"
+        if [[ "$elapsed" -gt 600 ]]; then
+          echo "::warning::Windows benchmark compile tail took ${elapsed}s on ${{ matrix.rust }}."
+        fi
   
   test-wasm:
     name: Test WASM Build


### PR DESCRIPTION
## Summary
Closes #269.

- Keep Windows pure-rust benchmark compile tail out of PR-required path by making it non-blocking.
- Scope benchmark no-run check to the runtime crate + simple_bench target to reduce redundant compile surface.
- Add deterministic timing output and warning annotation for slow tails.

This keeps CI truthfulness while preserving signal and observability for the long-tail workload.