### PR TITLE
tool: generate pure-Rust parser modules on C-codegen path

### DIFF
--- a/tool/src/lib.rs
+++ b/tool/src/lib.rs
@@ -121,35 +121,19 @@ pub fn build_parsers(root_file: &Path) {
 
     if use_pure_rust {
         // Use pure-Rust builder exclusively
-        use pure_rust_builder::{BuildOptions, build_parser_for_crate};
-        let options = BuildOptions::default();
-        match build_parser_for_crate(root_file, options) {
-            Ok(results) => {
-                for result in results {
-                    println!("cargo:rerun-if-changed={}", result.parser_path);
-                    if std::env::var("RUST_LOG")
-                        .ok()
-                        .unwrap_or_default()
-                        .contains("debug")
-                    {
-                        println!("Built pure-Rust parser for {}", result.grammar_name);
-                    }
-                }
-            }
-            Err(e) => {
-                eprintln!("Failed to build pure-Rust parser: {}", e);
-                // Print the full error chain
-                let mut source = e.source();
-                while let Some(err) = source {
-                    eprintln!("  Caused by: {}", err);
-                    source = err.source();
-                }
-                panic!("FATAL: Pure-Rust parser generation failed: {:#}", e);
-            }
-        }
+        run_pure_rust_builder(root_file, true);
         // Critical: don't fall through to C generation
         return;
     }
+
+    // Build pure-Rust parser modules opportunistically even on the C-codegen path.
+    //
+    // Why: downstream crates can enable `adze/pure-rust` without having a
+    // corresponding local Cargo feature. In that case `CARGO_FEATURE_PURE_RUST`
+    // is not set for the build script, but the proc-macro still expands to an
+    // `include!(.../parser_<grammar>.rs)` path. Generating the Rust parser here
+    // avoids that mismatch and keeps C codegen behavior unchanged.
+    run_pure_rust_builder(root_file, false);
 
     // If we get here, use C-based generation exclusively
     use std::env;
@@ -354,6 +338,37 @@ pub fn build_parsers(root_file: &Path) {
             .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
             .collect();
         c_config.compile(&lib_name);
+    }
+}
+
+fn run_pure_rust_builder(root_file: &Path, strict: bool) {
+    use pure_rust_builder::{BuildOptions, build_parser_for_crate};
+    let options = BuildOptions::default();
+    match build_parser_for_crate(root_file, options) {
+        Ok(results) => {
+            for result in results {
+                println!("cargo:rerun-if-changed={}", result.parser_path);
+                if std::env::var("RUST_LOG")
+                    .ok()
+                    .unwrap_or_default()
+                    .contains("debug")
+                {
+                    println!("Built pure-Rust parser for {}", result.grammar_name);
+                }
+            }
+        }
+        Err(e) if strict => {
+            eprintln!("Failed to build pure-Rust parser: {}", e);
+            let mut source = e.source();
+            while let Some(err) = source {
+                eprintln!("  Caused by: {}", err);
+                source = err.source();
+            }
+            panic!("FATAL: Pure-Rust parser generation failed: {:#}", e);
+        }
+        Err(e) => {
+            println!("cargo:warning=Failed to build optional pure-Rust parser modules: {e}");
+        }
     }
 }
 


### PR DESCRIPTION
### Motivation
- The build script only generated pure-Rust parser modules when `CARGO_FEATURE_PURE_RUST` / `ADZE_USE_PURE_RUST` was present, but proc-macro expansion can still `include!` the Rust parser module even when the build script took the C-only path, causing missing-file compile errors.
- Ensure downstream crates that enable the `adze/pure-rust` feature (without a local Cargo feature) do not fail to compile due to absent `parser_<grammar>.rs` files.

### Description
- Refactored pure-Rust generation into a helper `run_pure_rust_builder(root_file, strict)` to centralize logic and avoid duplication. 
- When pure-Rust mode is explicitly requested (`CARGO_FEATURE_PURE_RUST` / `ADZE_USE_PURE_RUST`) the helper is invoked in strict mode and failures still panic to preserve original semantics. 
- When on the C-codegen path, the helper is invoked opportunistically (non-strict) before C generation to produce `parser_<grammar>.rs` modules; failures now emit a `cargo:warning=` instead of aborting. 
- Kept existing C code generation behavior unchanged while ensuring the Rust parser module is available when macros expect it.

### Testing
- Ran `cargo check -p adze-tool` and the check completed successfully. 
- Ran `cargo run` in the `repro-issue-74/` example and it compiled and executed successfully, including verifying the leaf transform output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e894fed81c8333afb0534b5026168d)