### PR TITLE
Clarify runtime2 as experimental and add bounded smoke test

### DIFF
--- a/docs/status/KNOWN_RED.md
+++ b/docs/status/KNOWN_RED.md
@@ -45,7 +45,7 @@ This lane is intentionally bounded so it stays reliable and fast enough for day-
 ### Not in the supported lane (workspace members / tools)
 These are intentionally excluded for now because they are prototypes, platform-sensitive, heavier than the supported contract, or still stabilizing:
 
-- `runtime2/` (alt runtime path; still converging)
+- `runtime2/` (experimental proving ground; see `docs/status/RUNTIME2_STATUS.md` for bounded support expectations and smoke coverage)
 - `cli/`, `lsp-generator/`, `playground/`, `wasm-demo/` (tooling/prototypes)
 - `golden-tests/` (useful contract, but can be heavy and multi-language)
 - `benchmarks/` (signal, not merge-blocking)

--- a/docs/status/RUNTIME2_STATUS.md
+++ b/docs/status/RUNTIME2_STATUS.md
@@ -1,0 +1,31 @@
+# Runtime2 status
+
+**Last updated:** 2026-04-26
+
+## Support tier
+
+`runtime2/` is currently classified as an **experimental proving ground**.
+
+This means:
+- it is intentionally outside the required supported lane (`just ci-supported`),
+- APIs and behavior may change while convergence work continues,
+- it should not be treated as a stable/publicly guaranteed runtime contract yet.
+
+## What is currently proven (bounded smoke)
+
+The repository now includes a focused smoke test at
+`runtime2/tests/runtime2_smoke.rs` that proves one minimal behavior:
+
+- a `Language` can be built with parse table + symbol metadata,
+- static tokens can be attached,
+- and `Parser::set_language` accepts that language.
+
+This is intentionally narrow: it proves constructor/builder wiring only, not full
+parse correctness or stability guarantees.
+
+## Graduation criteria (high level)
+
+Runtime2 can be reconsidered for a stronger support tier only after it has:
+- a bounded, reliable CI gate in normal developer workflows,
+- explicit compatibility/stability guarantees documented for consumers,
+- and sustained green behavior beyond smoke-level constructor checks.

--- a/runtime2/tests/runtime2_smoke.rs
+++ b/runtime2/tests/runtime2_smoke.rs
@@ -1,0 +1,46 @@
+//! Bounded smoke tests for the `runtime2/` crate surface.
+//!
+//! These tests intentionally verify only minimal guarantees that are currently
+//! supported (builder + parser wiring), without asserting full parser maturity.
+
+use adze_runtime::{Parser, Token, language::SymbolMetadata};
+
+fn leak_parse_table() -> &'static adze_glr_core::ParseTable {
+    Box::leak(Box::new(adze_glr_core::ParseTable::default()))
+}
+
+#[test]
+fn smoke_language_builder_constructs_and_parser_accepts_language() {
+    let language = adze_runtime::Language::builder()
+        .parse_table(leak_parse_table())
+        .symbol_names(vec!["eof".to_string(), "expr".to_string()])
+        .symbol_metadata(vec![
+            SymbolMetadata {
+                is_terminal: true,
+                is_visible: false,
+                is_supertype: false,
+            },
+            SymbolMetadata {
+                is_terminal: false,
+                is_visible: true,
+                is_supertype: false,
+            },
+        ])
+        .build()
+        .expect("language builder should construct minimal runtime2 language");
+
+    let language = language.with_static_tokens(vec![Token {
+        kind: 0,
+        start: 0,
+        end: 0,
+    }]);
+
+    assert_eq!(language.symbol_name(1), Some("expr"));
+    assert_eq!(language.symbol_for_name("expr", true), Some(1));
+
+    let mut parser = Parser::new();
+    parser
+        .set_language(language)
+        .expect("runtime2 parser should accept minimally constructed language");
+    assert!(parser.language().is_some());
+}


### PR DESCRIPTION
### Motivation
- Runtime2’s role in the workspace was ambiguous and needed an explicit, bounded classification so consumers and CI know what to expect. 
- Provide a minimal, focused proof-of-life that a core constructor/installation path works without promoting runtime2 to a stable runtime.

### Description
- Add a bounded smoke test `runtime2/tests/runtime2_smoke.rs` that constructs a minimal `Language` via `Language::builder()`, attaches static tokens via `with_static_tokens`, and verifies `Parser::set_language` accepts it and `symbol_name`/`symbol_for_name` behave as expected.
- Add `docs/status/RUNTIME2_STATUS.md` documenting that `runtime2/` is an **experimental proving ground**, the exact minimal behavior proven by the smoke test, and high-level graduation criteria.
- Update `docs/status/KNOWN_RED.md` to reference the new runtime2 status doc and mark `runtime2/` as an experimental proving ground.

### Testing
- Ran `cargo fmt --all --check` (passed).
- Ran `cargo test -p adze-runtime2-governance` (all tests passed).
- Ran `cargo test -p adze-runtime --all-features --no-run` (build/test harness prepared successfully; no-run completed without error).
- Ran `cargo test -p adze-runtime --test runtime2_smoke -- --nocapture` and the new smoke test passed (`1 test, 0 failures`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a8f474c8333ad5923cfa2d86f2a)