### PR TITLE
tablegen: validate encoded id widths during table compression

### DIFF
--- a/tablegen/src/compress.rs
+++ b/tablegen/src/compress.rs
@@ -125,6 +125,22 @@ impl Default for TableCompressor {
 }
 
 impl TableCompressor {
+    fn checked_u16(&self, value: usize, id_type: &str, context: &str) -> Result<u16> {
+        u16::try_from(value).map_err(|_| {
+            TableGenError::Compression(format!(
+                "{id_type} {value} exceeds u16::MAX while {context}; compression would truncate data"
+            ))
+        })
+    }
+
+    fn checked_row_offset(&self, value: usize, table_kind: &str, row: usize) -> Result<u16> {
+        self.checked_u16(
+            value,
+            "row offset",
+            &format!("encoding {table_kind} row {row}"),
+        )
+    }
+
     /// Create a new compressor with default thresholds.
     #[must_use]
     pub fn new() -> Self {
@@ -405,7 +421,8 @@ impl TableCompressor {
             let default_action = Action::Error;
 
             default_actions.push(default_action.clone());
-            row_offsets.push(entries.len() as u16);
+            let row_index = row_offsets.len();
+            row_offsets.push(self.checked_row_offset(entries.len(), "action table", row_index)?);
 
             for (index, action_cell) in action_row.iter().enumerate() {
                 // Process each action in the cell
@@ -417,7 +434,16 @@ impl TableCompressor {
 
                     // Use the mapped index directly, not the original symbol ID
                     // This ensures terminals (index < token_count) are correctly identified
-                    let symbol_id = index as u16;
+                    let symbol_id = self.checked_u16(
+                        index,
+                        "symbol id",
+                        &format!("encoding action table row {row_index}"),
+                    )?;
+                    self.encode_action_small(action).map_err(|err| {
+                        TableGenError::Compression(format!(
+                            "invalid action id at action row {row_index}, symbol {index}: {err}"
+                        ))
+                    })?;
 
                     entries.push(CompressedActionEntry {
                         symbol: symbol_id,
@@ -427,7 +453,11 @@ impl TableCompressor {
             }
         }
 
-        row_offsets.push(entries.len() as u16);
+        row_offsets.push(self.checked_row_offset(
+            entries.len(),
+            "action table",
+            action_table.len(),
+        )?);
 
         // Validate row_offsets are strictly increasing
         for i in 1..row_offsets.len() {
@@ -466,10 +496,11 @@ impl TableCompressor {
         let mut row_offsets = Vec::new();
 
         for row in goto_table {
-            row_offsets.push(entries.len() as u16);
+            let row_index = row_offsets.len();
+            row_offsets.push(self.checked_row_offset(entries.len(), "goto table", row_index)?);
 
             let mut last_state = None;
-            let mut run_length = 0;
+            let mut run_length: usize = 0;
 
             for &state_id in row {
                 if last_state == Some(state_id.0) {
@@ -480,10 +511,12 @@ impl TableCompressor {
                         let state = last_state.expect("run_length > 0 implies last_state is set");
                         // Emit previous run
                         if run_length > 2 {
-                            entries.push(CompressedGotoEntry::RunLength {
-                                state,
-                                count: run_length,
-                            });
+                            let count = self.checked_u16(
+                                run_length,
+                                "goto run length",
+                                &format!("encoding goto row {row_index}"),
+                            )?;
+                            entries.push(CompressedGotoEntry::RunLength { state, count });
                         } else {
                             // For short runs, individual entries are more efficient
                             for _ in 0..run_length {
@@ -499,10 +532,12 @@ impl TableCompressor {
             if run_length > 0 {
                 let state = last_state.expect("run_length > 0 implies last_state is set");
                 if run_length > 2 {
-                    entries.push(CompressedGotoEntry::RunLength {
-                        state,
-                        count: run_length,
-                    });
+                    let count = self.checked_u16(
+                        run_length,
+                        "goto run length",
+                        &format!("encoding goto row {row_index}"),
+                    )?;
+                    entries.push(CompressedGotoEntry::RunLength { state, count });
                 } else {
                     for _ in 0..run_length {
                         entries.push(CompressedGotoEntry::Single(state));
@@ -511,7 +546,7 @@ impl TableCompressor {
             }
         }
 
-        row_offsets.push(entries.len() as u16);
+        row_offsets.push(self.checked_row_offset(entries.len(), "goto table", goto_table.len())?);
 
         Ok(CompressedGotoTable {
             data: entries,

--- a/tablegen/tests/compress_boundary_v9.rs
+++ b/tablegen/tests/compress_boundary_v9.rs
@@ -1153,3 +1153,35 @@ fn cb_v9_bitpack_all_reduce_row() {
         );
     }
 }
+
+#[test]
+fn cb_v9_rejects_action_symbol_id_over_u16() {
+    let compressor = TableCompressor::new();
+    let action_table = vec![vec![vec![Action::Shift(StateId(1))]]];
+    let symbol_to_index = std::collections::BTreeMap::from([(adze_ir::SymbolId(1), 70000usize)]);
+
+    let err = compressor
+        .compress_action_table_small(&action_table, &symbol_to_index)
+        .expect_err("compression should reject symbol ids above u16 width");
+
+    let msg = err.to_string();
+    assert!(msg.contains("symbol id 70000 exceeds u16::MAX"), "{msg}");
+}
+
+#[test]
+fn cb_v9_rejects_action_row_offset_over_u16() {
+    let compressor = TableCompressor::new();
+    let mut action_row = Vec::with_capacity(65536);
+    for _ in 0..65536 {
+        action_row.push(vec![Action::Shift(StateId(1))]);
+    }
+    let action_table = vec![action_row];
+    let symbol_to_index = std::collections::BTreeMap::new();
+
+    let err = compressor
+        .compress_action_table_small(&action_table, &symbol_to_index)
+        .expect_err("compression should reject row_offsets above u16 width");
+
+    let msg = err.to_string();
+    assert!(msg.contains("row offset 65536 exceeds u16::MAX"), "{msg}");
+}

--- a/tablegen/tests/compression_comprehensive_tablegen.rs
+++ b/tablegen/tests/compression_comprehensive_tablegen.rs
@@ -782,7 +782,7 @@ fn multiple_compressions_identical() {
 // ═══════════════════════════════════════════════════════════════════════════
 
 #[test]
-fn compression_handles_boundary_state_ids() {
+fn compression_rejects_state_ids_that_exceed_small_encoding_width() {
     let mut table = make_empty_table(5, 3, 1, 0);
 
     // Use boundary state IDs
@@ -791,13 +791,19 @@ fn compression_handles_boundary_state_ids() {
             cell.push(Action::Shift(StateId(0))); // Min state
         }
         if let Some(cell) = row.get_mut(2) {
-            cell.push(Action::Shift(StateId(u16::MAX - 1))); // Near max state
+            cell.push(Action::Shift(StateId(u16::MAX - 1))); // Too large for small-table encoding
         }
     }
 
     let compressor = TableCompressor::new();
     let result = compressor.compress(&table, &[1, 2, 3, 4], false);
-    assert!(result.is_ok(), "Should handle boundary state IDs");
+    assert!(result.is_err(), "oversized state ids must be rejected");
+    let err = result.err().expect("checked is_err above");
+    assert!(
+        err.to_string()
+            .contains("Shift state 65534 too large for small table encoding"),
+        "{err}"
+    );
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/tablegen/tests/compression_roundtrip_comprehensive.rs
+++ b/tablegen/tests/compression_roundtrip_comprehensive.rs
@@ -1535,6 +1535,27 @@ fn row_offsets_last_equals_data_len() {
     assert_eq!(last_offset, compressed.data.len());
 }
 
+#[test]
+fn compression_rejects_oversized_action_ids_with_location_context() {
+    let compressor = TableCompressor::new();
+    let action_table = vec![vec![vec![Action::Shift(StateId(0x8000))]]];
+    let sym_map = std::collections::BTreeMap::from([(adze_ir::SymbolId(1), 0usize)]);
+
+    let err = compressor
+        .compress_action_table_small(&action_table, &sym_map)
+        .expect_err("oversized shift state should fail compression");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("invalid action id at action row 0, symbol 0"),
+        "{msg}"
+    );
+    assert!(
+        msg.contains("Shift state 32768 too large for small table encoding"),
+        "{msg}"
+    );
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // 23. Integration: grammar → pipeline → validate
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
### Motivation

- Prevent silent truncation when compressing parse tables by validating values that will be encoded into u16 fields and emitting clear errors instead of wrapping.
- Make compression failures actionable with context (row, symbol, and table kind) so large grammars produce an explicit reportable error instead of corrupted parser data.

### Description

- Added `checked_u16` and `checked_row_offset` helpers to `TableCompressor` and used them to bounds-check all u16-encoded values in `tablegen/src/compress.rs`. 
- Emit `TableGenError::Compression` with contextual messages when any value would exceed `u16::MAX`, including row offsets, symbol ids, and goto run-length counts. 
- Validate every action before emitting by routing `encode_action_small` errors through `compress_action_table_small` and wrapping them with `action row`/`symbol` location context. 
- Added/updated tests to assert explicit failures for oversized IDs and to reflect the stricter behavior for out-of-range state IDs during small-table encoding.

### Testing

- Ran `cargo test -p adze-tablegen compression -- --nocapture` and observed compression-related test suites pass after adjustments. 
- Ran `cargo test -p adze-tablegen validation -- --nocapture` and `cargo test -p adze-tablegen --all-features --no-run` which completed successfully. 
- Ran `cargo fmt --all --check` which succeeded. 
- Added focused test runs demonstrating the new failures passed: `--test compress_boundary_v9 cb_v9_rejects_action_row_offset_over_u16` and `--test compression_roundtrip_comprehensive compression_rejects_oversized_action_ids_with_location_context` (both passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a5d10e483338e930f0ecb2aca5e)