### PR TITLE
tablegen: derive alias counters from grammar alias sequences

### DIFF
--- a/tablegen/src/generate.rs
+++ b/tablegen/src/generate.rs
@@ -6,6 +6,7 @@ use adze_glr_core::ParseTable;
 use adze_ir::Grammar;
 use proc_macro2::TokenStream;
 use quote::quote;
+use std::collections::HashSet;
 use std::os::raw::c_char;
 
 /// Language builder that produces validated Language structs
@@ -58,11 +59,9 @@ impl LanguageBuilder {
         let external_token_count = self.grammar.externals.len() as u32;
         let field_count = self.grammar.fields.len() as u32;
 
-        // TODO: Calculate these properly
-        let alias_count = 0;
+        let (alias_count, max_alias_sequence_length) = self.calculate_alias_metrics();
         let large_state_count = 0;
         let production_id_count = self.grammar.alias_sequences.len() as u32;
-        let max_alias_sequence_length = 0;
 
         // Build symbol names array
         let symbol_names = self.build_symbol_names();
@@ -147,6 +146,23 @@ impl LanguageBuilder {
         }
 
         names
+    }
+
+    /// Calculate alias-related ABI counters from grammar alias sequences.
+    fn calculate_alias_metrics(&self) -> (u32, u16) {
+        let mut aliases = HashSet::new();
+        let mut max_len = self.grammar.max_alias_sequence_length;
+
+        for seq in self.grammar.alias_sequences.values() {
+            max_len = max_len.max(seq.aliases.len());
+            for alias in seq.aliases.iter().flatten() {
+                aliases.insert(alias.as_str());
+            }
+        }
+
+        let alias_count = aliases.len() as u32;
+        let max_alias_sequence_length = u16::try_from(max_len).unwrap_or(u16::MAX);
+        (alias_count, max_alias_sequence_length)
     }
 
     fn build_field_names(&self) -> Vec<*const c_char> {

--- a/tablegen/tests/alias_handling_comprehensive.rs
+++ b/tablegen/tests/alias_handling_comprehensive.rs
@@ -336,10 +336,9 @@ fn language_builder_many_tokens_alias_zero() {
     assert_eq!(lang.max_alias_sequence_length, 0);
 }
 
-/// LanguageBuilder with grammar alias_sequences still gets alias_count=0
-/// because alias counting is not yet implemented.
+/// LanguageBuilder derives alias counters from grammar alias sequences.
 #[test]
-fn language_builder_ignores_grammar_alias_sequences_for_now() {
+fn language_builder_uses_grammar_alias_sequences_for_alias_counters() {
     let mut grammar = GrammarBuilder::new("alias_test")
         .token("x", "x")
         .rule("start", vec!["x"])
@@ -362,8 +361,49 @@ fn language_builder_ignores_grammar_alias_sequences_for_now() {
 
     // production_id_count reflects alias_sequences.len()
     assert_eq!(lang.production_id_count, 1);
-    // But alias_count itself is still 0 (TODO in source)
-    assert_eq!(lang.alias_count, 0);
+    assert_eq!(lang.alias_count, 1);
+    assert_eq!(lang.max_alias_sequence_length, 1);
+}
+
+/// LanguageBuilder deduplicates repeated alias names across productions.
+#[test]
+fn language_builder_deduplicates_alias_names() {
+    let mut grammar = GrammarBuilder::new("alias_dupe")
+        .token("x", "x")
+        .token("y", "y")
+        .rule("start", vec!["x"])
+        .start("start")
+        .build();
+
+    grammar.alias_sequences.insert(
+        ProductionId(0),
+        AliasSequence {
+            aliases: vec![
+                Some("same_alias".to_string()),
+                Some("same_alias".to_string()),
+            ],
+        },
+    );
+    grammar.alias_sequences.insert(
+        ProductionId(1),
+        AliasSequence {
+            aliases: vec![
+                Some("same_alias".to_string()),
+                None,
+                Some("other_alias".to_string()),
+            ],
+        },
+    );
+    grammar.max_alias_sequence_length = 3;
+
+    let table = ParseTable::default();
+    let builder = LanguageBuilder::new(grammar, table);
+    let lang = builder
+        .generate_language()
+        .expect("generate_language failed");
+
+    assert_eq!(lang.alias_count, 2);
+    assert_eq!(lang.max_alias_sequence_length, 3);
 }
 
 // =========================================================================


### PR DESCRIPTION
### Motivation
- `LanguageBuilder` previously hardcoded `alias_count` and `max_alias_sequence_length` to zero which under-reported alias metadata when the grammar contained `alias_sequences`.
- The language ABI (`TSLanguage`) should reflect real alias usage to enable downstream consumers and validation to observe alias data correctly.

### Description
- Compute alias metrics via a new helper `calculate_alias_metrics` in `tablegen/src/generate.rs` which returns `(alias_count, max_alias_sequence_length)`.
- `alias_count` is derived by deduplicating all non-`None` alias names across `grammar.alias_sequences` using a `HashSet`, and `max_alias_sequence_length` is computed as the max between `grammar.max_alias_sequence_length` and observed sequence lengths with safe saturation to `u16::MAX`.
- Wire the computed `(alias_count, max_alias_sequence_length)` into the constructed `TSLanguage` instead of hardcoded zeros.
- Add/modify tests in `tablegen/tests/alias_handling_comprehensive.rs` to assert that alias counters are populated when alias sequences exist and that duplicate alias names are deduplicated across productions.

### Testing
- Ran formatting: `cargo fmt --all` (succeeded).
- Unit tests executed: `cargo test -p adze-tablegen --test alias_handling_comprehensive -q` (33 tests passed) and `cargo test -p adze-tablegen --test language_gen_comprehensive -q` (110 tests passed), both succeeded.
- Attempted `just ci-supported` but it could not run in this environment because `just` is not installed (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e894ffd5d88333af2fbe3a7ab44fc3)