### PR TITLE
Clarify runtime2 status and add bounded Language builder smoke test

### DIFF
--- a/docs/status/KNOWN_RED.md
+++ b/docs/status/KNOWN_RED.md
@@ -45,7 +45,7 @@ This lane is intentionally bounded so it stays reliable and fast enough for day-
 ### Not in the supported lane (workspace members / tools)
 These are intentionally excluded for now because they are prototypes, platform-sensitive, heavier than the supported contract, or still stabilizing:
 
-- `runtime2/` (alt runtime path; still converging)
+- `runtime2/` (**experimental proving ground**; see `docs/status/RUNTIME2_STATUS.md` for bounded scope and smoke-proofed behavior)
 - `cli/`, `lsp-generator/`, `playground/`, `wasm-demo/` (tooling/prototypes)
 - `golden-tests/` (useful contract, but can be heavy and multi-language)
 - `benchmarks/` (signal, not merge-blocking)

--- a/docs/status/RUNTIME2_STATUS.md
+++ b/docs/status/RUNTIME2_STATUS.md
@@ -1,0 +1,27 @@
+# Runtime2 status (bounded)
+
+**Last updated:** 2026-04-26
+
+## Recommended support tier
+
+`runtime2/` is currently an **experimental proving ground**.
+
+It is intentionally outside the supported PR gate (`just ci-supported`) and should be treated as a place to iterate on runtime APIs and GLR runtime mechanics, not as the default stable runtime contract for users.
+
+## What is explicitly proven right now
+
+The runtime2 smoke test `smoke_language_builder_constructs_minimal_language` proves one bounded behavior:
+
+- a minimal `Language` can be constructed via `Language::builder()` with parse table + metadata,
+- symbol/field metadata can be queried from that object (`symbol_name`, `field_name`, `is_visible`).
+
+This is a construction/API sanity proof only; it does **not** claim parser correctness, full forest disambiguation guarantees, or production-readiness.
+
+## Scope boundary
+
+This status does **not** promote runtime2 to stable.
+
+Graduation from experimental should require:
+- inclusion in a required CI lane,
+- a small, explicitly documented contract suite (parser + tree semantics),
+- sustained green results over normal development cadence.

--- a/runtime2/tests/basic.rs
+++ b/runtime2/tests/basic.rs
@@ -1,6 +1,14 @@
 //! Basic tests to verify the runtime compiles and has the expected API
 
-use adze_runtime::{Parser, Tree, test_helpers::stub_language};
+use adze_runtime::{
+    Parser, Tree,
+    language::{Language, SymbolMetadata},
+    test_helpers::stub_language,
+};
+
+fn leak_parse_table() -> &'static adze_glr_core::ParseTable {
+    Box::leak(Box::new(adze_glr_core::ParseTable::default()))
+}
 
 #[test]
 fn can_create_parser() {
@@ -14,6 +22,34 @@ fn can_set_language() {
     let language = stub_language();
     parser.set_language(language).unwrap();
     assert!(parser.language().is_some());
+}
+
+#[test]
+fn smoke_language_builder_constructs_minimal_language() {
+    let language = Language::builder()
+        .version(15)
+        .parse_table(leak_parse_table())
+        .symbol_names(vec!["end".into(), "source".into()])
+        .symbol_metadata(vec![
+            SymbolMetadata {
+                is_terminal: true,
+                is_visible: false,
+                is_supertype: false,
+            },
+            SymbolMetadata {
+                is_terminal: false,
+                is_visible: true,
+                is_supertype: false,
+            },
+        ])
+        .field_names(vec!["body".into()])
+        .build()
+        .expect("builder should construct a language with parse table + metadata");
+
+    assert_eq!(language.version, 15);
+    assert_eq!(language.symbol_name(1), Some("source"));
+    assert_eq!(language.field_name(0), Some("body"));
+    assert!(language.is_visible(1));
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- runtime2's role in the workspace was ambiguous and should be explicitly classified so consumers and CI know its intended stability level. 
- Add a small, focused executable proof that a minimal public Language builder surface behaves as expected without asserting full parser maturity.  

### Description
- Add `docs/status/RUNTIME2_STATUS.md` that classifies `runtime2/` as an **experimental proving ground** and lists the bounded behavior that is proven today. 
- Update `docs/status/KNOWN_RED.md` to reference the new runtime2 status note and remove ambiguity about its exclusion from the supported lane. 
- Add a smoke test `smoke_language_builder_constructs_minimal_language` to `runtime2/tests/basic.rs` which constructs a minimal `Language` via `Language::builder()` (using a leaked `adze_glr_core::ParseTable::default()`), verifies builder success, and checks `symbol_name`, `field_name`, and `is_visible` accessors. 

### Testing
- Ran `cargo fmt --all --check` and it succeeded. 
- Ran `cargo test -p adze-runtime --all-features --no-run` to compile the runtime test suite and the build completed successfully. 
- Ran the targeted smoke test with `cargo test -p adze-runtime --test basic --features test-utils smoke_language_builder_constructs_minimal_language -- --nocapture` and it passed (1 passed; 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a8f474c8333ad5923cfa2d86f2a)