### PR TITLE
ci: make advisory tail lanes non-blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,6 +299,7 @@ jobs:
         run: cargo clippy -p adze ${{ matrix.backend.flags }} -- -D warnings
 
       - name: Run clippy on example with ${{ matrix.backend.name }}
+        continue-on-error: true
         run: cargo clippy --manifest-path example/Cargo.toml ${{ matrix.backend.flags }} -- -D warnings
       
       - name: Build example with ${{ matrix.backend.name }}
@@ -331,10 +332,11 @@ jobs:
           cargo +nightly miri test -p adze-tablegen --lib
       
       - name: Run Miri on external scanner tests
+        continue-on-error: true
         env:
           MIRIFLAGS: "-Zmiri-strict-provenance"
         run: |
-          cargo +nightly miri test -p adze --features external_scanners external_scanner_ || true
+          cargo +nightly miri test -p adze --features external_scanners external_scanner_
 
   ts-compat:
     if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.run_full_ci)
@@ -372,6 +374,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       
       - name: Run with Address Sanitizer
+        continue-on-error: true
         env:
           RUSTFLAGS: "-Zsanitizer=address"
           RUSTDOCFLAGS: "-Zsanitizer=address"
@@ -380,6 +383,7 @@ jobs:
             -p adze --lib --tests
       
       - name: Run with Undefined Behavior Sanitizer
+        continue-on-error: true
         env:
           RUSTFLAGS: "-Zsanitizer=undefined"
           RUSTDOCFLAGS: "-Zsanitizer=undefined"
@@ -401,6 +405,7 @@ jobs:
         run: cargo +nightly update -Z minimal-versions
 
       - name: Build with minimal versions
+        continue-on-error: true
         run: cargo build --workspace --all-features
 
   semver-checks:
@@ -661,6 +666,7 @@ jobs:
           tool: cargo-deny
       
       - name: Check advisories, licenses, and bans
+        continue-on-error: true
         run: cargo deny check
 
   docs:
@@ -771,6 +777,7 @@ jobs:
           EOF
 
       - name: Build for ${{ matrix.target }}
+        continue-on-error: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
         run: |
           if [ "${{ matrix.target }}" = "wasm32-unknown-unknown" ]; then
             cargo build --target ${{ matrix.target }} --package adze --no-default-features


### PR DESCRIPTION
## Summary
- mark known advisory CI tail steps as non-blocking instead of failing the whole workflow
- remove the `|| true` mask from the Miri external-scanner step so the step reports its real outcome
- keep the diff scoped to `.github/workflows/ci.yml`

## Validation
- yaml parse via `python3` + `yaml.safe_load`
- `git diff --check -- .github/workflows/ci.yml`
