### PR TITLE
fix: repair runtime compile surface for all-features and no-default

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -45,7 +45,7 @@ strict_api = [] # Enable strict API surface checking
 unstable-benches = [] # Enable benchmarks that depend on unstable APIs
 glr_telemetry = [] # Enable GLR telemetry
 glr = ["adze-runtime-governance-api/glr"] # Enable GLR parser mode
-with-grammars = ["ts_bridge", "tree_sitter_json"] # Enable tests that require ts-bridge and tree-sitter grammars
+with-grammars = ["dep:ts_bridge", "dep:tree_sitter_json"] # Enable tests that require ts-bridge and tree-sitter grammars
 
 [dependencies]
 tree-sitter-runtime-c2rust = { package = "tree-sitter-c2rust", version = "0.25.2", optional = true }

--- a/runtime/src/__private.rs
+++ b/runtime/src/__private.rs
@@ -594,7 +594,7 @@ mod tests {
     #[test]
     #[cfg(feature = "glr")]
     fn given_empty_symbol_zero_node_when_name_lookup_absent_then_marked_error_by_shape() {
-        let names = [b"root\0".as_ptr()];
+        let names = [c"root".as_ptr() as *const u8];
         let language = TSLanguage {
             symbol_count: 1,
             symbol_names: names.as_ptr(),

--- a/runtime/src/__private.rs
+++ b/runtime/src/__private.rs
@@ -388,7 +388,7 @@ fn parse_with_pure_parser<T: Extract<T>>(
 }
 
 /// Parse using the GLR parser (parser_v4)
-#[cfg(feature = "glr")]
+#[cfg(all(feature = "glr", feature = "pure-rust"))]
 fn parse_with_glr<T: Extract<T>>(
     input: &str,
     language: impl Fn() -> &'static crate::pure_parser::TSLanguage,
@@ -454,7 +454,7 @@ fn parse_with_glr<T: Extract<T>>(
 }
 
 /// Convert parser_v4::ParseNode to pure_parser::ParsedNode
-#[cfg(feature = "glr")]
+#[cfg(all(feature = "glr", feature = "pure-rust"))]
 fn convert_parse_node_v4_to_pure(
     node: &crate::parser_v4::ParseNode,
     lang: &crate::pure_parser::TSLanguage,

--- a/runtime/src/external_scanner/adapter.rs
+++ b/runtime/src/external_scanner/adapter.rs
@@ -137,18 +137,19 @@ impl<'a> crate::external_scanner::Lexer for TSLexerAdapter<'a> {
                 }
 
                 // Check if we need to move to next range
-                if let Some(range) = self.current_range() {
-                    if self.cursor >= range.end && self.ranges.next + 1 < self.ranges.spans.len() {
-                        // Move to next range
-                        self.ranges.next += 1;
-                        if let Some(next_range) = self.ranges.spans.get(self.ranges.next) {
-                            self.cursor = next_range.start;
-                            // Recalculate position for new range
-                            let (row, col) =
-                                position_to_line_col(self.src, self.cursor, self.line_starts);
-                            self.row = row;
-                            self.col = col;
-                        }
+                if let Some(range) = self.current_range()
+                    && self.cursor >= range.end
+                    && self.ranges.next + 1 < self.ranges.spans.len()
+                {
+                    // Move to next range
+                    self.ranges.next += 1;
+                    if let Some(next_range) = self.ranges.spans.get(self.ranges.next) {
+                        self.cursor = next_range.start;
+                        // Recalculate position for new range
+                        let (row, col) =
+                            position_to_line_col(self.src, self.cursor, self.line_starts);
+                        self.row = row;
+                        self.col = col;
                     }
                 }
             } else {

--- a/runtime/src/external_scanner/adapter.rs
+++ b/runtime/src/external_scanner/adapter.rs
@@ -224,7 +224,7 @@ mod tests {
     fn test_advance_crlf() {
         let input = b"hello\r\nworld";
         let line_starts = vec![0, 7]; // "hello\r\n" is 7 bytes
-        let ranges = vec![0..input.len()];
+        let ranges = std::iter::once(0..input.len()).collect::<Vec<_>>();
         let mut adapter = TSLexerAdapter::new(input, 0, &line_starts, ranges);
 
         // Advance through "hello"

--- a/runtime/src/glr_incremental.rs
+++ b/runtime/src/glr_incremental.rs
@@ -196,7 +196,7 @@ pub fn reparse<'arena>(
     // Only enable incremental parsing if the feature is enabled
     #[cfg(feature = "incremental_glr")]
     {
-        return None;
+        None
     }
 
     #[cfg(not(feature = "incremental_glr"))]

--- a/runtime/src/incremental.rs
+++ b/runtime/src/incremental.rs
@@ -299,6 +299,6 @@ mod tests {
         let affected = tree.apply_edit(&edit);
 
         // Should affect middle nodes
-        assert!(affected.len() > 0);
+        assert!(!affected.is_empty());
     }
 }

--- a/runtime/src/incremental_v3.rs
+++ b/runtime/src/incremental_v3.rs
@@ -599,10 +599,9 @@ mod tests {
         // This test would require a proper grammar and parse table
         // For now, it demonstrates the API
 
-        let grammar = Grammar::new("test".to_string());
+        let _grammar = Grammar::new("test".to_string());
         // TODO: ParseTable needs to be properly implemented in glr-core
         // For now, skip this test until ParseTable API is available
-        return;
 
         // Unreachable code - commented out until ParseTable is available:
         //

--- a/runtime/src/node.rs
+++ b/runtime/src/node.rs
@@ -30,7 +30,9 @@ use std::collections::HashMap;
 type NodeDataCacheKey = (usize, NodeHandle);
 
 thread_local! {
-    static NODE_DATA_CACHE: RefCell<HashMap<NodeDataCacheKey, &'static TreeNodeData>> =
+    // Root per-thread fallback metadata so repeated sanitizer/Miri runs do not
+    // report intentional leaks from boxed placeholders.
+    static NODE_DATA_CACHE: RefCell<HashMap<NodeDataCacheKey, Box<TreeNodeData>>> =
         RefCell::new(HashMap::new());
 }
 
@@ -91,17 +93,15 @@ impl<'arena> Node<'arena> {
     /// symbol while full parse-tree data integration is completed.
     pub fn data(&self) -> &'arena TreeNodeData {
         let key: NodeDataCacheKey = (self.arena as *const _ as usize, self.handle);
+        let symbol = self.raw_node().value() as u16;
 
         NODE_DATA_CACHE.with(|cache| {
             let mut cache = cache.borrow_mut();
-            if let Some(data) = cache.get(&key) {
-                return *data;
-            }
-
-            let symbol = self.raw_node().value() as u16;
-            let data = Box::leak(Box::new(TreeNodeData::new(symbol, 0, 0)));
-            cache.insert(key, data);
-            data
+            let data = cache
+                .entry(key)
+                .or_insert_with(|| Box::new(TreeNodeData::new(symbol, 0, 0)));
+            let ptr: *const TreeNodeData = data.as_ref();
+            unsafe { &*ptr }
         })
     }
 

--- a/runtime/src/parser_v2.rs
+++ b/runtime/src/parser_v2.rs
@@ -533,6 +533,7 @@ mod tests {
     use super::*;
     use adze_ir::{ProductionId, Symbol, TokenPattern};
 
+    #[allow(dead_code)]
     fn create_simple_grammar() -> Grammar {
         // Create a simple arithmetic grammar
         // E -> E + T | T

--- a/runtime/src/parser_v3.rs
+++ b/runtime/src/parser_v3.rs
@@ -763,7 +763,6 @@ mod tests {
 
         // TODO: ParseTable needs to be properly implemented in glr-core
         // For now, skip this test until ParseTable API is available
-        return;
 
         // Unreachable code - commented out until ParseTable is available:
         // let parse_table = ParseTable::default();

--- a/runtime/src/parser_v4.rs
+++ b/runtime/src/parser_v4.rs
@@ -1690,6 +1690,7 @@ mod tests {
     use crate::scanner_registry::ExternalScannerBuilder;
     use crate::scanners::IndentationScanner;
     use std::ffi::c_void;
+    use std::sync::OnceLock;
 
     #[allow(dead_code)]
     unsafe extern "C" fn test_custom_lexer_fn(_lexer: *mut c_void, _state: TSLexState) -> bool {
@@ -1697,7 +1698,8 @@ mod tests {
     }
 
     fn minimal_custom_lexer_language() -> &'static TSLanguage {
-        let language = TSLanguage {
+        static LANGUAGE: OnceLock<TSLanguage> = OnceLock::new();
+        LANGUAGE.get_or_init(|| TSLanguage {
             version: 15,
             symbol_count: 0,
             alias_count: 0,
@@ -1732,8 +1734,7 @@ mod tests {
             rules: std::ptr::null(),
             rule_count: 0,
             eof_symbol: 0,
-        };
-        Box::leak(Box::new(language))
+        })
     }
 
     #[test]

--- a/runtime/src/parser_v4.rs
+++ b/runtime/src/parser_v4.rs
@@ -1689,8 +1689,13 @@ mod tests {
     use crate::pure_parser::{ExternalScanner, TSLexState};
     use crate::scanner_registry::ExternalScannerBuilder;
     use crate::scanners::IndentationScanner;
+    use std::cell::RefCell;
     use std::ffi::c_void;
-    use std::sync::OnceLock;
+
+    thread_local! {
+        static MINIMAL_CUSTOM_LEXER_LANGUAGE: RefCell<Option<Box<TSLanguage>>> =
+            const { RefCell::new(None) };
+    }
 
     #[allow(dead_code)]
     unsafe extern "C" fn test_custom_lexer_fn(_lexer: *mut c_void, _state: TSLexState) -> bool {
@@ -1698,42 +1703,48 @@ mod tests {
     }
 
     fn minimal_custom_lexer_language() -> &'static TSLanguage {
-        static LANGUAGE: OnceLock<TSLanguage> = OnceLock::new();
-        LANGUAGE.get_or_init(|| TSLanguage {
-            version: 15,
-            symbol_count: 0,
-            alias_count: 0,
-            token_count: 0,
-            external_token_count: 0,
-            state_count: 0,
-            large_state_count: 0,
-            production_id_count: 0,
-            field_count: 0,
-            max_alias_sequence_length: 0,
-            production_id_map: std::ptr::null(),
-            parse_table: std::ptr::null(),
-            small_parse_table: std::ptr::null(),
-            small_parse_table_map: std::ptr::null(),
-            parse_actions: std::ptr::null(),
-            symbol_names: std::ptr::null(),
-            field_names: std::ptr::null(),
-            field_map_slices: std::ptr::null(),
-            field_map_entries: std::ptr::null(),
-            symbol_metadata: std::ptr::null(),
-            public_symbol_map: std::ptr::null(),
-            alias_map: std::ptr::null(),
-            alias_sequences: std::ptr::null(),
-            lex_modes: std::ptr::null(),
-            lex_fn: Some(test_custom_lexer_fn),
-            keyword_lex_fn: None,
-            keyword_capture_token: 0,
-            external_scanner: ExternalScanner::default(),
-            primary_state_ids: std::ptr::null(),
-            production_lhs_index: std::ptr::null(),
-            production_count: 0,
-            rules: std::ptr::null(),
-            rule_count: 0,
-            eof_symbol: 0,
+        MINIMAL_CUSTOM_LEXER_LANGUAGE.with(|language| {
+            let mut language = language.borrow_mut();
+            let language = language.get_or_insert_with(|| {
+                Box::new(TSLanguage {
+                    version: 15,
+                    symbol_count: 0,
+                    alias_count: 0,
+                    token_count: 0,
+                    external_token_count: 0,
+                    state_count: 0,
+                    large_state_count: 0,
+                    production_id_count: 0,
+                    field_count: 0,
+                    max_alias_sequence_length: 0,
+                    production_id_map: std::ptr::null(),
+                    parse_table: std::ptr::null(),
+                    small_parse_table: std::ptr::null(),
+                    small_parse_table_map: std::ptr::null(),
+                    parse_actions: std::ptr::null(),
+                    symbol_names: std::ptr::null(),
+                    field_names: std::ptr::null(),
+                    field_map_slices: std::ptr::null(),
+                    field_map_entries: std::ptr::null(),
+                    symbol_metadata: std::ptr::null(),
+                    public_symbol_map: std::ptr::null(),
+                    alias_map: std::ptr::null(),
+                    alias_sequences: std::ptr::null(),
+                    lex_modes: std::ptr::null(),
+                    lex_fn: Some(test_custom_lexer_fn),
+                    keyword_lex_fn: None,
+                    keyword_capture_token: 0,
+                    external_scanner: ExternalScanner::default(),
+                    primary_state_ids: std::ptr::null(),
+                    production_lhs_index: std::ptr::null(),
+                    production_count: 0,
+                    rules: std::ptr::null(),
+                    rule_count: 0,
+                    eof_symbol: 0,
+                })
+            });
+            let language_ptr = language.as_ref() as *const TSLanguage;
+            unsafe { &*language_ptr }
         })
     }
 

--- a/runtime/src/serialization.rs
+++ b/runtime/src/serialization.rs
@@ -166,11 +166,8 @@ impl<'a> TreeSerializer<'a> {
             kind: format!("symbol_{}", node.symbol), // Convert symbol to string
             is_named: node.is_named,
             field_name: node.field_id.map(|id| format!("field_{}", id)), // Convert field_id to placeholder name
-            start_position: (
-                node.start_point.row as usize,
-                node.start_point.column as usize,
-            ),
-            end_position: (node.end_point.row as usize, node.end_point.column as usize),
+            start_position: (node.start_point.row, node.start_point.column),
+            end_position: (node.end_point.row, node.end_point.column),
             start_byte: node.start_byte,
             end_byte: node.end_byte,
             text: None,
@@ -208,14 +205,8 @@ impl<'a> TreeSerializer<'a> {
             kind: node.kind().to_string(),
             is_named: node.is_named(),
             field_name: node.field_name().map(|s| s.to_string()),
-            start_position: (
-                node.start_position().row as usize,
-                node.start_position().column as usize,
-            ),
-            end_position: (
-                node.end_position().row as usize,
-                node.end_position().column as usize,
-            ),
+            start_position: (node.start_position().row, node.start_position().column),
+            end_position: (node.end_position().row, node.end_position().column),
             start_byte: node.start_byte(),
             end_byte: node.end_byte(),
             text: None,

--- a/runtime/src/serialization.rs
+++ b/runtime/src/serialization.rs
@@ -166,8 +166,11 @@ impl<'a> TreeSerializer<'a> {
             kind: format!("symbol_{}", node.symbol), // Convert symbol to string
             is_named: node.is_named,
             field_name: node.field_id.map(|id| format!("field_{}", id)), // Convert field_id to placeholder name
-            start_position: (node.start_point.row, node.start_point.column),
-            end_position: (node.end_point.row, node.end_point.column),
+            start_position: (
+                node.start_point.row as usize,
+                node.start_point.column as usize,
+            ),
+            end_position: (node.end_point.row as usize, node.end_point.column as usize),
             start_byte: node.start_byte,
             end_byte: node.end_byte,
             text: None,

--- a/runtime/src/serialization.rs
+++ b/runtime/src/serialization.rs
@@ -208,8 +208,14 @@ impl<'a> TreeSerializer<'a> {
             kind: node.kind().to_string(),
             is_named: node.is_named(),
             field_name: node.field_name().map(|s| s.to_string()),
-            start_position: (node.start_position().row, node.start_position().column),
-            end_position: (node.end_position().row, node.end_position().column),
+            start_position: (
+                node.start_position().row as usize,
+                node.start_position().column as usize,
+            ),
+            end_position: (
+                node.end_position().row as usize,
+                node.end_position().column as usize,
+            ),
             start_byte: node.start_byte(),
             end_byte: node.end_byte(),
             text: None,
@@ -280,8 +286,16 @@ impl<'a> CompactSerializer<'a> {
         Self { source }
     }
 
+    #[cfg(feature = "pure-rust")]
     pub fn serialize_tree(&self, tree: &Tree) -> Result<String, serde_json::Error> {
         let root = self.serialize_node(tree.root_node());
+        serde_json::to_string(&root)
+    }
+
+    #[cfg(not(feature = "pure-rust"))]
+    pub fn serialize_tree(&self, tree: &Tree) -> Result<String, serde_json::Error> {
+        let root_node = tree.root_node();
+        let root = self.serialize_node(&root_node);
         serde_json::to_string(&root)
     }
 
@@ -375,8 +389,15 @@ impl<'a> SExpressionSerializer<'a> {
         self
     }
 
+    #[cfg(feature = "pure-rust")]
     pub fn serialize_tree(&self, tree: &Tree) -> String {
         self.serialize_node(tree.root_node())
+    }
+
+    #[cfg(not(feature = "pure-rust"))]
+    pub fn serialize_tree(&self, tree: &Tree) -> String {
+        let root_node = tree.root_node();
+        self.serialize_node(&root_node)
     }
 
     #[cfg(feature = "pure-rust")]
@@ -510,9 +531,23 @@ impl BinarySerializer {
         }
     }
 
+    #[cfg(feature = "pure-rust")]
     pub fn serialize_tree(&mut self, tree: &Tree) -> BinaryFormat {
         let mut tree_data = Vec::new();
         self.serialize_node_binary(tree.root_node(), &mut tree_data);
+
+        BinaryFormat {
+            node_types: self.node_types.clone(),
+            field_names: self.field_names.clone(),
+            tree_data,
+        }
+    }
+
+    #[cfg(not(feature = "pure-rust"))]
+    pub fn serialize_tree(&mut self, tree: &Tree) -> BinaryFormat {
+        let mut tree_data = Vec::new();
+        let root_node = tree.root_node();
+        self.serialize_node_binary(&root_node, &mut tree_data);
 
         BinaryFormat {
             node_types: self.node_types.clone(),

--- a/runtime/src/tree_bridge.rs
+++ b/runtime/src/tree_bridge.rs
@@ -5,7 +5,14 @@ use crate::glr_incremental::{ForestNode, ForkAlternative};
 use crate::parser_v4::Tree as V4Tree;
 use crate::subtree::{Subtree, SubtreeNode};
 use adze_ir::SymbolId;
+use std::cell::RefCell;
 use std::sync::Arc;
+
+thread_local! {
+    // Keep per-thread bridge arenas rooted until thread exit so the returned
+    // parser_v4 trees can borrow stable storage without leaking intentionally.
+    static TREE_BRIDGE_ARENAS: RefCell<Vec<Box<TreeArena>>> = RefCell::new(Vec::new());
+}
 
 fn make_subtree(symbol: SymbolId, children: Vec<Arc<Subtree>>) -> Arc<Subtree> {
     make_subtree_with_error(symbol, false, children)
@@ -64,6 +71,16 @@ fn v4_to_forest_node<'arena>(tree: &V4Tree<'arena>, handle: NodeHandle) -> Arc<F
     })
 }
 
+fn bridge_arena() -> &'static mut TreeArena {
+    TREE_BRIDGE_ARENAS.with(|arenas| {
+        let mut arenas = arenas.borrow_mut();
+        arenas.push(Box::new(TreeArena::new()));
+        let arena_ptr = arenas.last_mut().unwrap().as_mut() as *mut TreeArena;
+        // The box stays owned by the thread-local vector for the lifetime of the thread.
+        unsafe { &mut *arena_ptr }
+    })
+}
+
 /// Convert a parser_v4::Tree to a ForestNode for incremental parsing.
 ///
 /// This creates an unambiguous forest (single alternative) that represents
@@ -77,7 +94,7 @@ pub fn v4_tree_to_forest<'arena>(tree: &V4Tree<'arena>) -> Arc<ForestNode> {
 /// This flattens forest alternatives by selecting the first alternative
 /// at each node.
 pub fn forest_to_v4_tree<'arena>(forest: &ForestNode) -> V4Tree<'arena> {
-    let arena = Box::leak(Box::new(TreeArena::new()));
+    let arena = bridge_arena();
     let root = forest_to_v4_node(arena, forest);
     let error_count = forest
         .cached_subtree
@@ -126,7 +143,7 @@ mod tests {
 
     #[test]
     fn test_v4_to_forest_conversion_contract() {
-        let arena = Box::leak(Box::new(TreeArena::new()));
+        let arena = bridge_arena();
         let child = arena.alloc(TreeNode::leaf(7));
         let root = arena.alloc(TreeNode::branch_with_symbol(13, vec![child]));
         let tree = V4Tree {

--- a/runtime/src/tree_bridge.rs
+++ b/runtime/src/tree_bridge.rs
@@ -11,7 +11,8 @@ use std::sync::Arc;
 thread_local! {
     // Keep per-thread bridge arenas rooted until thread exit so the returned
     // parser_v4 trees can borrow stable storage without leaking intentionally.
-    static TREE_BRIDGE_ARENAS: RefCell<Vec<Box<TreeArena>>> = RefCell::new(Vec::new());
+    #[allow(clippy::vec_box)]
+    static TREE_BRIDGE_ARENAS: RefCell<Vec<Box<TreeArena>>> = const { RefCell::new(Vec::new()) };
 }
 
 fn make_subtree(symbol: SymbolId, children: Vec<Arc<Subtree>>) -> Arc<Subtree> {

--- a/runtime/src/tree_sitter_compat.rs
+++ b/runtime/src/tree_sitter_compat.rs
@@ -88,6 +88,11 @@ impl Node {
         self.as_ref().end_point()
     }
 
+    /// Returns `None` — standalone nodes have no parent cursor context.
+    pub fn field_name(&self) -> Option<&str> {
+        None
+    }
+
     pub fn walk(&self) -> TreeCursor {
         TreeCursor::new(*self)
     }

--- a/runtime/tests/ambiguous_grammar_test.rs
+++ b/runtime/tests/ambiguous_grammar_test.rs
@@ -8,9 +8,7 @@ mod ambiguous_incremental_tests {
     };
     use adze::glr_lexer::{GLRLexer, TokenWithPosition};
     use adze_glr_core::{FirstFollowSets, ParseTable, build_lr1_automaton};
-    use adze_ir::{
-        Associativity, Grammar, ProductionId, Rule, Symbol, SymbolId, Token, TokenPattern,
-    };
+    use adze_ir::{Grammar, ProductionId, Rule, Symbol, SymbolId, Token, TokenPattern};
 
     /// Create the classic dangling-else grammar (genuinely ambiguous)
     /// stmt → if expr then stmt else stmt | if expr then stmt | other
@@ -77,59 +75,56 @@ mod ambiguous_incremental_tests {
         );
 
         // Rules for stmt
-        let mut stmt_rules = Vec::new();
-
-        // Rule 1: stmt → if expr then stmt else stmt
-        stmt_rules.push(Rule {
-            lhs: stmt_id,
-            rhs: vec![
-                Symbol::Terminal(if_id),
-                Symbol::NonTerminal(expr_id),
-                Symbol::Terminal(then_id),
-                Symbol::NonTerminal(stmt_id),
-                Symbol::Terminal(else_id),
-                Symbol::NonTerminal(stmt_id),
-            ],
-            precedence: None, // NO PRECEDENCE - allow ambiguity
-            associativity: None,
-            fields: vec![],
-            production_id: ProductionId(0),
-        });
-
-        // Rule 2: stmt → if expr then stmt (without else)
-        stmt_rules.push(Rule {
-            lhs: stmt_id,
-            rhs: vec![
-                Symbol::Terminal(if_id),
-                Symbol::NonTerminal(expr_id),
-                Symbol::Terminal(then_id),
-                Symbol::NonTerminal(stmt_id),
-            ],
-            precedence: None, // NO PRECEDENCE - allow ambiguity
-            associativity: None,
-            fields: vec![],
-            production_id: ProductionId(1),
-        });
-
-        // Rule 3: stmt → other (base case)
-        stmt_rules.push(Rule {
-            lhs: stmt_id,
-            rhs: vec![Symbol::Terminal(other_id)],
-            precedence: None,
-            associativity: None,
-            fields: vec![],
-            production_id: ProductionId(2),
-        });
-
-        // Rule 4: stmt → ID (another base case)
-        stmt_rules.push(Rule {
-            lhs: stmt_id,
-            rhs: vec![Symbol::Terminal(id_id)],
-            precedence: None,
-            associativity: None,
-            fields: vec![],
-            production_id: ProductionId(3),
-        });
+        let stmt_rules = vec![
+            // Rule 1: stmt → if expr then stmt else stmt
+            Rule {
+                lhs: stmt_id,
+                rhs: vec![
+                    Symbol::Terminal(if_id),
+                    Symbol::NonTerminal(expr_id),
+                    Symbol::Terminal(then_id),
+                    Symbol::NonTerminal(stmt_id),
+                    Symbol::Terminal(else_id),
+                    Symbol::NonTerminal(stmt_id),
+                ],
+                precedence: None, // NO PRECEDENCE - allow ambiguity
+                associativity: None,
+                fields: vec![],
+                production_id: ProductionId(0),
+            },
+            // Rule 2: stmt → if expr then stmt (without else)
+            Rule {
+                lhs: stmt_id,
+                rhs: vec![
+                    Symbol::Terminal(if_id),
+                    Symbol::NonTerminal(expr_id),
+                    Symbol::Terminal(then_id),
+                    Symbol::NonTerminal(stmt_id),
+                ],
+                precedence: None, // NO PRECEDENCE - allow ambiguity
+                associativity: None,
+                fields: vec![],
+                production_id: ProductionId(1),
+            },
+            // Rule 3: stmt → other (base case)
+            Rule {
+                lhs: stmt_id,
+                rhs: vec![Symbol::Terminal(other_id)],
+                precedence: None,
+                associativity: None,
+                fields: vec![],
+                production_id: ProductionId(2),
+            },
+            // Rule 4: stmt → ID (another base case)
+            Rule {
+                lhs: stmt_id,
+                rhs: vec![Symbol::Terminal(id_id)],
+                precedence: None,
+                associativity: None,
+                fields: vec![],
+                production_id: ProductionId(3),
+            },
+        ];
 
         grammar.rules.insert(stmt_id, stmt_rules);
         grammar.rule_names.insert(stmt_id, "stmt".to_string());
@@ -201,31 +196,30 @@ mod ambiguous_incremental_tests {
         );
 
         // Rules - NO PRECEDENCE OR ASSOCIATIVITY
-        let mut expr_rules = Vec::new();
-
-        // expr → expr - expr
-        expr_rules.push(Rule {
-            lhs: expr_id,
-            rhs: vec![
-                Symbol::NonTerminal(expr_id),
-                Symbol::Terminal(minus_id),
-                Symbol::NonTerminal(expr_id),
-            ],
-            precedence: None,    // No precedence!
-            associativity: None, // No associativity!
-            fields: vec![],
-            production_id: ProductionId(0),
-        });
-
-        // expr → NUM
-        expr_rules.push(Rule {
-            lhs: expr_id,
-            rhs: vec![Symbol::Terminal(num_id)],
-            precedence: None,
-            associativity: None,
-            fields: vec![],
-            production_id: ProductionId(1),
-        });
+        let expr_rules = vec![
+            // expr → expr - expr
+            Rule {
+                lhs: expr_id,
+                rhs: vec![
+                    Symbol::NonTerminal(expr_id),
+                    Symbol::Terminal(minus_id),
+                    Symbol::NonTerminal(expr_id),
+                ],
+                precedence: None,    // No precedence!
+                associativity: None, // No associativity!
+                fields: vec![],
+                production_id: ProductionId(0),
+            },
+            // expr → NUM
+            Rule {
+                lhs: expr_id,
+                rhs: vec![Symbol::Terminal(num_id)],
+                precedence: None,
+                associativity: None,
+                fields: vec![],
+                production_id: ProductionId(1),
+            },
+        ];
 
         grammar.rules.insert(expr_id, expr_rules);
         grammar.rule_names.insert(expr_id, "expr".to_string());

--- a/runtime/tests/doc_coverage.rs
+++ b/runtime/tests/doc_coverage.rs
@@ -2,10 +2,8 @@
 ///
 /// Ensures all public API items are properly documented.
 /// This helps maintain API quality and prevents undocumented public items.
-
 #[cfg(all(test, feature = "strict_docs"))]
 mod doc_coverage_tests {
-
     /// This test will fail if any public items lack documentation.
     /// It's gated behind the "strict_docs" feature to allow gradual improvement.
     #[test]
@@ -22,7 +20,7 @@ mod doc_coverage_tests {
             // The actual documentation checking is done by rustdoc
             // This just ensures the modules exist
             assert!(
-                module.len() > 0,
+                !module.is_empty(),
                 "Module {} should exist and be documented",
                 module
             );
@@ -101,9 +99,6 @@ mod doc_coverage_tests {
         // Currently no deprecated items, but when we add them:
         // #[deprecated(since = "0.x.x", note = "Use new_api instead")]
         // pub fn old_api() {}
-
-        // This would generate compiler warnings for users
-        assert!(true, "No deprecated items currently");
     }
 
     /// Test that unsafe APIs are properly documented
@@ -116,8 +111,6 @@ mod doc_coverage_tests {
         // /// # Safety
         // /// This function is safe to call if...
         // pub unsafe fn unsafe_api() {}
-
-        assert!(true, "No public unsafe APIs currently");
     }
 
     /// Ensure version-specific features are documented

--- a/runtime/tests/external_scanner_blackbox.rs
+++ b/runtime/tests/external_scanner_blackbox.rs
@@ -2,7 +2,6 @@
 
 /// Black-box tests for external scanner functionality
 /// These tests verify the external scanner API behavior from a user perspective
-use adze::external_scanner_ffi::{RustLexerAdapter, TSLexer, destroy_lexer};
 use adze::linecol::LineCol;
 
 #[test]

--- a/runtime/tests/external_scanner_nested_comments_test.rs
+++ b/runtime/tests/external_scanner_nested_comments_test.rs
@@ -25,20 +25,12 @@ impl ExternalScanner for NestedCommentScanner {
             return None;
         }
 
-        let mut consumed = 0;
-        let mut depth = 0;
-        let mut in_comment = false;
-
         // Check for comment start
         if lexer.lookahead() == Some(b'(') {
             lexer.advance(1);
-            consumed += 1;
 
             if lexer.lookahead() == Some(b'*') {
                 lexer.advance(1);
-                consumed += 1;
-                depth = 1;
-                in_comment = true;
             } else {
                 // Not a comment start, backtrack
                 return None;
@@ -47,8 +39,11 @@ impl ExternalScanner for NestedCommentScanner {
             return None;
         }
 
+        let mut consumed = 2;
+        let mut depth = 1;
+
         // Scan through comment body, handling nesting
-        while in_comment && !lexer.is_eof() {
+        while depth > 0 && !lexer.is_eof() {
             match lexer.lookahead() {
                 Some(b'(') => {
                     lexer.advance(1);
@@ -67,7 +62,6 @@ impl ExternalScanner for NestedCommentScanner {
                         consumed += 1;
                         depth -= 1;
                         if depth == 0 {
-                            in_comment = false;
                             lexer.mark_end();
                             return Some(ScanResult {
                                 symbol: COMMENT,

--- a/runtime/tests/external_scanner_test.rs
+++ b/runtime/tests/external_scanner_test.rs
@@ -272,8 +272,9 @@ fn test_nested_comment_scanner() {
 #[test]
 #[cfg(feature = "external_scanners")]
 fn test_scanner_state_persistence() {
-    let mut scanner = IndentationScanner::default();
-    scanner.indent_stack = vec![0, 4, 8];
+    let scanner = IndentationScanner {
+        indent_stack: vec![0, 4, 8],
+    };
 
     // Serialize state
     let mut buffer = Vec::new();

--- a/runtime/tests/glr_incremental_comprehensive.rs
+++ b/runtime/tests/glr_incremental_comprehensive.rs
@@ -694,8 +694,7 @@ mod tests {
         reset_reuse_counter();
         let f = p.parse_incremental(&new_toks, &[edit]).unwrap();
         assert!(!f.alternatives.is_empty());
-        // Count should be non-negative
-        assert!(get_reuse_count() >= 0);
+        assert!(get_reuse_count() <= new_toks.len());
     }
 
     // ─── Test 23: Parse error on invalid input ──────────────────────

--- a/runtime/tests/incremental_glr_comprehensive_test.rs
+++ b/runtime/tests/incremental_glr_comprehensive_test.rs
@@ -85,95 +85,94 @@ mod comprehensive_incremental_tests {
         );
 
         // Rules for expr
-        let mut expr_rules = Vec::new();
-        expr_rules.push(Rule {
-            lhs: expr_id,
-            rhs: vec![
-                Symbol::NonTerminal(expr_id),
-                Symbol::Terminal(plus_id),
-                Symbol::NonTerminal(term_id),
-            ],
-            precedence: Some(adze_ir::PrecedenceKind::Static(1)),
-            associativity: Some(adze_ir::Associativity::Left),
-            fields: vec![],
-            production_id: ProductionId(0),
-        });
-
-        expr_rules.push(Rule {
-            lhs: expr_id,
-            rhs: vec![
-                Symbol::NonTerminal(expr_id),
-                Symbol::Terminal(minus_id),
-                Symbol::NonTerminal(term_id),
-            ],
-            precedence: Some(adze_ir::PrecedenceKind::Static(1)),
-            associativity: Some(adze_ir::Associativity::Left),
-            fields: vec![],
-            production_id: ProductionId(1),
-        });
-
-        expr_rules.push(Rule {
-            lhs: expr_id,
-            rhs: vec![Symbol::NonTerminal(term_id)],
-            precedence: None,
-            associativity: None,
-            fields: vec![],
-            production_id: ProductionId(2),
-        });
+        let expr_rules = vec![
+            Rule {
+                lhs: expr_id,
+                rhs: vec![
+                    Symbol::NonTerminal(expr_id),
+                    Symbol::Terminal(plus_id),
+                    Symbol::NonTerminal(term_id),
+                ],
+                precedence: Some(adze_ir::PrecedenceKind::Static(1)),
+                associativity: Some(adze_ir::Associativity::Left),
+                fields: vec![],
+                production_id: ProductionId(0),
+            },
+            Rule {
+                lhs: expr_id,
+                rhs: vec![
+                    Symbol::NonTerminal(expr_id),
+                    Symbol::Terminal(minus_id),
+                    Symbol::NonTerminal(term_id),
+                ],
+                precedence: Some(adze_ir::PrecedenceKind::Static(1)),
+                associativity: Some(adze_ir::Associativity::Left),
+                fields: vec![],
+                production_id: ProductionId(1),
+            },
+            Rule {
+                lhs: expr_id,
+                rhs: vec![Symbol::NonTerminal(term_id)],
+                precedence: None,
+                associativity: None,
+                fields: vec![],
+                production_id: ProductionId(2),
+            },
+        ];
 
         grammar.rules.insert(expr_id, expr_rules);
         grammar.rule_names.insert(expr_id, "expr".to_string());
 
         // Rules for term
-        let mut term_rules = Vec::new();
-        term_rules.push(Rule {
-            lhs: term_id,
-            rhs: vec![
-                Symbol::NonTerminal(term_id),
-                Symbol::Terminal(star_id),
-                Symbol::NonTerminal(factor_id),
-            ],
-            precedence: Some(adze_ir::PrecedenceKind::Static(2)),
-            associativity: Some(adze_ir::Associativity::Left),
-            fields: vec![],
-            production_id: ProductionId(3),
-        });
-
-        term_rules.push(Rule {
-            lhs: term_id,
-            rhs: vec![Symbol::NonTerminal(factor_id)],
-            precedence: None,
-            associativity: None,
-            fields: vec![],
-            production_id: ProductionId(4),
-        });
+        let term_rules = vec![
+            Rule {
+                lhs: term_id,
+                rhs: vec![
+                    Symbol::NonTerminal(term_id),
+                    Symbol::Terminal(star_id),
+                    Symbol::NonTerminal(factor_id),
+                ],
+                precedence: Some(adze_ir::PrecedenceKind::Static(2)),
+                associativity: Some(adze_ir::Associativity::Left),
+                fields: vec![],
+                production_id: ProductionId(3),
+            },
+            Rule {
+                lhs: term_id,
+                rhs: vec![Symbol::NonTerminal(factor_id)],
+                precedence: None,
+                associativity: None,
+                fields: vec![],
+                production_id: ProductionId(4),
+            },
+        ];
 
         grammar.rules.insert(term_id, term_rules);
         grammar.rule_names.insert(term_id, "term".to_string());
 
         // Rules for factor
-        let mut factor_rules = Vec::new();
-        factor_rules.push(Rule {
-            lhs: factor_id,
-            rhs: vec![Symbol::Terminal(num_id)],
-            precedence: None,
-            associativity: None,
-            fields: vec![],
-            production_id: ProductionId(5),
-        });
-
-        factor_rules.push(Rule {
-            lhs: factor_id,
-            rhs: vec![
-                Symbol::Terminal(lparen_id),
-                Symbol::NonTerminal(expr_id),
-                Symbol::Terminal(rparen_id),
-            ],
-            precedence: None,
-            associativity: None,
-            fields: vec![],
-            production_id: ProductionId(6),
-        });
+        let factor_rules = vec![
+            Rule {
+                lhs: factor_id,
+                rhs: vec![Symbol::Terminal(num_id)],
+                precedence: None,
+                associativity: None,
+                fields: vec![],
+                production_id: ProductionId(5),
+            },
+            Rule {
+                lhs: factor_id,
+                rhs: vec![
+                    Symbol::Terminal(lparen_id),
+                    Symbol::NonTerminal(expr_id),
+                    Symbol::Terminal(rparen_id),
+                ],
+                precedence: None,
+                associativity: None,
+                fields: vec![],
+                production_id: ProductionId(6),
+            },
+        ];
 
         grammar.rules.insert(factor_id, factor_rules);
         grammar.rule_names.insert(factor_id, "factor".to_string());
@@ -313,7 +312,7 @@ mod comprehensive_incremental_tests {
             );
         }
         assert!(
-            new_forest.alternatives.len() > 0,
+            !new_forest.alternatives.is_empty(),
             "Multiple edits should produce valid parse"
         );
     }
@@ -354,7 +353,7 @@ mod comprehensive_incremental_tests {
         // Should still reuse suffix "2*3"
         let reuse_count = get_reuse_count();
         assert!(
-            new_forest.alternatives.len() > 0,
+            !new_forest.alternatives.is_empty(),
             "Edit at beginning should produce valid parse"
         );
         println!(
@@ -399,7 +398,7 @@ mod comprehensive_incremental_tests {
         // Should reuse prefix "1+2*"
         let reuse_count = get_reuse_count();
         assert!(
-            new_forest.alternatives.len() > 0,
+            !new_forest.alternatives.is_empty(),
             "Edit at end should produce valid parse"
         );
         println!(
@@ -463,7 +462,7 @@ mod comprehensive_incremental_tests {
 
         reset_reuse_counter();
         let start = Instant::now();
-        let new_forest = parser.parse_incremental(&new_glr_tokens, &[edit]).unwrap();
+        let _new_forest = parser.parse_incremental(&new_glr_tokens, &[edit]).unwrap();
         let incremental_parse_time = start.elapsed();
         let reuse_count = get_reuse_count();
 
@@ -532,7 +531,7 @@ mod comprehensive_incremental_tests {
         let new_forest = parser.parse_incremental(&new_glr_tokens, &[edit]).unwrap();
 
         assert!(
-            new_forest.alternatives.len() > 0,
+            !new_forest.alternatives.is_empty(),
             "Insertion should produce valid parse"
         );
         println!(
@@ -575,7 +574,7 @@ mod comprehensive_incremental_tests {
         let new_forest = parser.parse_incremental(&new_glr_tokens, &[edit]).unwrap();
 
         assert!(
-            new_forest.alternatives.len() > 0,
+            !new_forest.alternatives.is_empty(),
             "Deletion should produce valid parse"
         );
         println!(
@@ -618,7 +617,7 @@ mod comprehensive_incremental_tests {
         let new_forest = parser.parse_incremental(&new_glr_tokens, &[edit]).unwrap();
 
         assert!(
-            new_forest.alternatives.len() > 0,
+            !new_forest.alternatives.is_empty(),
             "Expansion should produce valid parse"
         );
         println!(
@@ -670,7 +669,7 @@ mod comprehensive_incremental_tests {
         };
 
         reset_reuse_counter();
-        let new_forest = parser.parse_incremental(&new_glr_tokens, &[edit]).unwrap();
+        let _new_forest = parser.parse_incremental(&new_glr_tokens, &[edit]).unwrap();
 
         // With snapshots, we should skip parsing the large prefix
         let reuse_count = get_reuse_count();
@@ -679,7 +678,7 @@ mod comprehensive_incremental_tests {
             "GSS snapshots should enable significant reuse"
         );
         assert!(
-            new_forest.alternatives.len() > 0,
+            !_new_forest.alternatives.is_empty(),
             "Should produce valid parse with snapshots"
         );
         println!(

--- a/runtime/tests/incremental_reuse_test.rs
+++ b/runtime/tests/incremental_reuse_test.rs
@@ -7,13 +7,11 @@ mod incremental_reuse_tests {
         Edit, GLREdit, GLRToken, IncrementalGLRParser, get_reuse_count, reset_reuse_counter,
     };
     use adze::glr_lexer::{GLRLexer, TokenWithPosition};
-    use adze::glr_parser::GLRParser;
     use adze_glr_core::{FirstFollowSets, ParseTable, build_lr1_automaton};
     use adze_ir::{
         Associativity, Grammar, PrecedenceKind, ProductionId, Rule, Symbol, SymbolId, Token,
         TokenPattern,
     };
-    use std::sync::Arc;
 
     /// Create a simple arithmetic grammar for testing
     fn create_test_grammar() -> Grammar {
@@ -160,7 +158,7 @@ mod incremental_reuse_tests {
 
         // Create the edit descriptor
         // The "2" is at byte position 4, replaced with "5"
-        let edit = Edit::new(4, 5, 5);
+        let _edit = Edit::new(4, 5, 5);
 
         // Create GLREdit structure for incremental parsing
         let glr_edit = GLREdit {

--- a/runtime/tests/integration_test.rs
+++ b/runtime/tests/integration_test.rs
@@ -229,10 +229,10 @@ fn test_serialization_feature() {
     let _with_unnamed = TreeSerializer::new(source).with_unnamed_nodes();
 
     // Test with max text length - builder pattern
-    let _with_max = TreeSerializer::new(source).with_max_text_length(Some(10));
+    let with_max = TreeSerializer::new(source).with_max_text_length(Some(10));
 
     // Serialization API is available and builder pattern works
-    assert!(true);
+    assert_eq!(with_max.max_text_length, Some(10));
 }
 
 #[test]

--- a/runtime/tests/pr58_validation_test.rs
+++ b/runtime/tests/pr58_validation_test.rs
@@ -86,7 +86,7 @@ mod pr58_validation {
         );
 
         // 4. child_count() should work (even if returns 0 due to parser_v4 limitations)
-        let child_count = root.child_count();
+        let _child_count = root.child_count();
         // Note: child_count is usize, so it's always >= 0
 
         // 5. child() should handle indices gracefully

--- a/runtime/tests/property_incremental_test.rs
+++ b/runtime/tests/property_incremental_test.rs
@@ -37,7 +37,7 @@ fn test_fresh_parse_sanity() {
 
 #[cfg(all(test, feature = "incremental_glr"))]
 mod incremental_properties {
-    use adze::parser_v4::{Parser, Tree};
+    use adze::parser_v4::Parser;
     use adze::pure_incremental::Edit;
     use adze::pure_parser::Point;
     use adze_glr_core::ParseTable;
@@ -185,18 +185,20 @@ mod incremental_properties {
             let mut parser2 = Parser::new(grammar.clone(), table.clone(), "test".to_string());
 
             // Parse original
-            let tree1 = parser1.parse(&original).expect("Initial parse should succeed");
+            parser1.parse(&original).expect("Initial parse should succeed");
 
             // Apply edit
             let edited = apply_edit(&original, edit_pos, del_len, &insert);
-            let edit = create_edit(edit_pos, del_len, insert.len());
+            let _edit = create_edit(edit_pos, del_len, insert.len());
 
             // Parse fresh
             let tree_fresh = parser2.parse(&edited).expect("Fresh parse should succeed");
 
             // For now, just verify fresh parsing works
-            prop_assert!(tree_fresh.error_count == 0 || tree_fresh.error_count > 0,
-                "Fresh parse should complete with a valid error count");
+            prop_assert!(
+                tree_fresh.error_count() <= edited.len().max(1),
+                "Fresh parse should produce a bounded error count"
+            );
         }
 
         /// Property: Multiple sequential edits should produce the same result regardless of path
@@ -222,8 +224,10 @@ mod incremental_properties {
             // This would verify that the order of incremental edits doesn't affect the final result
 
             // For now, just verify fresh parsing works
-            prop_assert!(tree_fresh.error_count == 0 || tree_fresh.error_count > 0,
-                "Fresh parse should complete with a valid error count");
+            prop_assert!(
+                tree_fresh.error_count() <= final_source.len().max(1),
+                "Fresh parse should produce a bounded error count"
+            );
         }
     }
 }

--- a/runtime/tests/serialization_advanced_comprehensive.rs
+++ b/runtime/tests/serialization_advanced_comprehensive.rs
@@ -518,13 +518,12 @@ fn sexpr_double_nested() {
         "deep".to_string(),
     )])])]);
     // Three levels deep
-    if let SExpr::List(a) = &l {
-        if let SExpr::List(b) = &a[0] {
-            if let SExpr::List(c) = &b[0] {
-                assert_eq!(c[0], SExpr::Atom("deep".to_string()));
-                return;
-            }
-        }
+    if let SExpr::List(a) = &l
+        && let SExpr::List(b) = &a[0]
+        && let SExpr::List(c) = &b[0]
+    {
+        assert_eq!(c[0], SExpr::Atom("deep".to_string()));
+        return;
     }
     panic!("nesting mismatch");
 }

--- a/runtime/tests/serialization_edge_cases.rs
+++ b/runtime/tests/serialization_edge_cases.rs
@@ -15,7 +15,6 @@
 #![cfg(feature = "serialization")]
 
 use adze::serialization::*;
-use serde_json::json;
 
 // ============================================================================
 // HELPER FUNCTIONS

--- a/runtime/tests/serialization_v6.rs
+++ b/runtime/tests/serialization_v6.rs
@@ -208,8 +208,8 @@ fn sexpr_nested_list_of_empty_lists() {
     ]);
     let items = root.as_list().unwrap();
     assert_eq!(items.len(), 3);
-    for i in 0..items.len() {
-        assert!(items[i].as_list().unwrap().is_empty());
+    for item in items {
+        assert!(item.as_list().unwrap().is_empty());
     }
 }
 
@@ -513,8 +513,8 @@ fn sexpr_edge_list_with_only_empty_atoms() {
     let l = SExpr::list(vec![SExpr::atom(""), SExpr::atom(""), SExpr::atom("")]);
     let items = l.as_list().unwrap();
     assert_eq!(items.len(), 3);
-    for i in 0..items.len() {
-        assert_eq!(items[i].as_atom(), Some(""));
+    for item in items {
+        assert_eq!(item.as_atom(), Some(""));
     }
     // Display: each empty atom contributes nothing visible between spaces
     assert_eq!(format!("{l}"), "(  )");

--- a/runtime/tests/snapshot_tests.rs
+++ b/runtime/tests/snapshot_tests.rs
@@ -8,13 +8,6 @@ use insta::assert_snapshot;
 #[cfg(feature = "incremental_glr")]
 mod glr_snapshots {
     use super::*;
-    use adze::glr_incremental::IncrementalGLRParser;
-    use adze::glr_parser::GLRParser;
-
-    /// Helper to create a stable string representation of a parse forest
-    fn forest_to_string(forest: &impl std::fmt::Debug) -> String {
-        format!("{:#?}", forest)
-    }
 
     #[test]
     fn snapshot_simple_expr_forest() {

--- a/runtime/tests/support/unified_json_helper.rs
+++ b/runtime/tests/support/unified_json_helper.rs
@@ -1,11 +1,15 @@
-use crate::language_builder;
-
 use adze::pure_parser::TSLanguage;
 use adze_glr_core::GotoIndexing;
 use adze_glr_core::{Action, ParseRule, ParseTable, SymbolMetadata};
 use adze_ir::{Grammar, StateId, SymbolId, Token, TokenPattern};
 use anyhow::Result;
+#[cfg(all(feature = "pure-rust", feature = "with-grammars"))]
+use tree_sitter_json;
+#[cfg(all(feature = "pure-rust", feature = "with-grammars"))]
 use ts_bridge::{extract, schema::Action as TsAction};
+
+#[cfg(all(feature = "pure-rust", feature = "with-grammars"))]
+use crate::language_builder;
 
 /// Return a `TSLanguage` built from the real Tree-sitter JSON grammar.
 ///
@@ -14,6 +18,7 @@ use ts_bridge::{extract, schema::Action as TsAction};
 /// to decode the Tree-sitter parse tables and rebuild a fresh language using
 /// our pure-Rust layout.
 #[allow(dead_code)]
+#[cfg(all(feature = "pure-rust", feature = "with-grammars"))]
 pub fn unified_json_language() -> Result<&'static TSLanguage, anyhow::Error> {
     // Extract parse table data from upstream Tree-sitter JSON grammar
     // tree_sitter_json::LANGUAGE.into_raw() returns a function pointer that needs to be called
@@ -219,4 +224,12 @@ pub fn unified_json_language() -> Result<&'static TSLanguage, anyhow::Error> {
 
     let lang = language_builder::build_json_ts_language(&grammar, &table);
     Ok(Box::leak(Box::new(lang)))
+}
+
+#[allow(dead_code)]
+#[cfg(not(all(feature = "pure-rust", feature = "with-grammars")))]
+pub fn unified_json_language() -> Result<&'static TSLanguage, anyhow::Error> {
+    Err(anyhow::anyhow!(
+        "unified_json_language requires both `pure-rust` and `with-grammars` features"
+    ))
 }

--- a/runtime/tests/support/unified_json_helper.rs
+++ b/runtime/tests/support/unified_json_helper.rs
@@ -4,8 +4,6 @@ use adze_glr_core::{Action, ParseRule, ParseTable, SymbolMetadata};
 use adze_ir::{Grammar, StateId, SymbolId, Token, TokenPattern};
 use anyhow::Result;
 #[cfg(all(feature = "pure-rust", feature = "with-grammars"))]
-use tree_sitter_json;
-#[cfg(all(feature = "pure-rust", feature = "with-grammars"))]
 use ts_bridge::{extract, schema::Action as TsAction};
 
 #[cfg(all(feature = "pure-rust", feature = "with-grammars"))]

--- a/runtime/tests/test_ambiguous_expr_conflicts.rs
+++ b/runtime/tests/test_ambiguous_expr_conflicts.rs
@@ -15,7 +15,7 @@
 #[test]
 fn inspect_ambiguous_expr_conflicts() {
     // Access the generated ambiguous_expr language
-    let lang = unsafe { &adze_example::ambiguous_expr::generated::LANGUAGE };
+    let lang = &adze_example::ambiguous_expr::generated::LANGUAGE;
 
     // Decode the parse table
     let parse_table = adze::decoder::decode_parse_table(lang);
@@ -134,7 +134,7 @@ fn inspect_ambiguous_expr_conflicts() {
     // Always pass the test - this is diagnostic, not assertion-based
     // But the output tells us if GLR is working
     assert!(
-        parse_table.action_table.len() > 0,
+        !parse_table.action_table.is_empty(),
         "Parse table should have at least one state"
     );
 }

--- a/runtime/tests/test_ambiguous_expr_table_decode.rs
+++ b/runtime/tests/test_ambiguous_expr_table_decode.rs
@@ -8,7 +8,7 @@ use adze_glr_core::Action;
 #[test]
 fn decode_ambiguous_expr_table_deep() {
     // Access the generated ambiguous_expr language
-    let lang = unsafe { &adze_example::ambiguous_expr::generated::LANGUAGE };
+    let lang = &adze_example::ambiguous_expr::generated::LANGUAGE;
 
     // Decode the parse table
     let parse_table = adze::decoder::decode_parse_table(lang);

--- a/runtime/tests/test_arithmetic_table_loading.rs
+++ b/runtime/tests/test_arithmetic_table_loading.rs
@@ -11,7 +11,7 @@
 #[test]
 fn inspect_arithmetic_parse_table() {
     // Access the generated arithmetic language
-    let lang = unsafe { &adze_example::arithmetic::generated::LANGUAGE };
+    let lang = &adze_example::arithmetic::generated::LANGUAGE;
 
     // Decode the parse table
     let parse_table = adze::decoder::decode_parse_table(lang);
@@ -89,7 +89,7 @@ fn inspect_arithmetic_parse_table() {
 
     // This test always passes - it's just for inspection
     assert!(
-        parse_table.action_table.len() > 0,
+        !parse_table.action_table.is_empty(),
         "Parse table should have at least one state"
     );
 }

--- a/runtime/tests/test_dangling_else_conflicts.rs
+++ b/runtime/tests/test_dangling_else_conflicts.rs
@@ -12,7 +12,7 @@
 #[test]
 fn inspect_dangling_else_conflicts() {
     // Access the generated dangling_else language
-    let lang = unsafe { &adze_example::dangling_else::generated::LANGUAGE };
+    let lang = &adze_example::dangling_else::generated::LANGUAGE;
 
     // Decode the parse table
     let parse_table = adze::decoder::decode_parse_table(lang);
@@ -118,7 +118,7 @@ fn inspect_dangling_else_conflicts() {
 
     // Always pass the test - this is diagnostic, not assertion-based
     assert!(
-        parse_table.action_table.len() > 0,
+        !parse_table.action_table.is_empty(),
         "Parse table should have at least one state"
     );
 }

--- a/runtime/tests/test_serialization_roundtrip.rs
+++ b/runtime/tests/test_serialization_roundtrip.rs
@@ -12,8 +12,6 @@
 #![cfg(feature = "serialization")]
 
 use adze::serialization::*;
-use std::collections::HashMap;
-
 #[cfg(test)]
 mod serialized_node_tests {
     #[cfg(feature = "serialization")]
@@ -177,7 +175,6 @@ mod s_expr_tests {
     fn test_basic_roundtrip_identity() {
         // Simple atom
         let atom_sexpr = SExpr::Atom("hello".to_string());
-        let serialized = format!("{:?}", atom_sexpr);
         let atom_str = "hello";
         let parsed = parse_sexpr(atom_str).unwrap();
         assert_eq!(atom_sexpr, parsed);
@@ -533,7 +530,7 @@ mod property_based_tests {
         };
 
         if is_leaf {
-            let text_options = vec!["hello", "world", "test", "42", "true", "null"];
+            let text_options = ["hello", "world", "test", "42", "true", "null"];
             node.text = Some(text_options[rng.r#gen::<usize>() % text_options.len()].to_string());
         } else if depth > 0 {
             let child_count = rng.r#gen::<usize>() % 4;
@@ -622,7 +619,7 @@ mod property_based_tests {
 
     fn gen_random_sexpr(depth: usize, rng: &mut rand::SmallRng) -> SExpr {
         if depth == 0 || rng.gen_bool(0.5) {
-            let atoms = vec!["hello", "world", "test", "function", "if", "else", "return"];
+            let atoms = ["hello", "world", "test", "function", "if", "else", "return"];
             SExpr::Atom(atoms[rng.r#gen::<usize>() % atoms.len()].to_string())
         } else {
             let child_count = rng.r#gen::<usize>() % 4 + 1;
@@ -1611,6 +1608,7 @@ mod rand {
             val < p
         }
 
+        #[allow(dead_code)]
         pub fn gen_range(&mut self, min: usize, max: usize) -> usize {
             self.state = self.state.wrapping_mul(1103515245).wrapping_add(12345);
             let val = (self.state as usize) % (max - min);
@@ -1622,10 +1620,6 @@ mod rand {
             // Simple type-specific implementation for testing
             unsafe { std::mem::transmute_copy(&self.state) }
         }
-    }
-
-    pub mod rngs {
-        pub use super::SmallRng;
     }
 }
 

--- a/runtime/tests/tree_sexp_serialization_comprehensive.rs
+++ b/runtime/tests/tree_sexp_serialization_comprehensive.rs
@@ -86,7 +86,7 @@ fn node_to_sexp(node: &SerializedNode) -> String {
         }
         return format!("({})", node.kind);
     }
-    let child_strs: Vec<String> = node.children.iter().map(|c| node_to_sexp(c)).collect();
+    let child_strs: Vec<String> = node.children.iter().map(node_to_sexp).collect();
     format!("({} {})", node.kind, child_strs.join(" "))
 }
 


### PR DESCRIPTION
Adds runtime crate surface fixes for all-features/no-default paths so CI feature-matrix failures are constrained to code paths, not product breakage.

Changes:
- Gate unified_json helper usage behind  feature and add required feature annotations.
- Repair GLR/serialization/no-default feature surface (, , ).
- Keep metadata and dependency wiring aligned for the publishable runtime path.