### PR TITLE
bdd-grid: add grid validation helpers and report warnings

### DIFF
--- a/crates/bdd-grid-core/src/lib.rs
+++ b/crates/bdd-grid-core/src/lib.rs
@@ -15,6 +15,33 @@ use core::fmt::Write;
 
 pub use adze_bdd_scenario_core::{BddPhase, BddScenario, BddScenarioStatus};
 
+/// Validation issue found in a BDD scenario grid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BddGridValidationIssue {
+    /// A scenario id appeared more than once.
+    DuplicateScenarioId {
+        /// Duplicated id value.
+        id: u8,
+    },
+    /// A scenario had an empty title.
+    EmptyTitle {
+        /// Scenario id for the invalid row.
+        id: u8,
+    },
+    /// A scenario had an empty reference path.
+    EmptyReference {
+        /// Scenario id for the invalid row.
+        id: u8,
+    },
+    /// A deferred status was declared without a reason.
+    DeferredWithoutReason {
+        /// Scenario id for the invalid row.
+        id: u8,
+        /// Phase that contains the invalid deferred status.
+        phase: BddPhase,
+    },
+}
+
 /// GLR conflict-preservation scenario ledger.
 pub const GLR_CONFLICT_PRESERVATION_GRID: &[BddScenario] = &[
     BddScenario {
@@ -107,6 +134,53 @@ pub fn bdd_progress(phase: BddPhase, scenarios: &[BddScenario]) -> (usize, usize
     (implemented, scenarios.len())
 }
 
+/// Collect validation issues for a scenario grid.
+///
+/// A valid grid should satisfy all of the following:
+/// - scenario ids are unique
+/// - scenario titles are non-empty (after trim)
+/// - references are non-empty (after trim)
+/// - deferred statuses include a non-empty reason (after trim)
+pub fn bdd_grid_validation_issues(scenarios: &[BddScenario]) -> Vec<BddGridValidationIssue> {
+    let mut issues = Vec::new();
+    let mut seen_ids = [false; u8::MAX as usize + 1];
+
+    for scenario in scenarios {
+        let id_idx = usize::from(scenario.id);
+        if seen_ids[id_idx] {
+            issues.push(BddGridValidationIssue::DuplicateScenarioId { id: scenario.id });
+        } else {
+            seen_ids[id_idx] = true;
+        }
+
+        if scenario.title.trim().is_empty() {
+            issues.push(BddGridValidationIssue::EmptyTitle { id: scenario.id });
+        }
+
+        if scenario.reference.trim().is_empty() {
+            issues.push(BddGridValidationIssue::EmptyReference { id: scenario.id });
+        }
+
+        for phase in [BddPhase::Core, BddPhase::Runtime] {
+            if let BddScenarioStatus::Deferred { reason } = scenario.status(phase)
+                && reason.trim().is_empty()
+            {
+                issues.push(BddGridValidationIssue::DeferredWithoutReason {
+                    id: scenario.id,
+                    phase,
+                });
+            }
+        }
+    }
+
+    issues
+}
+
+/// Return whether a scenario grid passes validation checks.
+pub fn bdd_grid_is_valid(scenarios: &[BddScenario]) -> bool {
+    bdd_grid_validation_issues(scenarios).is_empty()
+}
+
 /// Shared formatting for BDD progress summaries.
 ///
 /// # Examples
@@ -154,6 +228,15 @@ pub fn bdd_progress_report(
         out.push('\n');
     }
 
+    let validation_issues = bdd_grid_validation_issues(scenarios);
+    if !validation_issues.is_empty() {
+        let _ = write!(
+            out,
+            "\n⚠️ Grid validation issues detected: {}",
+            validation_issues.len()
+        );
+    }
+
     out.push('\n');
     let _ = write!(
         out,
@@ -189,5 +272,49 @@ mod tests {
             bdd_progress_report(BddPhase::Runtime, GLR_CONFLICT_PRESERVATION_GRID, "Runtime");
         assert!(report.contains("Runtime"));
         assert!(report.contains("Scenario 1"));
+    }
+
+    #[test]
+    fn grid_validation_passes_for_builtin_grid() {
+        assert!(bdd_grid_is_valid(GLR_CONFLICT_PRESERVATION_GRID));
+        assert!(bdd_grid_validation_issues(GLR_CONFLICT_PRESERVATION_GRID).is_empty());
+    }
+
+    #[test]
+    fn grid_validation_detects_common_issues() {
+        let scenarios = [
+            BddScenario {
+                id: 1,
+                title: "  ",
+                reference: "docs/ref",
+                core_status: BddScenarioStatus::Deferred { reason: "" },
+                runtime_status: BddScenarioStatus::Implemented,
+            },
+            BddScenario {
+                id: 1,
+                title: "valid title",
+                reference: "",
+                core_status: BddScenarioStatus::Implemented,
+                runtime_status: BddScenarioStatus::Deferred { reason: "   " },
+            },
+        ];
+
+        let issues = bdd_grid_validation_issues(&scenarios);
+        assert!(!issues.is_empty());
+        assert!(issues.contains(&BddGridValidationIssue::DuplicateScenarioId { id: 1 }));
+        assert!(issues.contains(&BddGridValidationIssue::EmptyTitle { id: 1 }));
+        assert!(issues.contains(&BddGridValidationIssue::EmptyReference { id: 1 }));
+        assert!(
+            issues.contains(&BddGridValidationIssue::DeferredWithoutReason {
+                id: 1,
+                phase: BddPhase::Core,
+            })
+        );
+        assert!(
+            issues.contains(&BddGridValidationIssue::DeferredWithoutReason {
+                id: 1,
+                phase: BddPhase::Runtime,
+            })
+        );
     }
 }

--- a/crates/bdd-grid-core/tests/grid_tests.rs
+++ b/crates/bdd-grid-core/tests/grid_tests.rs
@@ -131,3 +131,49 @@ fn glr_grid_constant_has_items() {
     assert!(!GLR_CONFLICT_PRESERVATION_GRID.is_empty());
     assert_eq!(GLR_CONFLICT_PRESERVATION_GRID.len(), 8);
 }
+
+#[test]
+fn bdd_grid_validation_helpers_detect_invalid_rows() {
+    let scenarios = [
+        BddScenario {
+            id: 9,
+            title: "scenario a",
+            reference: "ref",
+            core_status: BddScenarioStatus::Implemented,
+            runtime_status: BddScenarioStatus::Implemented,
+        },
+        BddScenario {
+            id: 9,
+            title: "",
+            reference: "",
+            core_status: BddScenarioStatus::Deferred { reason: "" },
+            runtime_status: BddScenarioStatus::Deferred { reason: "later" },
+        },
+    ];
+
+    assert!(!bdd_grid_is_valid(&scenarios));
+    let issues = bdd_grid_validation_issues(&scenarios);
+    assert!(issues.contains(&BddGridValidationIssue::DuplicateScenarioId { id: 9 }));
+    assert!(issues.contains(&BddGridValidationIssue::EmptyTitle { id: 9 }));
+    assert!(issues.contains(&BddGridValidationIssue::EmptyReference { id: 9 }));
+    assert!(
+        issues.contains(&BddGridValidationIssue::DeferredWithoutReason {
+            id: 9,
+            phase: BddPhase::Core,
+        })
+    );
+}
+
+#[test]
+fn bdd_progress_report_warns_for_invalid_grid() {
+    let scenarios = [BddScenario {
+        id: 1,
+        title: "test",
+        reference: "ref",
+        core_status: BddScenarioStatus::Deferred { reason: "" },
+        runtime_status: BddScenarioStatus::Implemented,
+    }];
+
+    let report = bdd_progress_report(BddPhase::Core, &scenarios, "Core");
+    assert!(report.contains("Grid validation issues detected: 1"));
+}


### PR DESCRIPTION
### Motivation

- Make BDD scenario grid integrity explicit so governance/reporting code can detect structural issues early. 
- Prevent silent metadata drift (duplicate ids, empty titles/references, deferred statuses without reasons) that could undermine BDD reporting and automation.

### Description

- Added a new `BddGridValidationIssue` enum to represent duplicate ids, empty titles, empty references, and deferred statuses missing reasons. 
- Implemented `bdd_grid_validation_issues(scenarios: &[BddScenario]) -> Vec<BddGridValidationIssue>` and `bdd_grid_is_valid(scenarios: &[BddScenario]) -> bool` to surface and check grid problems. 
- Updated `bdd_progress_report` to append a visible warning line when validation issues are detected. 
- Added unit/integration tests exercising the new validation helpers and report behavior in `crates/bdd-grid-core` tests.

### Testing

- Ran `cargo test -p adze-bdd-grid-core` and all package tests passed (95 tests across unit, integration and doc-tests succeeded). 
- Ran formatting via `cargo fmt --all` before tests. 
- The repository PR-gate `just ci-supported` could not be executed in this environment because `just` is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e957c6c6f483339390f7b752637325)