### PR TITLE
Fix GLR lexer infinite loops on zero-length token matches

### DIFF
--- a/runtime/src/glr_lexer.rs
+++ b/runtime/src/glr_lexer.rs
@@ -42,6 +42,9 @@ impl TokenMatcher {
 
         match self {
             TokenMatcher::Literal(s) => {
+                if s.is_empty() {
+                    return None;
+                }
                 if input[pos..].starts_with(s) {
                     Some(s.len())
                 } else {
@@ -51,7 +54,11 @@ impl TokenMatcher {
             TokenMatcher::Regex(re) => {
                 // Ensure regex matches at start of string slice
                 if let Some(m) = re.find(&input[pos..]) {
-                    if m.start() == 0 { Some(m.len()) } else { None }
+                    if m.start() == 0 && m.len() > 0 {
+                        Some(m.len())
+                    } else {
+                        None
+                    }
                 } else {
                     None
                 }
@@ -376,5 +383,39 @@ mod tests {
         assert_eq!(tokens.len(), 2);
         assert_eq!(tokens[0].text, "a");
         assert_eq!(tokens[1].text, "b");
+    }
+
+    #[test]
+    fn test_zero_length_literal_is_ignored() {
+        let mut grammar = Grammar::new("test".to_string());
+        grammar.tokens.insert(
+            SymbolId(1),
+            Token {
+                name: "empty".to_string(),
+                pattern: TokenPattern::String(String::new()),
+                fragile: false,
+            },
+        );
+
+        let mut lexer = GLRLexer::new(&grammar, "abc".to_string()).unwrap();
+        let tokens = lexer.tokenize_all();
+        assert!(tokens.is_empty());
+    }
+
+    #[test]
+    fn test_zero_length_regex_is_ignored() {
+        let mut grammar = Grammar::new("test".to_string());
+        grammar.tokens.insert(
+            SymbolId(1),
+            Token {
+                name: "digits_optional".to_string(),
+                pattern: TokenPattern::Regex(r"\d*".to_string()),
+                fragile: false,
+            },
+        );
+
+        let mut lexer = GLRLexer::new(&grammar, "abc".to_string()).unwrap();
+        let tokens = lexer.tokenize_all();
+        assert!(tokens.is_empty());
     }
 }


### PR DESCRIPTION
### Motivation
- The GLR lexer could enter an infinite loop when a token pattern matched with length 0 (e.g., an empty literal `""` or a regex like `\d*`) because the lexer would not advance the input position.
- This behavior was a known boundary issue and caused test instability and potential hangs in `tokenize_all()`.

### Description
- Reject zero-length literal token patterns by returning `None` from `TokenMatcher::matches_at` when the literal string is empty.
- Reject zero-length regex matches by treating regex matches of length 0 as non-matches in `TokenMatcher::Regex` logic.
- Add focused unit tests covering an empty literal token and a zero-length-regex token to ensure the lexer terminates and produces no tokens for non-matching input.
- Changes are contained in `runtime/src/glr_lexer.rs` (matcher logic + tests).

### Testing
- Ran code formatting with `cargo fmt --all`, which completed successfully.
- Ran unit tests for the new cases with `cargo test -p adze --lib test_zero_length_literal_is_ignored` and `cargo test -p adze --lib test_zero_length_regex_is_ignored`, and both tests passed.
- Also ran `cargo test -p adze --lib test_literal_token_matching` to ensure no regressions in existing literal matching, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e894fc53848333a75f01ccdafa2623)