### PR TITLE
fix: enforce unified parser timeouts

### DIFF
--- a/runtime/src/parser_v4.rs
+++ b/runtime/src/parser_v4.rs
@@ -131,13 +131,6 @@ pub struct Parser {
     /// Language name for scanner registry lookup
     #[allow(dead_code)]
     language: String,
-    /// Optional custom lexer function provided by the generated parser.
-    ///
-    /// `parser_v4` currently does not implement this path, so parse attempts are
-    /// rejected explicitly when present.
-    custom_lexer_fn: Option<
-        unsafe extern "C" fn(*mut core::ffi::c_void, crate::pure_parser::TSLexState) -> bool,
-    >,
     /// Maximum parse duration in microseconds. A value of 0 disables timeouts.
     timeout_micros: u64,
 }
@@ -249,7 +242,6 @@ impl Parser {
             external_scanner,
             external_runtime,
             language,
-            custom_lexer_fn: None,
             timeout_micros: 0,
         }
     }
@@ -317,7 +309,6 @@ impl Parser {
             external_scanner,
             external_runtime,
             language: language_name,
-            custom_lexer_fn: None,
             timeout_micros: 0,
         }
     }
@@ -373,7 +364,6 @@ impl Parser {
             external_scanner,
             external_runtime,
             language,
-            custom_lexer_fn: None,
             timeout_micros: 0,
         }
     }
