### PR TITLE
Add BDD grid validation and expose diagnostics in progress reports

### DIFF
--- a/crates/bdd-grid-core/src/lib.rs
+++ b/crates/bdd-grid-core/src/lib.rs
@@ -12,6 +12,7 @@
 #![cfg_attr(not(feature = "strict_docs"), allow(missing_docs))]
 
 use core::fmt::Write;
+use std::collections::HashSet;
 
 pub use adze_bdd_scenario_core::{BddPhase, BddScenario, BddScenarioStatus};
 
@@ -107,6 +108,62 @@ pub fn bdd_progress(phase: BddPhase, scenarios: &[BddScenario]) -> (usize, usize
     (implemented, scenarios.len())
 }
 
+/// Validate a BDD scenario grid for common authoring errors.
+///
+/// The returned vector is empty when the grid is valid.
+///
+/// # Validation checks
+///
+/// - Scenario IDs are unique.
+/// - Scenario IDs are strictly increasing in declaration order.
+/// - Scenario titles are non-empty after trimming.
+/// - Scenario references are non-empty after trimming.
+pub fn bdd_grid_validation_errors(scenarios: &[BddScenario]) -> Vec<String> {
+    let mut errors = Vec::new();
+    let mut seen_ids = HashSet::with_capacity(scenarios.len());
+    let mut previous_id: Option<u8> = None;
+
+    for (index, scenario) in scenarios.iter().enumerate() {
+        if !seen_ids.insert(scenario.id) {
+            errors.push(format!(
+                "scenario at index {index} reuses duplicate id {}",
+                scenario.id
+            ));
+        }
+
+        if let Some(prev) = previous_id
+            && scenario.id <= prev
+        {
+            errors.push(format!(
+                "scenario at index {index} has non-increasing id {} (previous id was {prev})",
+                scenario.id
+            ));
+        }
+        previous_id = Some(scenario.id);
+
+        if scenario.title.trim().is_empty() {
+            errors.push(format!(
+                "scenario id {} at index {index} has an empty title",
+                scenario.id
+            ));
+        }
+
+        if scenario.reference.trim().is_empty() {
+            errors.push(format!(
+                "scenario id {} at index {index} has an empty reference",
+                scenario.id
+            ));
+        }
+    }
+
+    errors
+}
+
+/// Return true when a BDD scenario grid passes validation checks.
+pub fn bdd_grid_is_valid(scenarios: &[BddScenario]) -> bool {
+    bdd_grid_validation_errors(scenarios).is_empty()
+}
+
 /// Shared formatting for BDD progress summaries.
 ///
 /// # Examples
@@ -164,6 +221,21 @@ pub fn bdd_progress_report(
         out.push_str("\nNext: Implement remaining deferred scenarios.");
     }
 
+    let validation_errors = bdd_grid_validation_errors(scenarios);
+    if validation_errors.is_empty() {
+        out.push_str("\nGrid validation: OK.");
+    } else {
+        let _ = write!(
+            out,
+            "\nGrid validation: FAILED ({} issue(s)).",
+            validation_errors.len()
+        );
+        for error in validation_errors {
+            out.push_str("\n - ");
+            out.push_str(&error);
+        }
+    }
+
     out
 }
 
@@ -189,5 +261,46 @@ mod tests {
             bdd_progress_report(BddPhase::Runtime, GLR_CONFLICT_PRESERVATION_GRID, "Runtime");
         assert!(report.contains("Runtime"));
         assert!(report.contains("Scenario 1"));
+        assert!(report.contains("Grid validation: OK."));
+    }
+
+    #[test]
+    fn grid_validation_reports_duplicate_ids() {
+        let scenarios = [
+            BddScenario {
+                id: 1,
+                title: "First",
+                reference: "ref-1",
+                core_status: BddScenarioStatus::Implemented,
+                runtime_status: BddScenarioStatus::Implemented,
+            },
+            BddScenario {
+                id: 1,
+                title: "Second",
+                reference: "ref-2",
+                core_status: BddScenarioStatus::Deferred { reason: "pending" },
+                runtime_status: BddScenarioStatus::Deferred { reason: "pending" },
+            },
+        ];
+
+        let errors = bdd_grid_validation_errors(&scenarios);
+        assert!(!errors.is_empty());
+        assert!(!bdd_grid_is_valid(&scenarios));
+    }
+
+    #[test]
+    fn progress_report_includes_validation_failures() {
+        let scenarios = [BddScenario {
+            id: 1,
+            title: "",
+            reference: "",
+            core_status: BddScenarioStatus::Implemented,
+            runtime_status: BddScenarioStatus::Implemented,
+        }];
+
+        let report = bdd_progress_report(BddPhase::Core, &scenarios, "Core");
+        assert!(report.contains("Grid validation: FAILED"));
+        assert!(report.contains("empty title"));
+        assert!(report.contains("empty reference"));
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent subtle authoring errors in the shared BDD scenario ledger (duplicate IDs, non-increasing IDs, or empty metadata) from appearing "healthy" in downstream reports.
- Surface concrete, actionable validation diagnostics in the same reporting path used by governance tooling so problems are noticed early.

### Description
- Add `bdd_grid_validation_errors(scenarios: &[BddScenario]) -> Vec<String>` which performs checks for duplicate ids, non-increasing ids, empty `title` and empty `reference` values and returns human-readable issues.
- Add `bdd_grid_is_valid(scenarios: &[BddScenario]) -> bool` as a convenience wrapper that returns true when no validation errors are present.
- Integrate validation into `bdd_progress_report` so the report appends either `Grid validation: OK.` or a `Grid validation: FAILED (...)` section with per-issue lines.
- Add unit tests that assert validation success on the canonical grid, detect duplicate ids, and ensure reports include validation failure details; import `HashSet` for validation logic.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p adze-bdd-grid-core` and the test suites passed (unit and integration tests exercised and all passed).
- Ran `cargo test -p adze-governance-status-core` and its tests passed (3 tests ran and passed).
- Attempted `just ci-supported` but it failed in this environment because `just` is not installed (`/bin/bash: line 1: just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e957c08e40833382e277374510f2de)