### PR TITLE
fix(runtime2): replace recursive forest-to-tree builder with iterative traversal to prevent stack overflow

### DIFF
--- a/runtime2/src/builder.rs
+++ b/runtime2/src/builder.rs
@@ -9,6 +9,8 @@ use crate::tree::{Tree, TreeNode};
 
 #[cfg(feature = "glr")]
 use adze_glr_core::ForestView as CoreForestView;
+#[cfg(feature = "glr-core")]
+use rustc_hash::FxHashSet;
 
 /// Converts a GLR parse forest into a Tree-sitter compatible tree.
 ///
@@ -151,11 +153,12 @@ fn build_from_glr(core: adze_glr_core::Forest) -> Tree {
     Tree::new(root_node)
 }
 
-/// Recursive tree builder with performance metrics tracking.
+/// Iterative tree builder with performance metrics tracking.
 ///
 /// This function builds a `TreeNode` tree from a forest view while tracking
-/// performance metrics like node count and maximum depth. It's used by
-/// `build_from_glr()` to provide detailed conversion statistics.
+/// performance metrics like node count and maximum depth. It uses an explicit
+/// traversal stack so deeply nested user input cannot overflow the Rust call
+/// stack during forest-to-tree conversion.
 ///
 /// # Arguments
 ///
@@ -185,16 +188,71 @@ fn build_node_with_metrics(
     node_count: &mut usize,
     max_depth: &mut usize,
 ) -> TreeNode {
-    *node_count += 1;
-    *max_depth = (*max_depth).max(depth);
+    #[derive(Debug, Clone, Copy)]
+    struct PendingNode {
+        id: u32,
+        depth: usize,
+        expanded: bool,
+    }
 
-    let span = view.span(id);
-    let kind = view.kind(id);
-    let kids = view
-        .best_children(id)
-        .iter()
-        .copied()
-        .map(|c| build_node_with_metrics(view, c, depth + 1, node_count, max_depth))
-        .collect();
-    TreeNode::new_with_children(kind, span.start as usize, span.end as usize, kids)
+    let mut pending = vec![PendingNode {
+        id,
+        depth,
+        expanded: false,
+    }];
+    let mut active = FxHashSet::default();
+    let mut built = Vec::new();
+
+    while let Some(node) = pending.pop() {
+        if !node.expanded {
+            *node_count += 1;
+            *max_depth = (*max_depth).max(node.depth);
+
+            if !active.insert(node.id) {
+                let span = view.span(node.id);
+                let kind = view.kind(node.id);
+                built.push(TreeNode::new_with_children(
+                    kind,
+                    span.start as usize,
+                    span.end as usize,
+                    Vec::new(),
+                ));
+                continue;
+            }
+
+            pending.push(PendingNode {
+                id: node.id,
+                depth: node.depth,
+                expanded: true,
+            });
+
+            for &child_id in view.best_children(node.id).iter().rev() {
+                pending.push(PendingNode {
+                    id: child_id,
+                    depth: node.depth + 1,
+                    expanded: false,
+                });
+            }
+
+            continue;
+        }
+
+        active.remove(&node.id);
+
+        let span = view.span(node.id);
+        let kind = view.kind(node.id);
+        let child_count = view.best_children(node.id).len();
+        let split_at = built.len() - child_count;
+        let children = built.split_off(split_at);
+        built.push(TreeNode::new_with_children(
+            kind,
+            span.start as usize,
+            span.end as usize,
+            children,
+        ));
+    }
+
+    built
+        .pop()
+        .expect("forest-to-tree conversion should build a root node")
 }

--- a/runtime2/tests/builder_tests.rs
+++ b/runtime2/tests/builder_tests.rs
@@ -81,6 +81,108 @@ fn make_language() -> Language {
         .unwrap()
 }
 
