### PR TITLE
Fix Tree-sitter lexer callback defaults in glr-core

### DIFF
--- a/glr-core/src/ts_lexer.rs
+++ b/glr-core/src/ts_lexer.rs
@@ -129,12 +129,20 @@ impl<'a> TsLexerHost<'a> {
         host.end_mark = host.pos;
     }
 
-    extern "C" fn get_column(_payload: *mut c_void) -> u32 {
-        0 // TODO: Track column for proper error reporting
+    extern "C" fn get_column(payload: *mut c_void) -> u32 {
+        // SAFETY: see shared invariant above.
+        let host = unsafe { &mut *(payload as *mut Self) };
+        let current_pos = host.pos.min(host.input.len());
+        let line_start = host.input[..current_pos]
+            .iter()
+            .rposition(|&b| b == b'\n')
+            .map_or(0, |idx| idx + 1);
+        (current_pos - line_start) as u32
     }
 
     extern "C" fn is_included(_payload: *mut c_void) -> bool {
-        false // TODO: Support included ranges for injections
+        // Without injection range support, treat the whole input as included.
+        true
     }
 }
 
@@ -217,6 +225,8 @@ unsafe extern "C" {
 
 #[cfg(test)]
 mod tests {
+    use super::TsLexerHost;
+    use std::ffi::c_void;
 
     #[test]
     #[ignore = "requires actual Tree-sitter library to be linked"]
@@ -231,5 +241,38 @@ mod tests {
         //     assert!(token.is_some());
         //     assert_eq!(token.unwrap().kind, 1); // { token
         // }
+    }
+
+    #[test]
+    fn get_column_reports_offset_from_current_line_start() {
+        let mut host = TsLexerHost {
+            input: b"abc\ndef",
+            pos: 6, // "abc\n|de|f"
+            end_mark: 6,
+        };
+        let payload = &mut host as *mut TsLexerHost<'_> as *mut c_void;
+        assert_eq!(TsLexerHost::get_column(payload), 2);
+    }
+
+    #[test]
+    fn get_column_reports_full_offset_on_first_line() {
+        let mut host = TsLexerHost {
+            input: b"abcdef",
+            pos: 4,
+            end_mark: 4,
+        };
+        let payload = &mut host as *mut TsLexerHost<'_> as *mut c_void;
+        assert_eq!(TsLexerHost::get_column(payload), 4);
+    }
+
+    #[test]
+    fn is_included_defaults_to_true_without_injection_ranges() {
+        let mut host = TsLexerHost {
+            input: b"",
+            pos: 0,
+            end_mark: 0,
+        };
+        let payload = &mut host as *mut TsLexerHost<'_> as *mut c_void;
+        assert!(TsLexerHost::is_included(payload));
     }
 }


### PR DESCRIPTION
### Motivation
- `TsLexerHost::get_column` previously returned `0` unconditionally which prevented correct column reporting to Tree-sitter lexers and external scanners.
- `TsLexerHost::is_included` returned `false` by default which incorrectly signals that no input is included when injection ranges are not modeled, and both behaviors reduce diagnostic and scanner correctness.

### Description
- Implement `TsLexerHost::get_column` to compute the byte offset from the start of the current line by searching for the last `\n` before the current position in `glr-core/src/ts_lexer.rs`.
- Change `TsLexerHost::is_included` to return `true` by default when injection ranges are not modeled so the entire input is treated as included.
- Add unit tests validating column computation across line boundaries and on the first line, plus a regression test for the `is_included` default in `glr-core/src/ts_lexer.rs`.
- Run formatting (`cargo fmt --all`) on the workspace.

### Testing
- Ran `cargo fmt --all` and formatting completed successfully.
- Ran `cargo test -p adze-glr-core ts_lexer` which passed the added tests (3 passed; 1 ignored) and reported the test suite as successful.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e894fc53848333a75f01ccdafa2623)