### PR TITLE
tablegen: compute alias metadata from grammar alias sequences

### DIFF
--- a/tablegen/src/generate.rs
+++ b/tablegen/src/generate.rs
@@ -58,11 +58,12 @@ impl LanguageBuilder {
         let external_token_count = self.grammar.externals.len() as u32;
         let field_count = self.grammar.fields.len() as u32;
 
-        // TODO: Calculate these properly
-        let alias_count = 0;
+        let alias_count = calculate_alias_count(&self.grammar);
         let large_state_count = 0;
-        let production_id_count = self.grammar.alias_sequences.len() as u32;
-        let max_alias_sequence_length = 0;
+        let production_id_count =
+            u32::try_from(self.grammar.alias_sequences.len()).unwrap_or(u32::MAX);
+        let max_alias_sequence_length =
+            u16::try_from(self.grammar.max_alias_sequence_length).unwrap_or(u16::MAX);
 
         // Build symbol names array
         let symbol_names = self.build_symbol_names();
@@ -220,6 +221,16 @@ impl LanguageBuilder {
             }
         }
     }
+}
+
+fn calculate_alias_count(grammar: &Grammar) -> u32 {
+    let count = grammar
+        .alias_sequences
+        .values()
+        .flat_map(|sequence| sequence.aliases.iter())
+        .filter(|alias| alias.is_some())
+        .count();
+    u32::try_from(count).unwrap_or(u32::MAX)
 }
 
 #[cfg(test)]

--- a/tablegen/src/serializer.rs
+++ b/tablegen/src/serializer.rs
@@ -61,7 +61,7 @@ fn build_serializable_language(
     SerializableLanguage {
         version: TREE_SITTER_LANGUAGE_VERSION,
         symbol_count: calculate_symbol_count(grammar) as u32,
-        alias_count: 0,
+        alias_count: calculate_alias_count(grammar),
         token_count: grammar.tokens.len() as u32,
         external_token_count: grammar.externals.len() as u32,
         state_count: parse_table.state_count as u32,
@@ -75,6 +75,16 @@ fn build_serializable_language(
         small_parse_table_map: small_table_map,
         lex_modes,
     }
+}
+
+fn calculate_alias_count(grammar: &Grammar) -> u32 {
+    let count = grammar
+        .alias_sequences
+        .values()
+        .flat_map(|sequence| sequence.aliases.iter())
+        .filter(|alias| alias.is_some())
+        .count();
+    u32::try_from(count).unwrap_or(u32::MAX)
 }
 
 fn generate_symbol_names(grammar: &Grammar) -> Vec<String> {

--- a/tablegen/tests/alias_handling_comprehensive.rs
+++ b/tablegen/tests/alias_handling_comprehensive.rs
@@ -336,10 +336,9 @@ fn language_builder_many_tokens_alias_zero() {
     assert_eq!(lang.max_alias_sequence_length, 0);
 }
 
-/// LanguageBuilder with grammar alias_sequences still gets alias_count=0
-/// because alias counting is not yet implemented.
+/// LanguageBuilder counts populated alias sequence entries.
 #[test]
-fn language_builder_ignores_grammar_alias_sequences_for_now() {
+fn language_builder_counts_grammar_alias_sequences() {
     let mut grammar = GrammarBuilder::new("alias_test")
         .token("x", "x")
         .rule("start", vec!["x"])
@@ -362,8 +361,8 @@ fn language_builder_ignores_grammar_alias_sequences_for_now() {
 
     // production_id_count reflects alias_sequences.len()
     assert_eq!(lang.production_id_count, 1);
-    // But alias_count itself is still 0 (TODO in source)
-    assert_eq!(lang.alias_count, 0);
+    assert_eq!(lang.alias_count, 1);
+    assert_eq!(lang.max_alias_sequence_length, 1);
 }
 
 // =========================================================================
@@ -584,10 +583,9 @@ fn serializer_grammar_with_aliases_does_not_panic() {
     assert!(json.is_ok(), "serialization should not fail");
 }
 
-/// Serialized alias_count remains 0 even when grammar has alias_sequences
-/// (serializer does not yet use alias_sequences to compute alias_count).
+/// Serialized alias_count reflects populated grammar alias_sequences.
 #[test]
-fn serializer_alias_count_still_zero_with_grammar_aliases() {
+fn serializer_alias_count_with_grammar_aliases() {
     let mut grammar = GrammarBuilder::new("alias_ser2")
         .token("t", "t")
         .rule("s", vec!["t"])
@@ -604,7 +602,7 @@ fn serializer_alias_count_still_zero_with_grammar_aliases() {
     let table = ParseTable::default();
     let json = serialize_language(&grammar, &table, None).unwrap();
     let lang: SerializableLanguage = serde_json::from_str(&json).unwrap();
-    assert_eq!(lang.alias_count, 0);
+    assert_eq!(lang.alias_count, 1);
 }
 
 // =========================================================================


### PR DESCRIPTION
### Motivation

- `alias_count` and `max_alias_sequence_length` were hardcoded to `0` in parts of the tablegen pipeline causing metadata to be inconsistent when `Grammar.alias_sequences` contained aliases.
- The change ensures ABI/serializer outputs and `LanguageBuilder` reflect actual alias data present in the grammar.

### Description

- Compute `alias_count` from `Grammar.alias_sequences` via a new `calculate_alias_count` helper used by `LanguageBuilder` in `tablegen/src/generate.rs` and by the JSON serializer in `tablegen/src/serializer.rs`.
- Wire `max_alias_sequence_length` in `LanguageBuilder` to use `grammar.max_alias_sequence_length` with checked integer conversions and make `production_id_count` use a safe `u32::try_from` conversion in `tablegen/src/generate.rs`.
- Update serializer to set `SerializableLanguage.alias_count` from `calculate_alias_count` instead of a constant zero in `tablegen/src/serializer.rs`.
- Update tests in `tablegen/tests/alias_handling_comprehensive.rs` to assert the new behavior when grammars include alias sequences.

### Testing

- Ran formatting with `cargo fmt --all` (succeeded).
- Ran targeted tests `cargo test -p adze-tablegen language_builder_counts_grammar_alias_sequences` and `cargo test -p adze-tablegen serializer_alias_count_with_grammar_aliases` (both passed).
- Ran `cargo test -p adze-tablegen alias_handling_comprehensive -- --nocapture` to exercise the updated alias tests (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e894fc53848333a75f01ccdafa2623)