### PR TITLE
tablegen: reject oversized IDs during table compression

### DIFF
--- a/tablegen/src/compress.rs
+++ b/tablegen/src/compress.rs
@@ -373,7 +373,7 @@ impl TableCompressor {
             index_to_symbol.insert(index, symbol_id);
         }
 
-        for action_row in action_table.iter() {
+        for (state_idx, action_row) in action_table.iter().enumerate() {
             // Find the most common action across all cells
             let mut action_counts: HashMap<Action, usize> = HashMap::new();
             let mut _has_shift = false;
@@ -405,7 +405,11 @@ impl TableCompressor {
             let default_action = Action::Error;
 
             default_actions.push(default_action.clone());
-            row_offsets.push(entries.len() as u16);
+            row_offsets.push(Self::checked_u16(
+                entries.len(),
+                "action row offset",
+                Some(state_idx),
+            )?);
 
             for (index, action_cell) in action_row.iter().enumerate() {
                 // Process each action in the cell
@@ -415,9 +419,18 @@ impl TableCompressor {
                         continue;
                     }
 
+                    // Validate the action can be represented by the encoded width used by
+                    // the small table backend (15-bit shift target / 14-bit production id).
+                    self.encode_action_small(action).map_err(|err| {
+                        TableGenError::Compression(format!(
+                            "Action at state {state_idx}, symbol column {index} cannot be encoded safely: {err}"
+                        ))
+                    })?;
+
                     // Use the mapped index directly, not the original symbol ID
                     // This ensures terminals (index < token_count) are correctly identified
-                    let symbol_id = index as u16;
+                    let symbol_id =
+                        Self::checked_u16(index, "symbol column index", Some(state_idx))?;
 
                     entries.push(CompressedActionEntry {
                         symbol: symbol_id,
@@ -427,7 +440,11 @@ impl TableCompressor {
             }
         }
 
-        row_offsets.push(entries.len() as u16);
+        row_offsets.push(Self::checked_u16(
+            entries.len(),
+            "action row offset tail",
+            None,
+        )?);
 
         // Validate row_offsets are strictly increasing
         for i in 1..row_offsets.len() {
@@ -465,8 +482,12 @@ impl TableCompressor {
         let mut entries = Vec::new();
         let mut row_offsets = Vec::new();
 
-        for row in goto_table {
-            row_offsets.push(entries.len() as u16);
+        for (state_idx, row) in goto_table.iter().enumerate() {
+            row_offsets.push(Self::checked_u16(
+                entries.len(),
+                "goto row offset",
+                Some(state_idx),
+            )?);
 
             let mut last_state = None;
             let mut run_length = 0;
@@ -511,7 +532,11 @@ impl TableCompressor {
             }
         }
 
-        row_offsets.push(entries.len() as u16);
+        row_offsets.push(Self::checked_u16(
+            entries.len(),
+            "goto row offset tail",
+            None,
+        )?);
 
         Ok(CompressedGotoTable {
             data: entries,
@@ -521,6 +546,19 @@ impl TableCompressor {
 
     // Removed in 0.8.0 - use compress(parse_table, token_indices, start_can_be_empty)
     // See MIGRATING.md for migration guide
+
+    fn checked_u16(value: usize, id_kind: &str, state_idx: Option<usize>) -> Result<u16> {
+        u16::try_from(value).map_err(|_| {
+            let state_note = state_idx
+                .map(|idx| format!(", state {idx}"))
+                .unwrap_or_default();
+            TableGenError::Compression(format!(
+                "{id_kind} value {value} exceeds u16::MAX (65535){state_note}; \
+                 table is too large for the current compressed representation. \
+                 Reduce grammar/table size or adjust encoding width."
+            ))
+        })
+    }
 }
 
 #[cfg(test)]
@@ -661,5 +699,72 @@ mod tests {
         );
         let result = tables.validate(&parse_table);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_compress_action_table_rejects_symbol_index_over_u16() {
+        let compressor = TableCompressor::new();
+        let action_table = vec![vec![
+            vec![Action::Shift(StateId(1))];
+            (u16::MAX as usize) + 1
+        ]];
+        let symbol_to_index = std::collections::BTreeMap::new();
+
+        let err = compressor
+            .compress_action_table_small(&action_table, &symbol_to_index)
+            .expect_err("symbol index overflow must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("symbol column index value"),
+            "unexpected error message: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_compress_action_table_rejects_shift_width_overflow() {
+        let compressor = TableCompressor::new();
+        let action_table = vec![vec![vec![Action::Shift(StateId(0x8000))]]];
+        let symbol_to_index = std::collections::BTreeMap::new();
+
+        let err = compressor
+            .compress_action_table_small(&action_table, &symbol_to_index)
+            .expect_err("shift encoding overflow must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("cannot be encoded safely"),
+            "unexpected error message: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_compress_action_table_rejects_reduce_width_overflow() {
+        let compressor = TableCompressor::new();
+        let action_table = vec![vec![vec![Action::Reduce(adze_ir::RuleId(0x4000))]]];
+        let symbol_to_index = std::collections::BTreeMap::new();
+
+        let err = compressor
+            .compress_action_table_small(&action_table, &symbol_to_index)
+            .expect_err("reduce encoding overflow must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("cannot be encoded safely"),
+            "unexpected error message: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_compress_goto_table_rejects_row_offset_over_u16() {
+        let compressor = TableCompressor::new();
+        let row_len = (u16::MAX as usize) + 1;
+        let goto_table = vec![vec![StateId(1); row_len], vec![StateId(2); row_len]];
+
+        let err = compressor
+            .compress_goto_table_small(&goto_table)
+            .expect_err("goto row offset overflow must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("goto row offset value"),
+            "unexpected error message: {msg}"
+        );
     }
 }

--- a/tablegen/tests/compression_comprehensive_tablegen.rs
+++ b/tablegen/tests/compression_comprehensive_tablegen.rs
@@ -778,26 +778,37 @@ fn multiple_compressions_identical() {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// TEST 21: Compression handles boundary state IDs
+// TEST 21: Compression rejects state IDs that exceed encoded width
 // ═══════════════════════════════════════════════════════════════════════════
 
 #[test]
-fn compression_handles_boundary_state_ids() {
+fn compression_rejects_state_ids_beyond_small_table_width() {
     let mut table = make_empty_table(5, 3, 1, 0);
 
-    // Use boundary state IDs
+    // Include an unencodable shift target (>= 0x8000)
     if let Some(row) = table.action_table.get_mut(0) {
         if let Some(cell) = row.get_mut(1) {
             cell.push(Action::Shift(StateId(0))); // Min state
         }
         if let Some(cell) = row.get_mut(2) {
-            cell.push(Action::Shift(StateId(u16::MAX - 1))); // Near max state
+            cell.push(Action::Shift(StateId(0x8000))); // Just beyond small-table width
         }
     }
 
     let compressor = TableCompressor::new();
     let result = compressor.compress(&table, &[1, 2, 3, 4], false);
-    assert!(result.is_ok(), "Should handle boundary state IDs");
+    assert!(
+        result.is_err(),
+        "Compression must reject unencodable state IDs"
+    );
+    let msg = match result {
+        Ok(_) => String::new(),
+        Err(err) => err.to_string(),
+    };
+    assert!(
+        msg.contains("cannot be encoded safely"),
+        "Error should be actionable, got: {msg}"
+    );
 }
 
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
### Motivation
- Prevent silent u16 truncation and corrupt compressed parse tables by validating IDs during compression and emitting explicit, actionable errors when values exceed the encoded width.

### Description
- Add a reusable `checked_u16(value, id_kind, state_idx)` helper that converts `usize -> u16` with an actionable `TableGenError::Compression` on overflow and use it for all row offsets and symbol column indices emitted into compressed tables.
- Validate each non-error action during action-table compression by calling `encode_action_small`, turning encoding failures (oversized shift/reduce IDs) into contextual errors that include `state` and `symbol` location information, emitted from `compress_action_table_small`.
- Apply bounds checks at these sites so oversized values are rejected instead of wrapped: action row offsets and tail offset (via `checked_u16`), symbol column indices (via `checked_u16`), goto row offsets (via `checked_u16`), and per-action encodability (shift and reduce ID width checked via `encode_action_small`).
- Add unit tests covering symbol index overflow, shift/reduce width overflow, and goto row-offset overflow, and update the comprehensive boundary test to assert compression rejects unencodable state IDs rather than silently accepting them.
- All changes are contained to the `tablegen` crate; runtime decoder was not modified.

### Testing
- Ran `cargo test -p adze-tablegen compression -- --nocapture` and the compression test suite passed after the changes (regressions fixed).
- Ran `cargo test -p adze-tablegen validation -- --nocapture` and validation tests passed.
- Ran `cargo test -p adze-tablegen --all-features --no-run` (build-only) and compilation for all features succeeded.
- Ran `cargo fmt --all --check` and formatting checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a5d10e483338e930f0ecb2aca5e)