### PR TITLE
Fix EOF symbol encoding in test TSLanguage (use column index)

### DIFF
--- a/runtime/tests/support/language_builder.rs
+++ b/runtime/tests/support/language_builder.rs
@@ -533,6 +533,14 @@ pub fn build_ts_language(grammar: &Grammar, parse_table: &ParseTable) -> TSLangu
     let primary_state_ids: Vec<u16> = (0..parse_table.state_count as u16).collect();
     let primary_state_ids = Box::leak(Box::new(primary_state_ids));
 
+    // Tree-sitter ABI expects `eof_symbol` to be a *column index* in parse-table space,
+    // not a raw SymbolId.
+    let eof_symbol_col = parse_table
+        .symbol_to_index
+        .get(&parse_table.eof_symbol)
+        .copied()
+        .unwrap_or(0) as u16;
+
     // If we have states, they should all be large states for simplicity
     // since we're not implementing compression
     TSLanguage {
@@ -567,7 +575,7 @@ pub fn build_ts_language(grammar: &Grammar, parse_table: &ParseTable) -> TSLangu
         primary_state_ids: primary_state_ids.as_ptr(),
         production_lhs_index: production_lhs.as_ptr(),
         production_count: parse_table.rules.len() as u16,
-        eof_symbol: parse_table.eof_symbol.0,
+        eof_symbol: eof_symbol_col,
         rules: ts_rules.as_ptr(),
         rule_count: parse_table.rules.len() as u16,
     }

--- a/runtime/tests/test_accept_executed.rs
+++ b/runtime/tests/test_accept_executed.rs
@@ -108,8 +108,8 @@ mod tests {
         let lang = Box::leak(Box::new(lang));
         let decoder = adze::decoder::decode_parse_table(lang);
 
-        // Find EOF column
-        let eof_symbol = SymbolId(0); // EOF is typically 0
+        // Find EOF column from the decoded table's own metadata.
+        let eof_symbol = decoder.eof_symbol;
         let eof_col = decoder.symbol_to_index.get(&eof_symbol);
 
         if let Some(&col) = eof_col {


### PR DESCRIPTION
### Motivation
- The decoder expects `TSLanguage.eof_symbol` to be the parse-table column index, but the test helper wrote the raw `SymbolId`, causing EOF metadata to be incorrect after normalization and making EOF/Accept diagnostics brittle.

### Description
- In `runtime/tests/support/language_builder.rs` compute the EOF column index via `parse_table.symbol_to_index.get(&parse_table.eof_symbol)` and write that into `TSLanguage.eof_symbol` instead of `parse_table.eof_symbol.0`.
- In `runtime/tests/test_accept_executed.rs` read EOF from the decoded table (`decoder.eof_symbol`) instead of assuming `SymbolId(0)` so the test inspects the table's actual EOF column.
- Kept known failing/ignored tests about Accept-on-EOF behavior unchanged (these remain separately tracked as known bugs).

### Testing
- Ran `cargo fmt --all` successfully.
- Ran unit tests focused on the affected area: `cargo test -p adze --features pure-rust --test test_accept_executed -- --exact` and observed `tests::test_accept_actually_executed` pass (ok).
- Ran `cargo test -p adze --features pure-rust --test test_normalization dense_mapping_and_token_boundary_hold` and observed the `dense_mapping_and_token_boundary_hold` test pass (ok).
- Note: some Accept-on-EOF related tests remain ignored due to a separate known bug and were left as-is.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e894ffd5d88333af2fbe3a7ab44fc3)