### PR TITLE
tablegen: add null-pointer guards in compressed parser table access

### DIFF
--- a/tablegen/src/parser.rs
+++ b/tablegen/src/parser.rs
@@ -97,17 +97,7 @@ impl Parser {
 
     fn get_action(&self, state: u16, symbol: u16) -> Result<ParseAction, String> {
         // Access compressed parse table
-        let parse_table = unsafe {
-            // SAFETY: `self.language.parse_table` must be a valid pointer to at least
-            // `state_count * 2` contiguous `u16` values. This is guaranteed by the
-            // TSLanguage ABI contract — callers must supply a well-formed language struct.
-            // TODO(safety): No runtime validation that `parse_table` is non-null; a null
-            // pointer here is instant UB. Consider adding a null check.
-            std::slice::from_raw_parts(
-                self.language.parse_table,
-                self.language.state_count as usize * 2,
-            )
-        };
+        let parse_table = self.parse_table_slice()?;
 
         // Decode compressed action
         let table_offset = (state as usize) * 2;
@@ -158,15 +148,7 @@ impl Parser {
 
     fn perform_reduction(&mut self, rule_id: u16) -> Result<(), String> {
         // Get rule info from grammar
-        let production_id_map = unsafe {
-            // SAFETY: `self.language.production_id_map` must point to at least
-            // `production_id_count` contiguous `u16` values per the TSLanguage ABI.
-            // TODO(safety): No null-pointer guard — UB if production_id_map is null.
-            std::slice::from_raw_parts(
-                self.language.production_id_map,
-                self.language.production_id_count as usize,
-            )
-        };
+        let production_id_map = self.production_id_map_slice()?;
 
         if rule_id as usize >= production_id_map.len() {
             return Err("Invalid rule ID".to_string());
@@ -221,15 +203,7 @@ impl Parser {
 
     fn get_goto(&self, state: u16, _symbol: u16) -> Result<u16, String> {
         // Access small parse table for gotos
-        let small_parse_table_map = unsafe {
-            // SAFETY: `self.language.small_parse_table_map` must point to at least
-            // `state_count * 4` contiguous `u32` values per the TSLanguage ABI.
-            // TODO(safety): No null-pointer guard — UB if small_parse_table_map is null.
-            std::slice::from_raw_parts(
-                self.language.small_parse_table_map,
-                self.language.state_count as usize * 4,
-            )
-        };
+        let small_parse_table_map = self.small_parse_table_map_slice()?;
 
         // Simplified goto lookup - real implementation would decode the compressed goto table
         let map_offset = (state as usize) * 4;
@@ -279,6 +253,51 @@ impl Parser {
 
         Ok(tokens)
     }
+
+    fn parse_table_slice(&self) -> Result<&[u16], String> {
+        let len = (self.language.state_count as usize)
+            .checked_mul(2)
+            .ok_or_else(|| "parse table length overflow".to_string())?;
+
+        if len == 0 {
+            return Ok(&[]);
+        }
+        if self.language.parse_table.is_null() {
+            return Err("parse table pointer is null".to_string());
+        }
+
+        // SAFETY: Pointer was checked for null, and length was derived from language metadata.
+        Ok(unsafe { std::slice::from_raw_parts(self.language.parse_table, len) })
+    }
+
+    fn production_id_map_slice(&self) -> Result<&[u16], String> {
+        let len = self.language.production_id_count as usize;
+        if len == 0 {
+            return Ok(&[]);
+        }
+        if self.language.production_id_map.is_null() {
+            return Err("production_id_map pointer is null".to_string());
+        }
+
+        // SAFETY: Pointer was checked for null, and length was derived from language metadata.
+        Ok(unsafe { std::slice::from_raw_parts(self.language.production_id_map, len) })
+    }
+
+    fn small_parse_table_map_slice(&self) -> Result<&[u32], String> {
+        let len = (self.language.state_count as usize)
+            .checked_mul(4)
+            .ok_or_else(|| "small parse table map length overflow".to_string())?;
+
+        if len == 0 {
+            return Ok(&[]);
+        }
+        if self.language.small_parse_table_map.is_null() {
+            return Err("small parse table map pointer is null".to_string());
+        }
+
+        // SAFETY: Pointer was checked for null, and length was derived from language metadata.
+        Ok(unsafe { std::slice::from_raw_parts(self.language.small_parse_table_map, len) })
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -300,10 +319,8 @@ enum ParseAction {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_decode_action() {
-        // Create a dummy language for testing
-        let lang = TSLanguage {
+    fn null_language() -> TSLanguage {
+        TSLanguage {
             version: 0,
             symbol_count: 0,
             alias_count: 0,
@@ -336,7 +353,13 @@ mod tests {
             production_lhs_index: std::ptr::null(),
             production_count: 0,
             eof_symbol: 0,
-        };
+        }
+    }
+
+    #[test]
+    fn test_decode_action() {
+        // Create a dummy language for testing
+        let lang = null_language();
 
         // For testing, we'll use unsafe to extend the lifetime
         // SAFETY: `lang` is stack-local and lives for the rest of this scope.
@@ -362,5 +385,20 @@ mod tests {
 
         // Test error
         assert!(matches!(parser.decode_action(0xFFFE), ParseAction::Error));
+    }
+
+    #[test]
+    fn test_parse_reports_null_parse_table_pointer() {
+        let mut lang = null_language();
+        lang.state_count = 1;
+
+        // SAFETY: `lang` outlives `parser` in this test scope.
+        let mut parser = unsafe {
+            let lang_ptr = &lang as *const TSLanguage;
+            Parser::new(&*lang_ptr)
+        };
+
+        let err = parser.parse("1").expect_err("expected parse to fail");
+        assert!(err.contains("parse table pointer is null"));
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent undefined behavior when `TSLanguage` metadata claims non-zero table/map lengths but the corresponding pointers are null. 
- Make parser slice creation robust and fail with descriptive errors instead of dereferencing null pointers.

### Description
- Replaced direct `from_raw_parts` calls in `get_action`, `perform_reduction`, and `get_goto` with checked helpers `parse_table_slice`, `production_id_map_slice`, and `small_parse_table_map_slice` that validate pointer non-nullness and lengths. 
- Helpers treat zero-length metadata as empty slices, use `checked_mul` for computed sizes, and return `Err` with clear messages when non-empty metadata pairs with a null pointer. 
- Refactored tests to provide a `null_language()` fixture and added `test_parse_reports_null_parse_table_pointer` to assert that parsing returns an error instead of invoking UB. 
- Small refactor to route existing code paths through the new helper methods (`get_action`, `perform_reduction`, `get_goto`).

### Testing
- Ran formatting with `cargo fmt --all` and it completed successfully. 
- Ran focused unit tests with `cargo test -p adze-tablegen parser::tests::` and the parser tests (including the new regression test) passed. 
- Ran linting with `cargo clippy -p adze-tablegen -- -D warnings` and it completed with no warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e89500d4f48333ae0e3fbe0502971c)