+/// Build a recursive grammar: start -> seq, seq -> a | a seq
+fn make_deep_chain_language() -> Language {
+    let mut grammar = Grammar::new("deep_chain".to_string());
+    let a_id = SymbolId(1);
+    grammar.tokens.insert(
+        a_id,
+        IrToken {
+            name: "a".to_string(),
+            pattern: TokenPattern::String("a".to_string()),
+            fragile: false,
+        },
+    );
+    let start_id = SymbolId(2);
+    let seq_id = SymbolId(3);
+    grammar.rule_names.insert(start_id, "start".to_string());
+    grammar.rule_names.insert(seq_id, "seq".to_string());
+    grammar.rules.insert(
+        start_id,
+        vec![Rule {
+            lhs: start_id,
+            rhs: vec![Symbol::NonTerminal(seq_id)],
+            precedence: None,
+            associativity: None,
+            production_id: ProductionId(0),
+            fields: vec![],
+        }],
+    );
+    grammar.rules.insert(
+        seq_id,
+        vec![
+            Rule {
+                lhs: seq_id,
+                rhs: vec![Symbol::Terminal(a_id)],
+                precedence: None,
+                associativity: None,
+                production_id: ProductionId(1),
+                fields: vec![],
+            },
+            Rule {
+                lhs: seq_id,
+                rhs: vec![Symbol::Terminal(a_id), Symbol::NonTerminal(seq_id)],
+                precedence: None,
+                associativity: None,
+                production_id: ProductionId(2),
+                fields: vec![],
+            },
+        ],
+    );
+    let ff = FirstFollowSets::compute(&grammar).unwrap();
+    let table = build_lr1_automaton(&grammar, &ff)
+        .expect("table")
+        .normalize_eof_to_zero()
+        .with_detected_goto_indexing();
+    let table: &'static _ = Box::leak(Box::new(table));
+
+    Language::builder()
+        .parse_table(table)
+        .symbol_names(vec!["EOF".into(), "a".into(), "start".into(), "seq".into()])
+        .symbol_metadata(vec![
+            SymbolMetadata {
+                is_terminal: true,
+                is_visible: false,
+                is_supertype: false,
+            },
+            SymbolMetadata {
+                is_terminal: true,
+                is_visible: true,
+                is_supertype: false,
+            },
+            SymbolMetadata {
+                is_terminal: false,
+                is_visible: true,
+                is_supertype: false,
+            },
+            SymbolMetadata {
+                is_terminal: false,
+                is_visible: true,
+                is_supertype: false,
+            },
+        ])
+        .tokenizer(|input: &[u8]| {
+            let mut toks = Vec::with_capacity(input.len() + 1);
+            for (idx, byte) in input.iter().enumerate() {
+                if *byte == b'a' {
+                    toks.push(Token {
+                        kind: 1,
+                        start: idx as u32,
+                        end: (idx + 1) as u32,
+                    });
+                }
+            }
+            toks.push(Token {
+                kind: 0,
+                start: input.len() as u32,
+                end: input.len() as u32,
+            });
+            Box::new(toks.into_iter()) as Box<dyn Iterator<Item = Token> + '_>
+        })
+        .build()
+        .unwrap()
+}
+
 #[test]
 fn forest_to_tree_produces_valid_root() {
     let lang = make_language();
@@ -147,4 +249,18 @@ fn parse_with_old_tree_succeeds() {
     // Passing old_tree should work (falls back to full parse if incremental disabled)
     let tree2 = parser.parse(b"a", Some(&tree1)).unwrap();
     assert_eq!(tree1.root_kind(), tree2.root_kind());
+}
+
+#[test]
+fn forest_to_tree_handles_deep_right_recursive_input() {
+    let lang = make_deep_chain_language();
+    let mut parser = Parser::new();
+    parser.set_language(lang).unwrap();
+
+    let input = vec![b'a'; 20_000];
+    let tree = parser.parse(&input, None).unwrap();
+
+    assert_eq!(tree.source_bytes(), Some(input.as_slice()));
+    assert!(tree.root_node().child_count() > 0);
+    assert_eq!(tree.root_node().end_byte(), input.len());
 }


### PR DESCRIPTION
### Motivation
- The GLR forest->tree conversion used a recursive `build_node` that could recurse without limit on deeply nested (attacker-controlled) inputs, risking stack overflow and denial-of-service when `glr-core` is enabled. 
- The intent is to preserve existing disambiguation and metrics while preventing unbounded Rust call-stack growth during conversion. 

### Description
- Replaced the recursive `build_node_with_metrics` implementation with an iterative traversal using an explicit `PendingNode` stack and an `FxHashSet` to manage active entries, assembling child subtrees from a `built` vector so deeply nested inputs do not exhaust the call stack (`runtime2/src/builder.rs`).
- Kept performance metrics (`node_count`, `max_depth`) and the existing logging behavior (via `ADZE_LOG_PERFORMANCE`) intact.
- Added a regression test that creates a right-recursive grammar and parses a 20,000-token input to exercise deep nesting and verify successful tree construction (`runtime2/tests/builder_tests.rs`).
- Added the `rustc_hash::FxHashSet` import and minimal defensive handling to avoid stuck cycles during iterative assembly.

### Testing
- Ran `cargo fmt --all` to format changes (succeeded).
- Ran `cargo check -p adze-runtime --lib --features glr-core` to verify the runtime crate compiles with GLR enabled (succeeded).
- Added a targeted regression test `forest_to_tree_handles_deep_right_recursive_input` that verifies conversion of a 20,000-token right-recursive input completes and preserves source/span metadata (test added to `runtime2/tests/builder_tests.rs`).
- Attempted to run the full `cargo test` invocation for the runtime tests, but execution of the workspace test run was blocked by unrelated missing dependencies in `adze-tablegen` (unresolved imports) in this environment, preventing the new test from being executed end-to-end here; the change compiles for `adze-runtime` and the regression test is present for CI to run where workspace dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ba347d2fc08333bdad475c32d9e350)