### PR TITLE
Classify runtime2 as experimental and add language-builder smoke test

### DIFF
--- a/docs/status/KNOWN_RED.md
+++ b/docs/status/KNOWN_RED.md
@@ -1,6 +1,6 @@
 # Known red
 
-**Last updated:** 2026-04-06
+**Last updated:** 2026-04-26
 
 This file tracks intentional exclusions from the supported lane:
 
@@ -45,7 +45,7 @@ This lane is intentionally bounded so it stays reliable and fast enough for day-
 ### Not in the supported lane (workspace members / tools)
 These are intentionally excluded for now because they are prototypes, platform-sensitive, heavier than the supported contract, or still stabilizing:
 
-- `runtime2/` (alt runtime path; still converging)
+- `runtime2/` (**experimental proving ground**; alt runtime path, still converging). See `docs/status/RUNTIME2_STATUS.md` for bounded scope and smoke proof status.
 - `cli/`, `lsp-generator/`, `playground/`, `wasm-demo/` (tooling/prototypes)
 - `golden-tests/` (useful contract, but can be heavy and multi-language)
 - `benchmarks/` (signal, not merge-blocking)

--- a/docs/status/RUNTIME2_STATUS.md
+++ b/docs/status/RUNTIME2_STATUS.md
@@ -1,0 +1,29 @@
+# Runtime2 status
+
+**Last updated:** 2026-04-26
+
+## Recommended support tier
+
+`runtime2/` is currently classified as an **experimental proving ground**.
+
+## Why this tier is recommended now
+
+- `runtime2/` is explicitly outside the required supported lane (`just ci-supported`).
+- The crate has broad test coverage, but it is not yet part of the merge-blocking contract.
+- There is still convergence language in repo docs (for example: "alt runtime path; still converging").
+
+This means runtime2 is useful for proving behavior and reducing integration risk, but it should not be described as stable/public-primary yet.
+
+## Bounded smoke behavior proven in this change
+
+Smoke proof added in `runtime2/tests/language_builder_tests.rs`:
+
+- Builds a minimal `Language` via `Language::builder()` with parse table, metadata, names, and tokenizer.
+- Verifies metadata access (`symbol_name`, `is_visible`) on the built object.
+- Loads that language into `Parser::set_language()` and confirms parser accepts it.
+
+This proves basic construction and parser-loading sanity for runtime2's language object path, without claiming full runtime stability.
+
+## Graduation guidance (not done here)
+
+To move beyond experimental status, promote a bounded runtime2 check into a required lane and keep it green over time (e.g., all-features build + a small smoke suite).

--- a/runtime2/tests/language_builder_tests.rs
+++ b/runtime2/tests/language_builder_tests.rs
@@ -1,6 +1,9 @@
 //! Tests for the LanguageBuilder API.
 
-use adze_runtime::language::{Language, SymbolMetadata};
+use adze_runtime::{
+    Parser,
+    language::{Language, SymbolMetadata},
+};
 
 fn eof_meta() -> SymbolMetadata {
     SymbolMetadata {
@@ -142,4 +145,25 @@ fn builder_is_terminal() {
         .unwrap();
     assert!(lang.is_terminal(0));
     assert!(!lang.is_terminal(1));
+}
+
+#[test]
+fn smoke_language_builder_constructs_and_loads_into_parser() {
+    let language = Language::builder()
+        .version(14)
+        .parse_table(leak_parse_table())
+        .symbol_names(vec!["end".into(), "source_file".into()])
+        .symbol_metadata(vec![eof_meta(), named_meta()])
+        .tokenizer(|_| Box::new(std::iter::empty()))
+        .build()
+        .expect("language should build with minimal required runtime2 data");
+
+    assert_eq!(language.symbol_name(1), Some("source_file"));
+    assert!(language.is_visible(1));
+
+    let mut parser = Parser::new();
+    parser
+        .set_language(language)
+        .expect("parser should accept a minimally constructed runtime2 language");
+    assert!(parser.language().is_some());
 }


### PR DESCRIPTION
### Motivation

- runtime2's role in the workspace was ambiguous and needed an explicit, honest support-tier declaration. 
- Provide a small, bounded smoke proof that a minimal runtime2 `Language` can be constructed and accepted by the `Parser` to reduce integration risk. 

### Description

- Add `docs/status/RUNTIME2_STATUS.md` that classifies `runtime2/` as an **experimental proving ground** and documents the bounded smoke behavior proven by this change. 
- Update `docs/status/KNOWN_RED.md` to reference the new runtime2 status file and mark `runtime2/` as an experimental proving ground in the exclusions list. 
- Add a smoke test `smoke_language_builder_constructs_and_loads_into_parser` to `runtime2/tests/language_builder_tests.rs` that builds a minimal `Language` via `Language::builder()`, verifies `symbol_name` and `is_visible`, and loads the language into `Parser::set_language()`. 
- No changes were made to `runtime/`, `adze-glr-core`, or `tablegen` source paths. 

### Testing

- Ran `cargo fmt --all --check` and it passed. 
- Ran `cargo test -p adze-runtime --all-features --no-run` which completed successfully and produced test executables. 
- Ran `cargo test -p adze-runtime -- --nocapture` which executed the runtime tests (including the new smoke test) and completed with tests passing for the `adze-runtime` crate. 
- An attempted `cargo test -p adze-runtime2 --all-features --no-run` failed due to a package name mismatch (`adze-runtime2` is not a workspace package), so tests were run against the correct crate `adze-runtime` instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a8f474c8333ad5923cfa2d86f2a)