### PR TITLE
Add query predicate canary and explicit error for unsupported predicates

### DIFF
--- a/runtime/src/query/parser.rs
+++ b/runtime/src/query/parser.rs
@@ -307,7 +307,10 @@ impl<'a> QueryParser<'a> {
             "is?" => self.parse_is_predicate(),
             "is-not?" => self.parse_is_not_predicate(),
             "any-of?" => self.parse_any_of_predicate(),
-            _ => self.parse_custom_predicate(name),
+            _ => Err(QueryError::InvalidPredicate(format!(
+                "Unsupported predicate: #{}",
+                name
+            ))),
         }
     }
 
@@ -445,24 +448,6 @@ impl<'a> QueryParser<'a> {
         }
 
         Ok(Predicate::AnyOf { capture, values })
-    }
-
-    fn parse_custom_predicate(&mut self, name: String) -> Result<Predicate, QueryError> {
-        let mut args = Vec::new();
-
-        self.skip_whitespace();
-        while self.peek_char() != Some(')') {
-            if self.peek_char() == Some('@') {
-                let capture = self.parse_capture_ref()?;
-                args.push(PredicateArg::Capture(capture));
-            } else {
-                let string = self.parse_string()?;
-                args.push(PredicateArg::String(string));
-            }
-            self.skip_whitespace();
-        }
-
-        Ok(Predicate::Custom { name, args })
     }
 
     // Helper methods

--- a/runtime/tests/test_query_predicates.rs
+++ b/runtime/tests/test_query_predicates.rs
@@ -1,367 +1,76 @@
-#![cfg(test)]
-#![allow(unused_imports, dead_code)]
-// TODO: This test file needs to be updated to work with the new Grammar API
-// The old API had get_or_add_symbol and different Rule structure
-#![cfg(skip_outdated_tests)]
+use adze::query::{QueryError, compile_query};
+use adze_ir::{Grammar, ProductionId, Rule, Symbol, SymbolId, Token, TokenPattern};
 
