### PR TITLE
docs: sync current post-hardening execution state

### DIFF
--- a/docs/status/NOW_NEXT_LATER.md
+++ b/docs/status/NOW_NEXT_LATER.md
@@ -1,7 +1,7 @@
 # Now / Next / Later
 
-**Last updated:** 2026-04-09
-**Status:** **Post-release hardening** — `adze` 0.8.0 is live on crates.io, the supported gate remains green, and the active work is broad CI truthfulness, runtime surface repair, and doc/status sync.
+**Last updated:** 2026-04-11
+**Status:** **Post-release hardening on `main`** — `adze` 0.8.0 is live on crates.io, the supported gate remains green, there is no open PR stack, and the remaining work is the residual advisory/broad CI tail on current `main`.
 
 Adze status and rolling execution plan. For recurring pain points, see [`docs/status/FRICTION_LOG.md`](./FRICTION_LOG.md). For API stability guarantees per crate, see [`docs/status/API_STABILITY.md`](./API_STABILITY.md). For the (substantially complete) post-PR264 follow-up plan, see [`plans/POST-PR264-CI-FOLLOWUPS.md`](../../plans/POST-PR264-CI-FOLLOWUPS.md).
 
@@ -21,22 +21,24 @@ Adze status and rolling execution plan. For recurring pain points, see [`docs/st
 ### ✅ Immediate close-out state
 - [x] PR `#280` (workflow hardening) merged on 2026-04-06.
 - [x] PR `#281` (roadmap/execution-state refresh) merged.
-- [x] `/home/steven/code/rust-sitter` is clean on `main` and aligned with `origin/main`.
-- [x] The remaining work is publication preparation and 0.9.0 planning, not backlog triage.
+- [x] `main` is aligned with `origin/main` and is now the source of truth for the remaining hardening work.
+- [x] GitHub currently shows no open PRs; any remaining hardening should restart from fresh branches off current `main`.
+- [x] A restore audit on 2026-04-11 confirmed that the proof surfaces trimmed during publication are already present again on `main`.
 
 ---
 
 ## Now
 
 ### 🧪 Broad CI truthfulness and hardening
-- [ ] Merge the remaining post-release hardening PRs and keep `KNOWN_RED.md` aligned with the real advisory-lane state.
-- [ ] Finish the runtime all-features and GLR/bench stability follow-up lanes now that the crates.io release is complete.
-- [ ] Restore any valuable proof surfaces that were trimmed only to unblock publication into `publish = false` internal harnesses where needed.
+- [ ] Finish the workflow/toolchain tail on current `main`: sanitizers, minimal-versions, supply-chain checks, cross-compilation, and the long-running Miri lane.
+- [ ] Clear the remaining `adze` broad-surface failures on current `main`: matrix smoke, coverage, strict-invariants release mode, feature-matrix `serialization` / `all-features` / `glr`, and the matching cross-platform test lanes.
+- [ ] Clear the remaining GLR tail on current `main`: `adze-glr-core / all-features` and deterministic codegen.
+- [ ] Keep `KNOWN_RED.md` aligned with the real advisory-lane state whenever a lane stops being intentionally red.
 
 ### 📦 Close remaining operational issues
 - [ ] [Issue #269](https://github.com/EffortlessMetrics/adze/issues/269): Windows pure-rust benchmark-compilation tail is gated but still open; decide whether to trim further or close as acceptable.
 - [ ] [Issue #268](https://github.com/EffortlessMetrics/adze/issues/268): Worktree cleanup script exists (`scripts/cleanup-worktrees.sh`); contributor documentation still needs finishing.
-- [ ] Keep `KNOWN_RED.md` current whenever an advisory lane is promoted into or removed from the supported contract.
+- [ ] Investigate the current rustdoc-only `Documentation` lane failure separately from reader-facing markdown/status drift.
 
 ---
 
@@ -45,7 +47,7 @@ Adze status and rolling execution plan. For recurring pain points, see [`docs/st
 ### 📚 Documentation polish
 - [ ] Continue tightening tutorial/reference accuracy around the actual 0.8.x release surface.
 - [ ] Add contributor-facing guidance for temporary worktree lifecycle and closeout hygiene ([issue #268](https://github.com/EffortlessMetrics/adze/issues/268)).
-- [ ] Keep roadmap/status docs aligned with the real repo state after each meaningful convergence wave.
+- [ ] Keep roadmap/status docs aligned with the real repo state after each meaningful convergence wave, but only after the corresponding code/CI family lands on `main`.
 
 ---
 


### PR DESCRIPTION
## Summary\n- update  to reflect the current  state after the 0.8.0 release hardening wave\n- remove stale language about pending PR merges and publication preparation\n- capture the actual remaining work families on \n\n## Validation\n- \n