### PR TITLE
Improve `adze init` scaffolds and make `adze parse` behavior explicit

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -139,6 +139,7 @@ fn main() -> Result<()> {
 fn init_grammar(name: &str, output: Option<PathBuf>) -> Result<()> {
     let dir = output.unwrap_or_else(|| PathBuf::from("."));
     let project_dir = dir.join(name);
+    let grammar_name = sanitize_grammar_name(name);
 
     println!(
         "{} Creating new grammar project: {}",
@@ -152,6 +153,9 @@ fn init_grammar(name: &str, output: Option<PathBuf>) -> Result<()> {
     fs::create_dir_all(project_dir.join("tests"))?;
     fs::create_dir_all(project_dir.join("examples"))?;
 
+    let (adze_dependency, adze_tool_dependency, dependency_note) =
+        scaffold_dependency_specs(&project_dir);
+
     // Create Cargo.toml
     let cargo_toml = format!(
         r#"[package]
@@ -159,16 +163,20 @@ name = "{}"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+default = ["pure-rust"]
+pure-rust = []
+
 [dependencies]
-adze = {{ version = "0.5.0-beta" }}
+{}
 
 [build-dependencies]
-adze-tool = {{ version = "0.5.0-beta" }}
+{}
 
 [dev-dependencies]
 insta = "1.40"
 "#,
-        name
+        name, adze_dependency, adze_tool_dependency
     );
 
     fs::write(project_dir.join("Cargo.toml"), cargo_toml)?;
@@ -194,7 +202,7 @@ mod grammar {{
     /// Root node of the grammar
     #[adze::language]
     pub struct Program {{
-        #[adze::repeat]
+        #[adze::repeat(non_empty = true)]
         pub statements: Vec<Statement>,
     }}
     
@@ -228,7 +236,7 @@ mod grammar {{
     }}
 }}
 "#,
-        name, name
+        name, grammar_name
     );
 
     fs::write(project_dir.join("src/grammar.rs"), grammar_rs)?;
@@ -242,13 +250,20 @@ pub use grammar::*;
     fs::write(project_dir.join("src/lib.rs"), lib_rs)?;
 
     // Create example test
-    let test_rs = r#"use insta::assert_snapshot;
+    let test_rs = r#"use adze::pure_parser::Parser;
 
 #[test]
-fn test_simple_program() {
-    let input = "42; foo;";
-    // TODO: Add parsing logic once grammar is built
-    assert_snapshot!(input);
+fn test_generated_language_can_parse_a_minimal_input() {
+    let mut parser = Parser::new();
+    parser
+        .set_language(language())
+        .expect("generated language should be loadable");
+
+    let parse = parser.parse_bytes(b"42;");
+    assert!(
+        parse.root.is_some(),
+        "generated parser should produce a root node"
+    );
 }
 "#;
 
@@ -292,6 +307,9 @@ MIT
         "✅".green(),
         project_dir.display().to_string().bright_blue()
     );
+    if let Some(note) = dependency_note {
+        println!("  {} {}", "ℹ️".blue(), note.bright_black());
+    }
     println!("\n{}", "Next steps:".bright_yellow());
     println!("  cd {}", name);
     println!("  cargo build");
@@ -384,28 +402,32 @@ fn parse_file(
         }
         #[cfg(not(feature = "dynamic"))]
         {
-            eprintln!(
-                "{}\n",
-                "Error: Dynamic loading not enabled. Build with --features dynamic".red()
+            anyhow::bail!(
+                "{}",
+                "dynamic parse mode is experimental and unavailable in this build. Rebuild adze-cli with --features dynamic.".red()
             );
-            std::process::exit(2);
         }
     }
-    println!("{} Parsing file: {}", "📄".blue(), input.display());
-
     let input_content = fs::read_to_string(input)?;
-    println!(
-        "  Grammar: {}\n  Input: {} ({} bytes)",
+    anyhow::bail!(
+        "{} grammar={} input={} ({} bytes). Use generated Rust parser APIs after `adze build`.",
+        "static parse mode is experimental and not yet implemented in adze-cli.".yellow(),
         grammar.display(),
         input.display(),
         input_content.len()
-    );
-    println!(
-        "{} Static parsing not yet implemented. Use `adze build` first, then parse in your Rust code.",
-        "⚠️ ".yellow()
-    );
+    )
+}
 
-    Ok(())
+fn sanitize_grammar_name(name: &str) -> String {
+    name.chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '_' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
 }
 
 #[cfg(feature = "dynamic")]
@@ -444,21 +466,48 @@ fn parse_file_dynamic(
         let _lang_ptr = get_language();
 
         // TODO: Bridge to adze's pure parser using the language pointer
-        println!(
-            "{} Loaded language from: {}",
-            "✓".green(),
-            grammar.display()
+        anyhow::bail!(
+            "{} grammar={} input_size={} format={:?}. Dynamic loading works, but CLI parse output is not implemented yet.",
+            "dynamic parse mode is experimental and incomplete.".yellow(),
+            grammar.display(),
+            input_content.len(),
+            format
         );
-        println!("Input size: {} bytes", input_content.len());
+    }
+}
 
-        // For now, just show we loaded it successfully
-        match format {
-            OutputFormat::Json => println!("{{\"status\": \"dynamic loading successful\"}}"),
-            _ => println!("Dynamic loading successful - parser integration pending"),
+fn scaffold_dependency_specs(project_dir: &Path) -> (String, String, Option<String>) {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).parent();
+    let version = env!("CARGO_PKG_VERSION");
+
+    if let Some(root) = workspace_root {
+        let runtime_path = root.join("runtime");
+        let tool_path = root.join("tool");
+
+        if runtime_path.join("Cargo.toml").exists() && tool_path.join("Cargo.toml").exists() {
+            let runtime_dep = format!(
+                "adze = {{ path = \"{}\", version = \"{}\" }}",
+                runtime_path.display(),
+                version
+            );
+            let tool_dep = format!(
+                "adze-tool = {{ path = \"{}\", version = \"{}\" }}",
+                tool_path.display(),
+                version
+            );
+            let note = format!(
+                "Using local workspace path dependencies because this adze-cli binary was built from a source checkout (project: {}).",
+                project_dir.display()
+            );
+            return (runtime_dep, tool_dep, Some(note));
         }
     }
 
-    Ok(())
+    (
+        format!("adze = {{ version = \"{}\" }}", version),
+        format!("adze-tool = {{ version = \"{}\" }}", version),
+        None,
+    )
 }
 
 fn test_grammar(_path: &Path, update: bool) -> Result<()> {

--- a/cli/tests/cli_test.rs
+++ b/cli/tests/cli_test.rs
@@ -5,6 +5,8 @@
 
 use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
+use std::fs;
+use tempfile::tempdir;
 
 // ---------------------------------------------------------------------------
 // End-to-end smoke tests (lightweight — no grammar compilation)
@@ -65,6 +67,75 @@ fn test_cli_unknown_command() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("unrecognized subcommand"));
+}
+
+#[test]
+fn test_init_generates_buildable_project() {
+    let temp = tempdir().expect("tempdir should be created");
+    let project_name = "mylang";
+
+    let mut cmd = cargo_bin_cmd!("adze");
+    cmd.current_dir(temp.path())
+        .arg("init")
+        .arg(project_name)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Project created"));
+
+    let project_dir = temp.path().join(project_name);
+    assert!(
+        project_dir.join("Cargo.toml").exists(),
+        "generated project should include Cargo.toml"
+    );
+
+    let mut check_cmd = std::process::Command::new("cargo");
+    check_cmd.current_dir(&project_dir).arg("check");
+    let status = check_cmd
+        .status()
+        .expect("cargo check should run in generated project");
+    assert!(
+        status.success(),
+        "generated project should pass cargo check"
+    );
+}
+
+#[test]
+fn test_parse_static_mode_reports_unimplemented_behavior() {
+    let temp = tempdir().expect("tempdir should be created");
+    let grammar = temp.path().join("grammar.rs");
+    let input = temp.path().join("input.txt");
+    fs::write(&grammar, "// placeholder grammar path").expect("grammar file should be written");
+    fs::write(&input, "42;").expect("input file should be written");
+
+    let mut cmd = cargo_bin_cmd!("adze");
+    cmd.arg("parse")
+        .arg(&grammar)
+        .arg(&input)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "static parse mode is experimental and not yet implemented in adze-cli",
+        ));
+}
+
+#[test]
+fn test_init_sanitizes_grammar_name_for_non_identifier_project_names() {
+    let temp = tempdir().expect("tempdir should be created");
+    let project_name = "my-lang";
+
+    let mut cmd = cargo_bin_cmd!("adze");
+    cmd.current_dir(temp.path())
+        .arg("init")
+        .arg(project_name)
+        .assert()
+        .success();
+
+    let grammar_file = temp.path().join(project_name).join("src/grammar.rs");
+    let grammar_source = fs::read_to_string(grammar_file).expect("grammar file should exist");
+    assert!(
+        grammar_source.contains(r#"#[adze::grammar("my_lang")]"#),
+        "grammar name should be sanitized to a valid identifier-like token"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- The CLI first-run experience produced scaffolded projects with stale/invalid dependency hints and placeholder tests that did not reliably build in-repo.
- `adze parse` previously printed vague messages for unimplemented paths and could mislead users into thinking full parsing was available from the CLI.
- The goal was to make `adze init` produce a buildable starter crate and make parse-related commands truthful and testable.

### Description
- `adze init` now generates dependency specs that prefer local workspace path dependencies when the CLI was built from a source checkout and otherwise use the current `adze-cli` package version, via a new helper `scaffold_dependency_specs`.  (changes in `cli/src/main.rs`).
- The generated `Cargo.toml` now includes a `pure-rust` feature stub so the scaffolded `build.rs` can use the pure-Rust parser generation path, and the generated `build.rs` remains `build_parsers("src/grammar.rs")`.
- Grammar scaffolding was fixed to avoid an empty-start rule by setting `#[adze::repeat(non_empty = true)]` for the `Program` root and to sanitize project names into identifier-safe grammar names (e.g. `my-lang` -> `my_lang`) via `sanitize_grammar_name`.
- Replaced the placeholder Insta snapshot test in the generated project with a minimal parser smoke test that initializes the generated language and asserts a root node is produced for a minimal input.
- `adze parse` now bails with explicit, user-friendly error messages for unimplemented/experimental modes: static parse mode reports that it is experimental/unimplemented, and dynamic parse mode reports experimental/incomplete status (and errors if the `dynamic` feature is unavailable); `parse_file_dynamic` also returns a clear message rather than silently printing success.
- Added CLI integration tests to cover the improved first-run path: `test_init_generates_buildable_project`, `test_parse_static_mode_reports_unimplemented_behavior`, and `test_init_sanitizes_grammar_name_for_non_identifier_project_names` (changes in `cli/tests/cli_test.rs`).

### Testing
- Ran `cargo fmt --all --check` which succeeded.
- Ran `cargo test -p adze-cli -- --nocapture` which completed: new/updated CLI unit and integration tests passed, with output showing all CLI tests succeeding.
- The `init` scaffold was exercised by a test that creates a temporary project and runs `cargo check` inside it to validate the generated crate is buildable (test passed in CI-local run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a6cf0a48333a15a98605f47ff0f)