### PR TITLE
fix(ci): repair current main red

### DIFF
--- a/tablegen/Cargo.toml
+++ b/tablegen/Cargo.toml
@@ -62,3 +62,4 @@ serialization = [
     "adze-glr-core/serialization",
 ] # Enable serialization support (used by runtime2)
 small-table = [] # Test-only feature for compressed table round-trip tests
+incremental_glr = [] # Enable incremental parsing metadata flag for parity metadata


### PR DESCRIPTION
Repairs the first current-main failing CI body (tablegen unexpected cfg value in feature checks).