### PR TITLE
bdd-grid: make progress reports reusable across scenario sets

### DIFF
--- a/crates/bdd-grid-core/src/lib.rs
+++ b/crates/bdd-grid-core/src/lib.rs
@@ -130,7 +130,7 @@ pub fn bdd_progress_report(
     let mut out = String::new();
 
     let (implemented, total) = bdd_progress(phase, scenarios);
-    out.push_str("\n=== BDD GLR Conflict Preservation Test Summary ===\n");
+    out.push_str("=== BDD Scenario Progress Summary ===\n");
     out.push_str(phase_title);
     out.push('\n');
     out.push('\n');
@@ -160,6 +160,9 @@ pub fn bdd_progress_report(
         "{}: {}/{} scenarios complete",
         phase_title, implemented, total
     );
+    if let Some(reference) = scenarios.first().map(|scenario| scenario.reference) {
+        let _ = write!(out, "\nReference: {reference}");
+    }
     if implemented < total {
         out.push_str("\nNext: Implement remaining deferred scenarios.");
     }
@@ -189,5 +192,18 @@ mod tests {
             bdd_progress_report(BddPhase::Runtime, GLR_CONFLICT_PRESERVATION_GRID, "Runtime");
         assert!(report.contains("Runtime"));
         assert!(report.contains("Scenario 1"));
+    }
+
+    #[test]
+    fn progress_report_uses_generic_heading_and_reference() {
+        let report = bdd_progress_report(BddPhase::Core, GLR_CONFLICT_PRESERVATION_GRID, "Core");
+        assert!(report.starts_with("=== BDD Scenario Progress Summary ==="));
+        assert!(report.contains("Reference: docs/archive/plans/BDD_GLR_CONFLICT_PRESERVATION.md"));
+    }
+
+    #[test]
+    fn progress_report_omits_reference_for_empty_grid() {
+        let report = bdd_progress_report(BddPhase::Core, &[], "Core");
+        assert!(!report.contains("Reference:"));
     }
 }


### PR DESCRIPTION
### Motivation
- `bdd_progress_report` previously included a GLR-specific banner which made the report misleading when reused for other BDD grids, so the report should be generic and traceable to its source plan.

### Description
- Changed the report heading to a generic title by replacing the GLR-specific banner with `=== BDD Scenario Progress Summary ===` in `crates/bdd-grid-core/src/lib.rs` and kept the rest of the report structure intact.
- Added a footer line that includes the originating scenario `reference` when a non-empty scenario slice is provided, and added tests exercising reference inclusion and omission for empty grids in `bdd-grid-core`.

### Testing
- Ran `cargo test -p adze-bdd-grid-core -p adze-bdd-grid-contract -p adze-bdd-governance-reporting-core` and all tests passed (multiple crate test suites including new unit tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e957bece3c8333afb915328e1ed568)