### PR TITLE
Clarify runtime2 support tier and add language metadata smoke test

### DIFF
--- a/docs/status/KNOWN_RED.md
+++ b/docs/status/KNOWN_RED.md
@@ -45,7 +45,10 @@ This lane is intentionally bounded so it stays reliable and fast enough for day-
 ### Not in the supported lane (workspace members / tools)
 These are intentionally excluded for now because they are prototypes, platform-sensitive, heavier than the supported contract, or still stabilizing:
 
-- `runtime2/` (alt runtime path; still converging)
+- `runtime2/` (experimental proving ground; still converging, not in merge-blocking lane)
+  - **Support tier:** `experimental proving ground`.
+  - **Bounded expectation (as of 2026-04-26):** we only treat runtime2 as an opt-in surface for API and behavior experiments; `ci-supported` does not certify it as stable/public-primary runtime yet.
+  - **Current smoke proof:** `runtime2/tests/basic.rs::language_smoke_exposes_metadata_queries` validates that a minimal language object can be constructed and queried for symbol metadata.
 - `cli/`, `lsp-generator/`, `playground/`, `wasm-demo/` (tooling/prototypes)
 - `golden-tests/` (useful contract, but can be heavy and multi-language)
 - `benchmarks/` (signal, not merge-blocking)

--- a/runtime2/tests/basic.rs
+++ b/runtime2/tests/basic.rs
@@ -17,6 +17,19 @@ fn can_set_language() {
 }
 
 #[test]
+fn language_smoke_exposes_metadata_queries() {
+    let language = stub_language();
+
+    assert_eq!(language.symbol_count, 1);
+    assert_eq!(language.field_count, 0);
+
+    assert_eq!(language.symbol_name(0), Some("placeholder"));
+    assert_eq!(language.symbol_for_name("placeholder", true), Some(0));
+    assert!(language.is_terminal(0));
+    assert!(language.is_visible(0));
+}
+
+#[test]
 fn parse_requires_language() {
     let mut parser = Parser::new();
     let result = parser.parse_utf8("test input", None);


### PR DESCRIPTION
### Motivation
- Make `runtime2/` intent explicit (avoid ambiguous second-runtime story) and add a minimal, bounded smoke proof of a public API surface that is already closest to working.

### Description
- Classify `runtime2/` as an `experimental proving ground` in `docs/status/KNOWN_RED.md` with a short bounded expectation and reference to the smoke proof. 
- Add `runtime2/tests/basic.rs::language_smoke_exposes_metadata_queries` which constructs a minimal `Language` via `test_helpers::stub_language()` and asserts `symbol_count`, `field_count`, `symbol_name`, `symbol_for_name`, `is_terminal`, and `is_visible` behavior. 
- No changes were made to `runtime/`, `adze-glr-core`, or `adze-tablegen` and the wording intentionally does not promote `runtime2` to stable.

### Testing
- Ran `cargo test -p adze-runtime --all-features --no-run` which finished successfully and produced test executables. 
- Ran `cargo test -p adze-runtime --test basic --features test-utils -- --nocapture` and the `basic` test binary passed all tests including the new `language_smoke_exposes_metadata_queries` (7 passed, 0 failed). 
- Ran `cargo fmt --all --check` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a8f474c8333ad5923cfa2d86f2a)