### PR TITLE
fix: cap GLR active stacks to prevent exponential growth

### DIFF
--- a/glr-core/src/driver.rs
+++ b/glr-core/src/driver.rs
@@ -76,6 +76,8 @@ struct GlrState {
 impl<'t> Driver<'t> {
     /// Maximum insertions allowed at a single position before forcing skip
     const MAX_INSERTS_PER_POS: u32 = 3;
+    /// Hard cap on the number of active stacks to prevent exponential GLR blow-ups.
+    const MAX_ACTIVE_STACKS: usize = 1024;
 
     /// Create a new driver with the given parse tables
     pub fn new(tables: &'t ParseTable) -> Self {
@@ -267,7 +269,7 @@ impl<'t> Driver<'t> {
                             s2.states.push(ns);
                             s2.nodes.push(node_id);
                             s2.pos = token_end;
-                            new_stacks.push(s2);
+                            self.push_limited_stack(&mut new_stacks, s2, "shifting a token")?;
                         }
                         Action::Accept => {
                             if let Some(&root_id) = stk.nodes.last()
@@ -301,7 +303,11 @@ impl<'t> Driver<'t> {
                                     s3.states.push(ns);
                                     s3.nodes.push(node_id);
                                     s3.pos = token_end;
-                                    new_stacks.push(s3);
+                                    self.push_limited_stack(
+                                        &mut new_stacks,
+                                        s3,
+                                        "branching after a reduction",
+                                    )?;
                                 }
                             }
                         }
@@ -342,6 +348,13 @@ impl<'t> Driver<'t> {
                     t.inc_fork_by((new_stacks.len() - 1) as u64);
                 }
                 // Commit the new frontier
+                if new_stacks.len() > Self::MAX_ACTIVE_STACKS {
+                    return Err(GlrError::Parse(format!(
+                        "parse aborted: active stack limit ({}) exceeded while processing byte {}",
+                        Self::MAX_ACTIVE_STACKS,
+                        pos,
+                    )));
+                }
                 state.stacks = new_stacks;
                 inserts_at_pos = 0; // Reset counter on successful real token
             }
@@ -418,6 +431,23 @@ impl<'t> Driver<'t> {
                 .map(|top| !self.tables.actions(top, sym).is_empty())
                 .unwrap_or(false)
         })
+    }
+
+    fn push_limited_stack(
+        &self,
+        stacks: &mut Vec<ParseStack>,
+        stack: ParseStack,
+        context: &str,
+    ) -> Result<(), GlrError> {
+        if stacks.len() >= Self::MAX_ACTIVE_STACKS {
+            return Err(GlrError::Parse(format!(
+                "parse aborted: active stack limit ({}) exceeded while {}",
+                Self::MAX_ACTIVE_STACKS,
+                context,
+            )));
+        }
+        stacks.push(stack);
+        Ok(())
     }
 
     /// Parse from a token stream.
@@ -498,7 +528,7 @@ impl<'t> Driver<'t> {
                             s2.states.push(ns);
                             s2.nodes.push(node_id);
                             s2.pos = end as usize; // Update position to token end
-                            new_stacks.push(s2);
+                            self.push_limited_stack(&mut new_stacks, s2, "shifting a token")?;
                         }
                         Action::Accept => {
                             // Accept on lookahead (rare, usually on EOF)
@@ -541,7 +571,11 @@ impl<'t> Driver<'t> {
                                     s3.states.push(ns);
                                     s3.nodes.push(node_id);
                                     s3.pos = end as usize; // Update position to token end
-                                    new_stacks.push(s3);
+                                    self.push_limited_stack(
+                                        &mut new_stacks,
+                                        s3,
+                                        "branching after a reduction",
+                                    )?;
                                 }
                             }
                         }
@@ -566,7 +600,11 @@ impl<'t> Driver<'t> {
                                     s2.states.push(ns);
                                     s2.nodes.push(node_id);
                                     s2.pos = end as usize; // Update position to token end
-                                    new_stacks.push(s2);
+                                    self.push_limited_stack(
+                                        &mut new_stacks,
+                                        s2,
+                                        "shifting a token",
+                                    )?;
                                 } else if let Action::Reduce(rid) = *a {
                                     let mut s2 = self.reduce_once(&mut state, stk.clone(), rid)?;
                                     self.reduce_closure(&mut state, &mut s2, lookahead)?;
@@ -583,7 +621,11 @@ impl<'t> Driver<'t> {
                                             s3.states.push(ns);
                                             s3.nodes.push(node_id);
                                             s3.pos = end as usize;
-                                            new_stacks.push(s3);
+                                            self.push_limited_stack(
+                                                &mut new_stacks,
+                                                s3,
+                                                "branching after a reduction",
+                                            )?;
                                         }
                                     }
                                 }
@@ -617,6 +659,13 @@ impl<'t> Driver<'t> {
                     start, top_state.0, lookahead.0
                 )));
             } else {
+                if new_stacks.len() > Self::MAX_ACTIVE_STACKS {
+                    return Err(GlrError::Parse(format!(
+                        "parse aborted: active stack limit ({}) exceeded at byte {}",
+                        Self::MAX_ACTIVE_STACKS,
+                        start,
+                    )));
+                }
                 state.stacks = new_stacks;
             }
         }