@@ -605,13 +595,14 @@ impl Parser {
 
         loop {
             // Periodically enforce time-based parse limits to avoid per-iteration overhead.
-            if self.timeout_micros > 0 && loop_iterations % TIMEOUT_CHECK_INTERVAL == 0 {
-                if start_time.elapsed().as_micros() as u64 > self.timeout_micros {
-                    bail!(
-                        "Parser timed out after {} microseconds",
-                        self.timeout_micros
-                    );
-                }
+            if self.timeout_micros > 0
+                && loop_iterations.is_multiple_of(TIMEOUT_CHECK_INTERVAL)
+                && start_time.elapsed().as_micros() as u64 > self.timeout_micros
+            {
+                bail!(
+                    "Parser timed out after {} microseconds",
+                    self.timeout_micros
+                );
             }
             // Safety check to prevent infinite loops
             loop_iterations += 1;

--- a/runtime/src/parser_v4.rs
+++ b/runtime/src/parser_v4.rs
@@ -14,6 +14,7 @@ use adze_ir::{Grammar, Rule, RuleId, StateId, SymbolId, TokenPattern};
 use anyhow::{Result, anyhow, bail};
 use std::collections::HashSet;
 use std::rc::Rc;
+use std::time::Instant;
 
 const PARSE_WITH_CUSTOM_LEXER_UNSUPPORTED: &str = "Custom lexer functions are not yet supported by parser_v4 runtime. \
      Provide a grammar/tokenization path without a custom transform lexer.";
@@ -130,6 +131,15 @@ pub struct Parser {
     /// Language name for scanner registry lookup
     #[allow(dead_code)]
     language: String,
+    /// Optional custom lexer function provided by the generated parser.
+    ///
+    /// `parser_v4` currently does not implement this path, so parse attempts are
+    /// rejected explicitly when present.
+    custom_lexer_fn: Option<
+        unsafe extern "C" fn(*mut core::ffi::c_void, crate::pure_parser::TSLexState) -> bool,
+    >,
+    /// Maximum parse duration in microseconds. A value of 0 disables timeouts.
+    timeout_micros: u64,
 }
 
 impl Parser {
@@ -239,6 +249,8 @@ impl Parser {
             external_scanner,
             external_runtime,
             language,
+            custom_lexer_fn: None,
+            timeout_micros: 0,
         }
     }
 
@@ -305,6 +317,8 @@ impl Parser {
             external_scanner,
             external_runtime,
             language: language_name,
+            custom_lexer_fn: None,
+            timeout_micros: 0,
         }
     }
 
@@ -359,7 +373,19 @@ impl Parser {
             external_scanner,
             external_runtime,
             language,
+            custom_lexer_fn: None,
+            timeout_micros: 0,
         }
+    }
+
+    /// Sets the maximum time the parser may run in microseconds.
+    pub fn set_timeout_micros(&mut self, timeout: u64) {
+        self.timeout_micros = timeout;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn timeout_micros(&self) -> u64 {
+        self.timeout_micros
     }
 
     /// Get current arena metrics
@@ -574,8 +600,17 @@ impl Parser {
         // Main parsing loop with safety limits
         let mut loop_iterations = 0;
         const MAX_LOOP_ITERATIONS: usize = 1_000_000; // Prevent infinite loops
+        let start_time = Instant::now();
 
         loop {
+            if self.timeout_micros > 0
+                && start_time.elapsed().as_micros() as u64 > self.timeout_micros
+            {
+                bail!(
+                    "Parser timed out after {} microseconds",
+                    self.timeout_micros
+                );
+            }
             // Safety check to prevent infinite loops
             loop_iterations += 1;
             if loop_iterations > MAX_LOOP_ITERATIONS {

--- a/runtime/src/parser_v4.rs
+++ b/runtime/src/parser_v4.rs
@@ -598,18 +598,20 @@ impl Parser {
         let mut current_position = 0;
 
         // Main parsing loop with safety limits
-        let mut loop_iterations = 0;
+        let mut loop_iterations = 0usize;
         const MAX_LOOP_ITERATIONS: usize = 1_000_000; // Prevent infinite loops
+        const TIMEOUT_CHECK_INTERVAL: usize = 32; // Amortize time checks in hot loops
         let start_time = Instant::now();
 
         loop {
-            if self.timeout_micros > 0
-                && start_time.elapsed().as_micros() as u64 > self.timeout_micros
-            {
-                bail!(
-                    "Parser timed out after {} microseconds",
-                    self.timeout_micros
-                );
+            // Periodically enforce time-based parse limits to avoid per-iteration overhead.
+            if self.timeout_micros > 0 && loop_iterations % TIMEOUT_CHECK_INTERVAL == 0 {
+                if start_time.elapsed().as_micros() as u64 > self.timeout_micros {
+                    bail!(
+                        "Parser timed out after {} microseconds",
+                        self.timeout_micros
+                    );
+                }
             }
             // Safety check to prevent infinite loops
             loop_iterations += 1;

--- a/runtime/src/unified_parser.rs
+++ b/runtime/src/unified_parser.rs
@@ -59,12 +59,11 @@ impl Parser {
         let language_name = name.to_string();
 
         // Create a V4 (GLR) parser for this language
-        let v4_parser = parser_v4::Parser::from_language(language, language_name.clone());
+        let mut v4_parser = parser_v4::Parser::from_language(language, language_name.clone());
 
         // Apply any previously set timeout
-        if let Some(_timeout) = self.timeout_micros {
-            // TODO: Add timeout support to parser_v4
-            // v4_parser.set_timeout(timeout);
+        if let Some(timeout) = self.timeout_micros {
+            v4_parser.set_timeout_micros(timeout);
         }
 
         self.inner = Some(v4_parser);
@@ -187,10 +186,9 @@ impl Parser {
     /// * `timeout_micros` - Timeout in microseconds (0 = no timeout)
     pub fn set_timeout_micros(&mut self, timeout_micros: u64) {
         self.timeout_micros = Some(timeout_micros);
-        // TODO: Add timeout support to parser_v4
-        // if let Some(ref mut parser) = self.inner {
-        //     parser.set_timeout(timeout_micros);
-        // }
+        if let Some(ref mut parser) = self.inner {
+            parser.set_timeout_micros(timeout_micros);
+        }
     }
 
     /// Reset the parser state
@@ -271,6 +269,23 @@ mod tests {
         // Then
         assert!(debug.contains("language: None"));
         assert!(debug.contains("has_timeout: true"));
+    }
+
+    #[test]
+    fn given_timeout_is_set_when_inner_parser_exists_then_timeout_is_propagated() {
+        let mut parser = Parser::new();
+        parser.inner = Some(parser_v4::Parser::new(
+            adze_ir::Grammar::new("test".to_string()),
+            adze_glr_core::ParseTable::default(),
+            "test".to_string(),
+        ));
+
+        parser.set_timeout_micros(7_500);
+
+        assert_eq!(
+            parser.inner.as_ref().map(parser_v4::Parser::timeout_micros),
+            Some(7_500)
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- The unified parser stored `timeout_micros` but never applied it to the GLR backend, removing previously enforced timeouts and creating a DoS risk for long-running/ambiguous parses.
- The intent is to restore effective timeout/cancellation behavior for the unified API by ensuring configured time budgets are enforced by the underlying `parser_v4` implementation.

### Description
- Propagate timeouts from the unified API into the GLR backend by calling `parser_v4::Parser::set_timeout_micros` when loading a language in `set_language_with_name` and when `set_timeout_micros` is called on the unified `Parser` (file: `runtime/src/unified_parser.rs`).
- Add `timeout_micros` storage and a `set_timeout_micros` setter to `parser_v4::Parser` and initialize it in constructors (file: `runtime/src/parser_v4.rs`).
- Enforce the timeout inside the main `parser_v4` parse loop using `Instant::now()` and bail with an error when the configured microsecond budget is exceeded (file: `runtime/src/parser_v4.rs`).
- Add regression unit tests to verify that timeouts propagate from the unified parser into the inner GLR parser and that calling `set_timeout_micros` after creation updates the backend (file: `runtime/src/unified_parser.rs` tests).

### Testing
- Ran the focused unit tests with `cargo test -p adze --lib unified_parser::tests:: -- --nocapture`, and all tests passed (`6 passed; 0 failed`).
- Ran formatting with `cargo fmt --all` to ensure style consistency and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ba456658648333a4e55c7b0d126e99)