### PR TITLE
test: clean up glr all-features tail

### DIFF
--- a/glr-core/tests/action_cell_v3_comprehensive.rs
+++ b/glr-core/tests/action_cell_v3_comprehensive.rs
@@ -7,12 +7,11 @@
 //! patterns, and edge cases.
 
 use adze_glr_core::{
-    Action, ActionCell, FirstFollowSets, ParseRule, ParseTable, RuleId, StateId, SymbolId,
-    build_lr1_automaton,
+    Action, ActionCell, FirstFollowSets, RuleId, StateId, SymbolId, build_lr1_automaton,
 };
 use adze_ir::builder::GrammarBuilder;
 use adze_ir::*;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::HashSet;
 
 // ===========================================================================
 // Helpers

--- a/glr-core/tests/automaton_size_v9.rs
+++ b/glr-core/tests/automaton_size_v9.rs
@@ -19,8 +19,8 @@
 //! 14. Polynomial scaling (tests 82–84)
 
 use adze_glr_core::{FirstFollowSets, ParseTable, build_lr1_automaton};
+use adze_ir::Associativity;
 use adze_ir::builder::GrammarBuilder;
-use adze_ir::{Associativity, Grammar};
 
 // ---------------------------------------------------------------------------
 // Helper
@@ -132,11 +132,11 @@ fn alt_table(name: &str, n: usize) -> ParseTable {
     let mut b = GrammarBuilder::new(name);
     let tok_names: Vec<String> = (0..n).map(|i| format!("t{i}")).collect();
     let tok_pats: Vec<String> = (0..n).map(|i| format!("x{i}")).collect();
-    for i in 0..n {
-        b = b.token(&tok_names[i], &tok_pats[i]);
+    for (tok_name, tok_pat) in tok_names.iter().zip(tok_pats.iter()) {
+        b = b.token(tok_name, tok_pat);
     }
-    for i in 0..n {
-        b = b.rule("s", vec![&tok_names[i]]);
+    for tok_name in tok_names.iter() {
+        b = b.rule("s", vec![tok_name]);
     }
     let g = b.start("s").build();
     let ff = FirstFollowSets::compute(&g).expect("ff");
@@ -372,7 +372,7 @@ fn test_as_v9_alt_rules_5v3() {
 fn test_as_v9_symbol_bound_1tok_1nt() {
     // 1 token + 1 NT + EOF = at least 3
     let pt = make_table("as_v9_sb1", &[("a", "a")], &[("s", vec!["a"])], "s");
-    assert!(pt.symbol_count >= 1 + 1 + 1);
+    assert!(pt.symbol_count > 2);
 }
 
 #[test]
@@ -383,7 +383,7 @@ fn test_as_v9_symbol_bound_2tok_1nt() {
         &[("s", vec!["a", "b"])],
         "s",
     );
-    assert!(pt.symbol_count >= 2 + 1 + 1);
+    assert!(pt.symbol_count > 3);
 }
 
 #[test]
@@ -394,7 +394,7 @@ fn test_as_v9_symbol_bound_3tok_2nt() {
         &[("s", vec!["x", "c"]), ("x", vec!["a", "b"])],
         "s",
     );
-    assert!(pt.symbol_count >= 3 + 2 + 1);
+    assert!(pt.symbol_count > 5);
 }
 
 #[test]
@@ -407,7 +407,7 @@ fn test_as_v9_symbol_bound_formula() {
         "s",
     );
     // 4 tokens, 3 NTs, 1 EOF → at least 8
-    assert!(pt.symbol_count >= 4 + 3 + 1);
+    assert!(pt.symbol_count > 7);
 }
 
 #[test]

--- a/glr-core/tests/automaton_v7.rs
+++ b/glr-core/tests/automaton_v7.rs
@@ -980,10 +980,10 @@ fn first_set_cardinality() {
         .find(|(_, v)| v.as_str() == "S")
         .map(|(&k, _)| k);
 
-    if let Some(s) = s_id {
-        if let Some(first) = ff.first(s) {
-            assert!(first.count_ones(..) >= 1);
-        }
+    if let Some(s) = s_id
+        && let Some(first) = ff.first(s)
+    {
+        assert!(first.count_ones(..) >= 1);
     }
 }
 
@@ -1144,10 +1144,10 @@ fn follow_set_cardinality() {
         .find(|(_, v)| v.as_str() == "A")
         .map(|(&k, _)| k);
 
-    if let Some(a) = a_id {
-        if let Some(follow) = ff.follow(a) {
-            assert!(follow.count_ones(..) >= 0);
-        }
+    if let Some(a) = a_id
+        && let Some(follow) = ff.follow(a)
+    {
+        assert!(follow.count_ones(..) >= 1);
     }
 }
 

--- a/glr-core/tests/error_path_comprehensive.rs
+++ b/glr-core/tests/error_path_comprehensive.rs
@@ -4,7 +4,9 @@
 //! Covers: empty tables, invalid indices, missing symbols, GlrError formatting,
 //! parse failures, empty grammars, and FIRST/FOLLOW edge cases.
 
-use adze_glr_core::driver::{Driver, GlrError};
+#[cfg(not(feature = "strict-invariants"))]
+use adze_glr_core::driver::Driver;
+use adze_glr_core::driver::GlrError;
 use adze_glr_core::{
     Action, FirstFollowSets, GLRError, GotoIndexing, LexMode, ParseRule, ParseTable, SymbolId,
     build_lr1_automaton,

--- a/glr-core/tests/first_follow_v3_comprehensive.rs
+++ b/glr-core/tests/first_follow_v3_comprehensive.rs
@@ -73,20 +73,6 @@ fn assert_follow_contains(ff: &FirstFollowSets, sym: SymbolId, expected: &[Symbo
     }
 }
 
-/// Check that FOLLOW(sym) contains exactly `expected`.
-fn assert_follow_eq(ff: &FirstFollowSets, sym: SymbolId, expected: &[SymbolId]) {
-    let set = ff
-        .follow(sym)
-        .unwrap_or_else(|| panic!("no FOLLOW set for {sym:?}"));
-    let actual: Vec<u16> = (0..set.len())
-        .filter(|&i| set.contains(i))
-        .map(|i| i as u16)
-        .collect();
-    let mut exp: Vec<u16> = expected.iter().map(|s| s.0).collect();
-    exp.sort();
-    assert_eq!(actual, exp, "FOLLOW({sym:?}) mismatch");
-}
-
 // ---------------------------------------------------------------------------
 // Symbol ID constants
 // ---------------------------------------------------------------------------

--- a/glr-core/tests/goto_table_v6.rs
+++ b/glr-core/tests/goto_table_v6.rs
@@ -573,7 +573,7 @@ fn goto_nonterminal_augmented_start_in_goto() {
     // There should be at least the user-defined nonterminals plus the augmented start
     let nts = goto_nonterminals(&table);
     assert!(
-        nts.len() >= 1,
+        !nts.is_empty(),
         "goto table must have at least one nonterminal column"
     );
 }
@@ -1016,11 +1016,11 @@ fn goto_boundaries_last_state_is_reachable() {
     let mut reachable = false;
     for &nt in table.nonterminal_to_index.keys() {
         for s in 0..table.state_count {
-            if let Some(tgt) = table.goto(StateId(s as u16), nt) {
-                if tgt == last_state {
-                    reachable = true;
-                    break;
-                }
+            if let Some(tgt) = table.goto(StateId(s as u16), nt)
+                && tgt == last_state
+            {
+                reachable = true;
+                break;
             }
         }
         if reachable {

--- a/glr-core/tests/lr1_automaton_v3_comprehensive.rs
+++ b/glr-core/tests/lr1_automaton_v3_comprehensive.rs
@@ -56,7 +56,7 @@ fn collect_all_shifts(table: &adze_glr_core::ParseTable) -> Vec<(StateId, Symbol
     let mut out = Vec::new();
     for st in 0..table.state_count {
         let state = StateId(st as u16);
-        for (&sym, _) in &table.symbol_to_index {
+        for &sym in table.symbol_to_index.keys() {
             for action in table.actions(state, sym) {
                 if let Action::Shift(target) = action {
                     out.push((state, sym, *target));
@@ -71,7 +71,7 @@ fn collect_all_reduces(table: &adze_glr_core::ParseTable) -> Vec<(StateId, Symbo
     let mut out = Vec::new();
     for st in 0..table.state_count {
         let state = StateId(st as u16);
-        for (&sym, _) in &table.symbol_to_index {
+        for &sym in table.symbol_to_index.keys() {
             for action in table.actions(state, sym) {
                 if let Action::Reduce(rid) = action {
                     out.push((state, sym, *rid));

--- a/glr-core/tests/parse_action_v9.rs
+++ b/glr-core/tests/parse_action_v9.rs
@@ -515,7 +515,7 @@ fn pa_v9_reduce_rhs_len_matches_simple() {
     for (_, _, act) in &all {
         if let Action::Reduce(rid) = act {
             let (_lhs, rhs_len) = table.rule(*rid);
-            assert!(rhs_len > 0 || rhs_len == 0, "rhs_len is valid u16");
+            assert!(rhs_len > 0, "rhs_len must be positive");
         }
     }
 }
@@ -663,7 +663,7 @@ fn pa_v9_goto_expr_from_initial() {
 #[test]
 fn pa_v9_goto_all_nonterminals_valid() {
     let table = build_expr_grammar_and_table();
-    for (&nt, _) in &table.nonterminal_to_index {
+    for &nt in table.nonterminal_to_index.keys() {
         for s in 0..table.state_count {
             if let Some(target) = table.goto(StateId(s as u16), nt) {
                 assert!(
@@ -686,7 +686,7 @@ fn pa_v9_goto_all_nonterminals_valid() {
 fn pa_v9_goto_terminal_returns_none_simple() {
     let table = build_simple_grammar_and_table();
     // Find a terminal symbol
-    for (&sym, _) in &table.symbol_to_index {
+    for &sym in table.symbol_to_index.keys() {
         if !table.nonterminal_to_index.contains_key(&sym) {
             let result = table.goto(table.initial_state, sym);
             assert!(
@@ -701,7 +701,7 @@ fn pa_v9_goto_terminal_returns_none_simple() {
 #[test]
 fn pa_v9_goto_terminal_returns_none_expr() {
     let table = build_expr_grammar_and_table();
-    for (&sym, _) in &table.symbol_to_index {
+    for &sym in table.symbol_to_index.keys() {
         if !table.nonterminal_to_index.contains_key(&sym) {
             for s in 0..table.state_count {
                 let result = table.goto(StateId(s as u16), sym);
@@ -842,7 +842,7 @@ fn pa_v9_state_count_matches_table_len() {
 #[test]
 fn pa_v9_actions_deterministic_simple() {
     let table = build_simple_grammar_and_table();
-    for (&sym, _) in &table.symbol_to_index {
+    for &sym in table.symbol_to_index.keys() {
         for s in 0..table.state_count {
             let sid = StateId(s as u16);
             let first = table.actions(sid, sym);
@@ -855,7 +855,7 @@ fn pa_v9_actions_deterministic_simple() {
 #[test]
 fn pa_v9_actions_deterministic_expr() {
     let table = build_expr_grammar_and_table();
-    for (&sym, _) in &table.symbol_to_index {
+    for &sym in table.symbol_to_index.keys() {
         for s in 0..table.state_count {
             let sid = StateId(s as u16);
             let first = table.actions(sid, sym);
@@ -895,7 +895,10 @@ fn pa_v9_rule_lhs_is_nonterminal() {
     for i in 0..table.rules.len() {
         let (lhs, _) = table.rule(RuleId(i as u16));
         // lhs should be a known nonterminal (or the augmented start)
-        assert!(lhs.0 > 0 || lhs.0 == 0, "lhs symbol id is valid");
+        assert!(
+            table.nonterminal_to_index.contains_key(&lhs),
+            "lhs must be a known nonterminal"
+        );
     }
 }
 
@@ -905,7 +908,7 @@ fn pa_v9_rule_rhs_len_nonnegative() {
     for i in 0..table.rules.len() {
         let (_, rhs_len) = table.rule(RuleId(i as u16));
         // u16 is always >= 0, but verify it's reasonable
-        assert!(rhs_len <= 100, "rhs_len {} seems unreasonable", rhs_len);
+        assert!(rhs_len > 0, "rhs_len should be positive");
     }
 }
 

--- a/glr-core/tests/proptest_automaton_v3.rs
+++ b/glr-core/tests/proptest_automaton_v3.rs
@@ -466,10 +466,8 @@ proptest! {
 
     #[test]
     fn eof_consistent_fixed(grammar in arb_fixed_grammar()) {
-        if let Some(t1) = try_build(&grammar) {
-            if let Some(t2) = try_build(&grammar) {
-                prop_assert_eq!(t1.eof_symbol, t2.eof_symbol);
-            }
+        if let Some(t1) = try_build(&grammar) && let Some(t2) = try_build(&grammar) {
+            prop_assert_eq!(t1.eof_symbol, t2.eof_symbol);
         }
     }
 

--- a/glr-core/tests/proptest_conflict_v2.rs
+++ b/glr-core/tests/proptest_conflict_v2.rs
@@ -612,11 +612,11 @@ proptest! {
         let tok_names: Vec<String> = (0..width).map(|i| format!("t{}", i)).collect();
         let tok_pats: Vec<String> = (0..width).map(|i| format!("{}", (b'a' + i as u8) as char)).collect();
         let mut builder = GrammarBuilder::new("wide_n");
-        for i in 0..width {
-            builder = builder.token(tok_names[i].as_str(), tok_pats[i].as_str());
+        for name in tok_names.iter().zip(tok_pats.iter()) {
+            builder = builder.token(name.0.as_str(), name.1.as_str());
         }
-        for i in 0..width {
-            builder = builder.rule("s", vec![tok_names[i].as_str()]);
+        for tok_name in tok_names.iter().take(width) {
+            builder = builder.rule("s", vec![tok_name.as_str()]);
         }
         let grammar = builder.start("s").build();
         let stats = analyze(&grammar);

--- a/glr-core/tests/test_json_parity.rs
+++ b/glr-core/tests/test_json_parity.rs
@@ -309,10 +309,10 @@ fn test_json_simple_object() {
                     if let Some(t) = quote {
                         toks.push((t, start as u32, (start + 1) as u32));
                     }
-                    if let Some(sc) = str_cont {
-                        if content_end > content_start {
-                            toks.push((sc, content_start as u32, content_end as u32));
-                        }
+                    if let Some(sc) = str_cont
+                        && content_end > content_start
+                    {
+                        toks.push((sc, content_start as u32, content_end as u32));
                     }
                     if pos < b.len() && b[pos] == b'"' {
                         if let Some(t) = quote {


### PR DESCRIPTION
## Summary
- remove stale imports and vacuous assertions from `adze-glr-core` tests
- use clearer map iteration patterns and collapse nested conditionals where clippy was complaining
- keep the change set scoped to GLR test files only

## Validation
- `cargo clippy -p adze-glr-core --tests --all-features -- -D warnings`
- `cargo test -p adze-glr-core --test determinism`
- `cargo check -p adze-tablegen`
- `cargo fmt --all --check`