--- a/glr-core/tests/parser_driver_tests.rs
+++ b/glr-core/tests/parser_driver_tests.rs
@@ -593,6 +593,41 @@ fn ambiguous_grammar_two_tokens_parse() {
     assert_eq!(view.span(root).start, 0);
     assert_eq!(view.span(root).end, 2);
 }
+#[test]
+fn ambiguous_grammar_large_input_hits_active_stack_limit() {
+    let mut symbol_to_index = std::collections::BTreeMap::new();
+    symbol_to_index.insert(SymbolId(0), 0);
+    symbol_to_index.insert(SymbolId(1), 1);
+
+    let table = ParseTable {
+        state_count: 1,
+        symbol_count: 2,
+        symbol_to_index,
+        start_symbol: SymbolId(1),
+        index_to_symbol: vec![SymbolId(0), SymbolId(1)],
+        action_table: vec![vec![
+            vec![Action::Accept],
+            vec![Action::Fork(vec![
+                Action::Shift(StateId(0)),
+                Action::Shift(StateId(0)),
+            ])],
+        ]],
+        goto_table: vec![vec![]],
+        ..Default::default()
+    };
+
+    let tokens = (0..11).map(|i| (1_u32, i, i + 1));
+    let mut driver = Driver::new(&table);
+    let err = match driver.parse_tokens(tokens) {
+        Ok(_) => panic!("ambiguous input should trip the active stack guard"),
+        Err(err) => err,
+    };
+
+    assert!(
+        err.to_string().contains("active stack limit"),
+        "unexpected error: {err}"
+    );
+}
 
 // ═══════════════════════════════════════════════════════════════════════
 // 10. Driver reset / reuse

--- a/glr-core/tests/parser_driver_tests.rs
+++ b/glr-core/tests/parser_driver_tests.rs
@@ -593,6 +593,33 @@ fn ambiguous_grammar_two_tokens_parse() {
     assert_eq!(view.span(root).start, 0);
     assert_eq!(view.span(root).end, 2);
 }
+
+#[test]
+fn ambiguous_grammar_small_input_remains_under_active_stack_limit() {
+    let table = ambiguous_grammar_table().unwrap();
+
+    let a_id = {
+        let mut id = None;
+        for (&sym, tok) in &table.grammar.tokens {
+            if tok.name == "a" {
+                id = Some(sym);
+            }
+        }
+        id.expect("token 'a' should exist")
+    };
+
+    let tokens = (0..4).map(|i| (a_id.0 as u32, i, i + 1));
+    let mut driver = Driver::new(&table);
+    let forest = driver
+        .parse_tokens(tokens)
+        .expect("ambiguous grammar should parse short input within stack cap");
+
+    let view = forest.view();
+    let root = view.roots()[0];
+    assert_eq!(view.span(root).start, 0);
+    assert_eq!(view.span(root).end, 4);
+}
+
 #[test]
 fn ambiguous_grammar_large_input_hits_active_stack_limit() {
     let mut symbol_to_index = std::collections::BTreeMap::new();


### PR DESCRIPTION
### Motivation
- The GLR driver cloned and enqueued full parse stacks for every shift/reduce/fork without deduplication or limits, allowing ambiguous or crafted inputs to trigger exponential active-stack growth and potential DoS. 
- The token-based `parse_tokens` and streaming `parse_streaming` paths are reachable from runtime entry points, so a defensive cap is required to protect availability.

### Description
- Add a hard cap `const MAX_ACTIVE_STACKS: usize = 1024` to the `Driver` to limit concurrently active parse stacks. 
- Introduce `push_limited_stack(&self, stacks: &mut Vec<ParseStack>, stack: ParseStack, context: &str) -> Result<(), GlrError>` which returns a `GlrError::Parse` when the cap is exceeded and use it in place of direct `new_stacks.push(...)` calls. 
- Check `new_stacks.len()` before committing the new frontier in both streaming and token parsing paths and abort with a clear parse error if the cap is hit. 
- Add a regression test `ambiguous_grammar_large_input_hits_active_stack_limit` in `glr-core/tests/parser_driver_tests.rs` which exercises a pathological `Fork`-heavy table and verifies the guard trips while preserving the existing ambiguous two-token parse behavior.

### Testing
- Ran the focused GLR tests: `cargo test -p adze-glr-core --test parser_driver_tests ambiguous_grammar_large_input_hits_active_stack_limit -- --nocapture` which passed, confirming the guard triggers on the pathological input. 
- Verified the existing ambiguous parse still succeeds with `cargo test -p adze-glr-core --test parser_driver_tests ambiguous_grammar_two_tokens_parse -- --nocapture`, which passed. 
- Attempting the broader runtime test `cargo test -p adze-runtime given_parse_full_and_parse_incremental_when_inputs_match_then_forest_shape_is_identical -- --nocapture` failed to build in this checkout due to unrelated unresolved dependencies in `adze-tablegen` (missing crates like `adze_bdd_grid_core`, `adze_parsetable_metadata`, `sha2`, `chrono`, etc.), so it was not run to completion here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ba34604db083338e153bcc8a7a37c7)