### PR TITLE
tablegen: reject out-of-range IDs during compression

### DIFF
--- a/tablegen/src/compress.rs
+++ b/tablegen/src/compress.rs
@@ -125,6 +125,15 @@ impl Default for TableCompressor {
 }
 
 impl TableCompressor {
+    fn checked_u16(&self, value: usize, id_kind: &'static str, context: &str) -> Result<u16> {
+        u16::try_from(value).map_err(|_| {
+            TableGenError::Compression(format!(
+                "{id_kind} value {value} exceeds u16::MAX ({}) while {context}",
+                u16::MAX
+            ))
+        })
+    }
+
     /// Create a new compressor with default thresholds.
     #[must_use]
     pub fn new() -> Self {
@@ -405,7 +414,11 @@ impl TableCompressor {
             let default_action = Action::Error;
 
             default_actions.push(default_action.clone());
-            row_offsets.push(entries.len() as u16);
+            row_offsets.push(self.checked_u16(
+                entries.len(),
+                "action row offset",
+                "recording compressed action row start",
+            )?);
 
             for (index, action_cell) in action_row.iter().enumerate() {
                 // Process each action in the cell
@@ -415,9 +428,15 @@ impl TableCompressor {
                         continue;
                     }
 
+                    self.encode_action_small(action)?;
+
                     // Use the mapped index directly, not the original symbol ID
                     // This ensures terminals (index < token_count) are correctly identified
-                    let symbol_id = index as u16;
+                    let symbol_id = self.checked_u16(
+                        index,
+                        "action symbol ID",
+                        "encoding compressed action entry",
+                    )?;
 
                     entries.push(CompressedActionEntry {
                         symbol: symbol_id,
@@ -427,7 +446,11 @@ impl TableCompressor {
             }
         }
 
-        row_offsets.push(entries.len() as u16);
+        row_offsets.push(self.checked_u16(
+            entries.len(),
+            "action row offset",
+            "recording compressed action table end",
+        )?);
 
         // Validate row_offsets are strictly increasing
         for i in 1..row_offsets.len() {
@@ -466,7 +489,11 @@ impl TableCompressor {
         let mut row_offsets = Vec::new();
 
         for row in goto_table {
-            row_offsets.push(entries.len() as u16);
+            row_offsets.push(self.checked_u16(
+                entries.len(),
+                "goto row offset",
+                "recording compressed goto row start",
+            )?);
 
             let mut last_state = None;
             let mut run_length = 0;
@@ -511,7 +538,11 @@ impl TableCompressor {
             }
         }
 
-        row_offsets.push(entries.len() as u16);
+        row_offsets.push(self.checked_u16(
+            entries.len(),
+            "goto row offset",
+            "recording compressed goto table end",
+        )?);
 
         Ok(CompressedGotoTable {
             data: entries,

--- a/tablegen/tests/compress_boundary_v9.rs
+++ b/tablegen/tests/compress_boundary_v9.rs
@@ -1153,3 +1153,45 @@ fn cb_v9_bitpack_all_reduce_row() {
         );
     }
 }
+
+#[test]
+fn cb_v9_rejects_action_symbol_id_over_u16() {
+    let compressor = TableCompressor::new();
+    let mut row = vec![Vec::<Action>::new(); (u16::MAX as usize) + 2];
+    row[u16::MAX as usize + 1] = vec![Action::Accept];
+    let action_table = vec![row];
+
+    let result =
+        compressor.compress_action_table_small(&action_table, &std::collections::BTreeMap::new());
+    let err = result.expect_err("symbol IDs > u16::MAX must fail compression");
+    let msg = err.to_string();
+    assert!(msg.contains("action symbol ID"));
+    assert!(msg.contains("exceeds u16::MAX"));
+}
+
+#[test]
+fn cb_v9_rejects_action_row_offset_over_u16() {
+    let compressor = TableCompressor::new();
+    let action_table = vec![vec![Action::Accept; (u16::MAX as usize) + 1]];
+    let action_table = vec![action_table];
+
+    let result =
+        compressor.compress_action_table_small(&action_table, &std::collections::BTreeMap::new());
+    let err = result.expect_err("action row offsets > u16::MAX must fail compression");
+    let msg = err.to_string();
+    assert!(msg.contains("action row offset"));
+    assert!(msg.contains("exceeds u16::MAX"));
+}
+
+#[test]
+fn cb_v9_rejects_goto_row_offset_over_u16() {
+    let compressor = TableCompressor::new();
+    let goto_row = vec![StateId(1); (u16::MAX as usize) + 1];
+    let goto_table = vec![goto_row];
+
+    let result = compressor.compress_goto_table_small(&goto_table);
+    let err = result.expect_err("goto row offsets > u16::MAX must fail compression");
+    let msg = err.to_string();
+    assert!(msg.contains("goto row offset"));
+    assert!(msg.contains("exceeds u16::MAX"));
+}

--- a/tablegen/tests/compression_comprehensive_tablegen.rs
+++ b/tablegen/tests/compression_comprehensive_tablegen.rs
@@ -778,11 +778,11 @@ fn multiple_compressions_identical() {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// TEST 21: Compression handles boundary state IDs
+// TEST 21: Compression rejects out-of-range small-table state IDs
 // ═══════════════════════════════════════════════════════════════════════════
 
 #[test]
-fn compression_handles_boundary_state_ids() {
+fn compression_rejects_out_of_range_small_table_state_ids() {
     let mut table = make_empty_table(5, 3, 1, 0);
 
     // Use boundary state IDs
@@ -797,7 +797,14 @@ fn compression_handles_boundary_state_ids() {
 
     let compressor = TableCompressor::new();
     let result = compressor.compress(&table, &[1, 2, 3, 4], false);
-    assert!(result.is_ok(), "Should handle boundary state IDs");
+    match result {
+        Ok(_) => panic!("small-table compression must reject out-of-range shift states"),
+        Err(err) => {
+            let msg = err.to_string();
+            assert!(msg.contains("Shift state"));
+            assert!(msg.contains("too large for small table encoding"));
+        }
+    }
 }
 
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
### Motivation
- Prevent silent u16 truncation/wrapping in tablegen compression paths so oversized parse-table IDs cause explicit failures instead of corrupt compressed tables.

### Description
- Added `TableCompressor::checked_u16` to centralize u16-width checks and return `TableGenError::Compression` with actionable context when a value exceeds `u16::MAX`.
- Applied `checked_u16` to record and finalize compressed `action` and `goto` row offsets and to validate action symbol IDs before emitting `CompressedActionEntry` values in `compress_action_table_small` and `compress_goto_table_small` in `tablegen/src/compress.rs`.
- Enforced per-entry small-table action validation by calling `encode_action_small` for every non-`Error` action during action-table compression so out-of-range shift/reduce IDs fail compression with clear messages.
- Added and updated unit/integration tests to assert explicit failures for oversized IDs: tests for action symbol overflow, action row-offset overflow, goto row-offset overflow, and updated the boundary-state test to expect rejection of out-of-range small-table shift states (files under `tablegen/tests/*`).

### Testing
- Ran `cargo fmt --all --check` and it passed. 
- Ran `cargo test -p adze-tablegen compression -- --nocapture` and compression tests passed after the changes. 
- Ran `cargo test -p adze-tablegen validation -- --nocapture` and validation tests passed. 
- Ran `cargo test -p adze-tablegen --all-features --no-run` (build-only check) and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a5d10e483338e930f0ecb2aca5e)