-mod tests {
-    use adze::{
-        parser_v3::{ParseNode, Parser},
-        query::{Query, QueryCursor, compile_query},
-    };
-    use adze_ir::{Grammar, Rule, RuleExpr, Symbol, SymbolId};
-    use std::collections::HashMap;
+fn create_query_grammar() -> Grammar {
+    let mut grammar = Grammar::new("query-canary".to_string());
 
-    /// Create a simple test grammar
-    fn create_test_grammar() -> Grammar {
-        let mut grammar = Grammar::new("test".to_string());
+    let identifier = SymbolId(1);
+    let expression = SymbolId(10);
 
-        // Define symbols
-        let program_id = grammar.get_or_add_symbol("program");
-        let identifier_id = grammar.get_or_add_symbol("identifier");
-        let keyword_id = grammar.get_or_add_symbol("keyword");
-        let string_id = grammar.get_or_add_symbol("string");
+    grammar.tokens.insert(
+        identifier,
+        Token {
+            name: "identifier".to_string(),
+            pattern: TokenPattern::Regex("[a-zA-Z_][a-zA-Z0-9_]*".to_string()),
+            fragile: false,
+        },
+    );
 
-        // Define rules
-        grammar.rules.push(Rule {
-            name: program_id,
-            expr: RuleExpr::Repeat(Box::new(RuleExpr::Choice(vec![
-                RuleExpr::Symbol(identifier_id),
-                RuleExpr::Symbol(keyword_id),
-                RuleExpr::Symbol(string_id),
-            ]))),
-            is_public: true,
-            precedence: None,
-            associativity: None,
-        });
+    grammar.rules.entry(expression).or_default().push(Rule {
+        lhs: expression,
+        rhs: vec![Symbol::Terminal(identifier)],
+        fields: vec![],
+        precedence: None,
+        associativity: None,
+        production_id: ProductionId(0),
+    });
 
-        grammar.rules.push(Rule {
-            name: identifier_id,
-            expr: RuleExpr::Pattern("[a-zA-Z_][a-zA-Z0-9_]*".to_string()),
-            is_public: true,
-            precedence: None,
-            associativity: None,
-        });
+    grammar
+        .rule_names
+        .insert(identifier, "identifier".to_string());
+    grammar
+        .rule_names
+        .insert(expression, "expression".to_string());
 
-        grammar.rules.push(Rule {
-            name: keyword_id,
-            expr: RuleExpr::Choice(vec![
-                RuleExpr::String("if".to_string()),
-                RuleExpr::String("else".to_string()),
-                RuleExpr::String("while".to_string()),
-                RuleExpr::String("for".to_string()),
-                RuleExpr::String("return".to_string()),
-            ]),
-            is_public: true,
-            precedence: None,
-            associativity: None,
-        });
+    grammar
+}
 
-        grammar.rules.push(Rule {
-            name: string_id,
-            expr: RuleExpr::Pattern(r#""[^"]*""#.to_string()),
-            is_public: true,
-            precedence: None,
-            associativity: None,
-        });
+#[test]
+fn test_eq_predicate_compiles_for_known_predicate() {
+    let grammar = create_query_grammar();
+    let query_src = r#"
+        (identifier @id)
+        (#eq? @id "alpha")
+    "#;
 
-        grammar
-    }
+    let query = compile_query(query_src, &grammar).expect("#eq? should compile");
 
-    /// Helper to create a parse node
-    fn make_node(
-        symbol: SymbolId,
-        start: usize,
-        end: usize,
-        children: Vec<ParseNode>,
-    ) -> ParseNode {
-        ParseNode {
-            symbol,
-            children,
-            start_byte: start,
-            end_byte: end,
-            field_name: None,
+    assert_eq!(query.patterns.len(), 1);
+    assert_eq!(query.patterns[0].predicates.len(), 1);
+    assert_eq!(query.capture_index("id"), Some(0));
+}
+
+#[test]
+fn test_unsupported_predicate_returns_clear_error() {
+    let grammar = create_query_grammar();
+    let query_src = r#"
+        (identifier @id)
+        (#contains? @id "alp")
+    "#;
+
+    let err = compile_query(query_src, &grammar).expect_err("unsupported predicate should fail");
+
+    match err {
+        QueryError::InvalidPredicate(message) => {
+            assert!(
+                message.contains("#contains?"),
+                "unexpected message: {message}"
+            );
+            assert!(
+                message.contains("Unsupported predicate"),
+                "unexpected message: {message}"
+            );
         }
-    }
-
-    #[test]
-    #[ignore = "query engine incomplete"]
-    fn test_eq_predicate_with_value() {
-        let source = "if test else while";
-        let grammar = create_test_grammar();
-
-        // Mock parse tree
-        let tree = make_node(
-            grammar.get_or_add_symbol("program"),
-            0,
-            18,
-            vec![
-                make_node(grammar.get_or_add_symbol("keyword"), 0, 2, vec![]), // "if"
-                make_node(grammar.get_or_add_symbol("identifier"), 3, 7, vec![]), // "test"
-                make_node(grammar.get_or_add_symbol("keyword"), 8, 12, vec![]), // "else"
-                make_node(grammar.get_or_add_symbol("keyword"), 13, 18, vec![]), // "while"
-            ],
-        );
-
-        // Query that matches keywords equal to "if"
-        let query_str = r#"
-            (keyword) @kw
-            (#eq? @kw "if")
-        "#;
-
-        // Test with the enhanced matcher
-        use adze::query::matcher_v2::{QueryMatch, QueryMatcher};
-
-        // Create a mock query
-        let mut query = Query {
-            source: query_str.to_string(),
-            patterns: vec![],
-            capture_names: HashMap::new(),
-            property_settings: vec![],
-            property_predicates: vec![],
-        };
-
-        query.capture_names.insert("kw".to_string(), 0);
-
-        use adze::query::ast::{Pattern, PatternNode, Predicate, Quantifier};
-
-        let pattern = Pattern {
-            root: PatternNode {
-                symbol: grammar.get_or_add_symbol("keyword"),
-                children: vec![],
-                fields: HashMap::new(),
-                capture: Some(0),
-                is_named: true,
-                quantifier: Quantifier::One,
-            },
-            predicates: vec![Predicate::Eq {
-                capture1: 0,
-                capture2: None,
-                value: Some("if".to_string()),
-            }],
-            start_byte: 0,
-        };
-
-        query.patterns.push(pattern);
-
-        // Match with predicates
-        let matcher = QueryMatcher::new(&query, source);
-        let matches = matcher.matches(&tree);
-
-        // Should match only the "if" keyword
-        assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].captures[0].node.start_byte, 0);
-        assert_eq!(matches[0].captures[0].node.end_byte, 2);
-    }
-
-    #[test]
-    #[ignore = "query engine incomplete"]
-    fn test_eq_predicate_between_captures() {
-        let source = "test other test";
-        let grammar = create_test_grammar();
-
-        // Mock parse tree
-        let tree = make_node(
-            grammar.get_or_add_symbol("program"),
-            0,
-            15,
-            vec![
-                make_node(grammar.get_or_add_symbol("identifier"), 0, 4, vec![]), // "test"
-                make_node(grammar.get_or_add_symbol("identifier"), 5, 10, vec![]), // "other"
-                make_node(grammar.get_or_add_symbol("identifier"), 11, 15, vec![]), // "test"
-            ],
-        );
-
-        // Query that matches consecutive identifiers that are equal
-        let query_str = r#"
-            (identifier) @first . (identifier) @second
-            (#eq? @first @second)
-        "#;
-
-        // This would need a more sophisticated pattern matching for consecutive nodes
-        // For now, test individual nodes
-    }
-
-    #[test]
-    #[ignore = "query engine incomplete"]
-    fn test_match_predicate() {
-        let source = "test_var myFunction123 _private";
-        let grammar = create_test_grammar();
-
-        // Mock parse tree
-        let tree = make_node(
-            grammar.get_or_add_symbol("program"),
-            0,
-            31,
-            vec![
-                make_node(grammar.get_or_add_symbol("identifier"), 0, 8, vec![]), // "test_var"
-                make_node(grammar.get_or_add_symbol("identifier"), 9, 22, vec![]), // "myFunction123"
-                make_node(grammar.get_or_add_symbol("identifier"), 23, 31, vec![]), // "_private"
-            ],
-        );
-
-        // Query that matches identifiers starting with underscore
-        use adze::query::{
-            ast::{Pattern, PatternNode, Predicate, Quantifier, Query},
-            matcher_v2::QueryMatcher,
-        };
-
-        let mut query = Query {
-            source: "".to_string(),
-            patterns: vec![],
-            capture_names: HashMap::new(),
-            property_settings: vec![],
-            property_predicates: vec![],
-        };
-
-        query.capture_names.insert("id".to_string(), 0);
-
-        let pattern = Pattern {
-            root: PatternNode {
-                symbol: grammar.get_or_add_symbol("identifier"),
-                children: vec![],
-                fields: HashMap::new(),
-                capture: Some(0),
-                is_named: true,
-                quantifier: Quantifier::One,
-            },
-            predicates: vec![Predicate::Match {
-                capture: 0,
-                regex: "^_".to_string(),
-            }],
-            start_byte: 0,
-        };
-
-        query.patterns.push(pattern);
-
-        let matcher = QueryMatcher::new(&query, source);
-        let matches = matcher.matches(&tree);
-
-        // Should match only "_private"
-        assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].captures[0].node.start_byte, 23);
-    }
-
-    #[test]
-    #[ignore = "query engine incomplete"]
-    fn test_any_of_predicate() {
-        let source = "if test return while";
-        let grammar = create_test_grammar();
-
-        // Mock parse tree
-        let tree = make_node(
-            grammar.get_or_add_symbol("program"),
-            0,
-            20,
-            vec![
-                make_node(grammar.get_or_add_symbol("keyword"), 0, 2, vec![]), // "if"
-                make_node(grammar.get_or_add_symbol("identifier"), 3, 7, vec![]), // "test"
-                make_node(grammar.get_or_add_symbol("keyword"), 8, 14, vec![]), // "return"
-                make_node(grammar.get_or_add_symbol("keyword"), 15, 20, vec![]), // "while"
-            ],
-        );
-
-        // Query that matches control flow keywords
-        use adze::query::{
-            ast::{Pattern, PatternNode, Predicate, Quantifier, Query},
-            matcher_v2::QueryMatcher,
-        };
-
-        let mut query = Query {
-            source: "".to_string(),
-            patterns: vec![],
-            capture_names: HashMap::new(),
-            property_settings: vec![],
-            property_predicates: vec![],
-        };
-
-        query.capture_names.insert("flow".to_string(), 0);
-
-        let pattern = Pattern {
-            root: PatternNode {
-                symbol: grammar.get_or_add_symbol("keyword"),
-                children: vec![],
-                fields: HashMap::new(),
-                capture: Some(0),
-                is_named: true,
-                quantifier: Quantifier::One,
-            },
-            predicates: vec![Predicate::AnyOf {
-                capture: 0,
-                values: vec!["if".to_string(), "while".to_string(), "for".to_string()],
-            }],
-            start_byte: 0,
-        };
-
-        query.patterns.push(pattern);
-
-        let matcher = QueryMatcher::new(&query, source);
-        let matches = matcher.matches(&tree);
-
-        // Should match "if" and "while" but not "return"
-        assert_eq!(matches.len(), 2);
-        assert_eq!(matches[0].captures[0].node.start_byte, 0); // "if"
-        assert_eq!(matches[1].captures[0].node.start_byte, 15); // "while"
-    }
-
-    #[test]
-    #[ignore = "query engine incomplete"]
-    fn test_not_predicates() {
-        let source = "test if other";
-        let grammar = create_test_grammar();
-
-        // Mock parse tree
-        let tree = make_node(
-            grammar.get_or_add_symbol("program"),
-            0,
-            13,
-            vec![
-                make_node(grammar.get_or_add_symbol("identifier"), 0, 4, vec![]), // "test"
-                make_node(grammar.get_or_add_symbol("keyword"), 5, 7, vec![]),    // "if"
-                make_node(grammar.get_or_add_symbol("identifier"), 8, 13, vec![]), // "other"
-            ],
-        );
-
-        // Query that matches identifiers NOT equal to "test"
-        use adze::query::{
-            ast::{Pattern, PatternNode, Predicate, Quantifier, Query},
-            matcher_v2::QueryMatcher,
-        };
-
-        let mut query = Query {
-            source: "".to_string(),
-            patterns: vec![],
-            capture_names: HashMap::new(),
-            property_settings: vec![],
-            property_predicates: vec![],
-        };
-
-        query.capture_names.insert("id".to_string(), 0);
-
-        let pattern = Pattern {
-            root: PatternNode {
-                symbol: grammar.get_or_add_symbol("identifier"),
-                children: vec![],
-                fields: HashMap::new(),
-                capture: Some(0),
-                is_named: true,
-                quantifier: Quantifier::One,
-            },
-            predicates: vec![Predicate::NotEq {
-                capture1: 0,
-                capture2: None,
-                value: Some("test".to_string()),
-            }],
-            start_byte: 0,
-        };
-
-        query.patterns.push(pattern);
-
-        let matcher = QueryMatcher::new(&query, source);
-        let matches = matcher.matches(&tree);
-
-        // Should match only "other"
-        assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].captures[0].node.start_byte, 8);
+        other => panic!("expected InvalidPredicate, got {other:?}"),
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a small Tree-sitter-style canary test that demonstrates predicate behaviour against the current `Grammar` API. 
- Make predicate support explicit so unsupported predicates fail fast with a useful error instead of being silently accepted. 
- Keep changes limited to the query runtime tests and the query parser surface so parser generation/GLR/macro code is untouched.

### Description
- Update `runtime/src/query/parser.rs` to reject unknown predicate names with `QueryError::InvalidPredicate(format!("Unsupported predicate: #{}", name))` instead of parsing them as `Custom` predicates. 
- Remove the ad-hoc `parse_custom_predicate` handling so unsupported predicates are reported at compile time. 
- Replace the outdated/skipped `runtime/tests/test_query_predicates.rs` with a focused canary that builds a minimal `Grammar` and asserts that `#eq?` compiles and that an unsupported predicate (example: `#contains?`) returns `QueryError::InvalidPredicate` containing the predicate name. 
- Run `cargo fmt` formatting on modified files to keep style consistent.

### Testing
- Ran `cargo test -p adze --test test_query_predicates -- --nocapture`, which executed the new canary and reported `2 passed; 0 failed`. 
- Ran `cargo test -p adze --test test_syntax_highlighting -- --nocapture`, which reported `1 passed; 0 failed; 3 ignored` (highlight compilation tests remain gated/ignored). 
- Ran `cargo fmt --all --check`, which succeeded with no formatting complaints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a9348508333a6ae4b6f7edbef37)