### PR TITLE
Preserve Accept-on-EOF across tablegen roundtrips

### DIFF
--- a/tablegen/src/compress.rs
+++ b/tablegen/src/compress.rs
@@ -53,10 +53,61 @@ pub struct CompressedTables {
 impl CompressedTables {
     /// Validate compressed tables against original parse table
     #[must_use = "validation result must be checked"]
-    pub fn validate(&self, _parse_table: &ParseTable) -> Result<()> {
-        // TODO: Implement validation logic
-        // For now, just return Ok to make tests compile
+    pub fn validate(&self, parse_table: &ParseTable) -> Result<()> {
+        let state_count = parse_table.state_count;
+        if self.action_table.row_offsets.len() != state_count + 1 {
+            return Err(TableGenError::InvalidTable(format!(
+                "Compressed action row_offsets length {} does not match state_count + 1 ({})",
+                self.action_table.row_offsets.len(),
+                state_count + 1
+            )));
+        }
+
+        let eof_index = *parse_table
+            .symbol_to_index
+            .get(&parse_table.eof_symbol)
+            .ok_or_else(|| {
+                TableGenError::InvalidTable(format!(
+                    "EOF symbol {} is not present in symbol_to_index",
+                    parse_table.eof_symbol.0
+                ))
+            })?;
+
+        let mut source_accepting_states = Vec::new();
+        for state in 0..state_count {
+            if parse_table.action_table[state]
+                .get(eof_index)
+                .is_some_and(|cell| cell.iter().any(|a| matches!(a, Action::Accept)))
+            {
+                source_accepting_states.push(state);
+            }
+        }
+
+        if source_accepting_states.is_empty() {
+            return Err(TableGenError::InvalidTable(
+                "Source parse table has no Accept action on EOF".to_string(),
+            ));
+        }
+
+        for state in source_accepting_states {
+            if !self.has_action(state, eof_index, &Action::Accept) {
+                return Err(TableGenError::InvalidTable(format!(
+                    "Accept on EOF lost during compression for state {} (EOF column {})",
+                    state, eof_index
+                )));
+            }
+        }
+
         Ok(())
+    }
+
+    fn has_action(&self, state: usize, symbol_index: usize, expected: &Action) -> bool {
+        let start = self.action_table.row_offsets[state] as usize;
+        let end = self.action_table.row_offsets[state + 1] as usize;
+
+        self.action_table.data[start..end]
+            .iter()
+            .any(|entry| entry.symbol as usize == symbol_index && entry.action == *expected)
     }
 }
 
@@ -640,26 +691,54 @@ mod tests {
     fn test_compressed_tables_validation() {
         let tables = CompressedTables {
             action_table: CompressedActionTable {
-                data: vec![],
-                row_offsets: vec![],
-                default_actions: vec![],
+                data: vec![CompressedActionEntry::new(1, Action::Accept)],
+                row_offsets: vec![0, 1],
+                default_actions: vec![Action::Error],
             },
             goto_table: CompressedGotoTable {
                 data: vec![],
-                row_offsets: vec![],
+                row_offsets: vec![0, 0],
             },
             small_table_threshold: 32768,
         };
 
         let parse_table = crate::test_helpers::test::make_minimal_table(
-            vec![vec![vec![]]], // 1 state, 1 symbol (minimum required)
+            vec![vec![vec![], vec![Action::Accept]]], // 1 state, 2 symbols; Accept on EOF
             vec![vec![crate::test_helpers::test::INVALID]], // 1 state, 1 symbol
-            vec![],             // 0 rules
-            SymbolId(1),        // start_symbol
-            SymbolId(1),        // eof_symbol (must be >= 1)
-            0,                  // external_token_count
+            vec![],                                   // 0 rules
+            SymbolId(1),                              // start_symbol
+            SymbolId(1),                              // eof_symbol (must be >= 1)
+            0,                                        // external_token_count
         );
         let result = tables.validate(&parse_table);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_compressed_tables_validation_rejects_missing_eof_accept() {
+        let tables = CompressedTables {
+            action_table: CompressedActionTable {
+                data: vec![],
+                row_offsets: vec![0, 0],
+                default_actions: vec![Action::Error],
+            },
+            goto_table: CompressedGotoTable {
+                data: vec![],
+                row_offsets: vec![0, 0],
+            },
+            small_table_threshold: 32768,
+        };
+
+        let parse_table = crate::test_helpers::test::make_minimal_table(
+            vec![vec![vec![], vec![Action::Accept]]], // 1 state, 2 symbols; Accept on EOF
+            vec![vec![crate::test_helpers::test::INVALID]], // 1 state, 1 symbol
+            vec![],                                   // 0 rules
+            SymbolId(1),                              // start_symbol
+            SymbolId(1),                              // eof_symbol (must be >= 1)
+            0,                                        // external_token_count
+        );
+
+        let result = tables.validate(&parse_table);
+        assert!(result.is_err());
     }
 }

--- a/tablegen/tests/compression_roundtrip_comprehensive.rs
+++ b/tablegen/tests/compression_roundtrip_comprehensive.rs
@@ -1640,3 +1640,44 @@ fn action_entries_preserve_action_types() {
     assert!(matches!(compressed.data[2].action, Action::Accept));
     assert!(matches!(compressed.data[3].action, Action::Recover));
 }
+
+#[test]
+fn eof_accept_is_preserved_by_table_compressor_validation() {
+    let (parse_table, compressed) = pipeline(|| {
+        GrammarBuilder::new("accept_eof_roundtrip")
+            .token("a", "a")
+            .rule("start", vec!["a"])
+            .start("start")
+            .build()
+    });
+
+    compressed
+        .validate(&parse_table)
+        .expect("compressed tables must preserve Accept on EOF");
+}
+
+#[test]
+fn eof_accept_validation_rejects_corrupted_compressed_tables() {
+    let (parse_table, mut compressed) = pipeline(|| {
+        GrammarBuilder::new("accept_eof_negative")
+            .token("a", "a")
+            .rule("start", vec!["a"])
+            .start("start")
+            .build()
+    });
+
+    let eof_idx = parse_table.symbol_to_index[&parse_table.eof_symbol] as u16;
+    compressed
+        .action_table
+        .data
+        .retain(|entry| !(entry.symbol == eof_idx && matches!(entry.action, Action::Accept)));
+    if let Some(last) = compressed.action_table.row_offsets.last_mut() {
+        *last = compressed.action_table.data.len() as u16;
+    }
+
+    let result = compressed.validate(&parse_table);
+    assert!(
+        result.is_err(),
+        "validation should fail when Accept on EOF is removed"
+    );
+}

--- a/tablegen/tests/serializer_comprehensive.rs
+++ b/tablegen/tests/serializer_comprehensive.rs
@@ -1393,3 +1393,36 @@ fn large_state_count_is_always_zero() {
     let deser: SerializableLanguage = serde_json::from_str(&json).unwrap();
     assert_eq!(deser.large_state_count, 0);
 }
+
+#[test]
+fn serialize_preserves_accept_on_eof_in_parse_table_data() {
+    let grammar = grammar_with(&["a"], &["start"]);
+    let pt = make_empty_table(1, 1, 1, 0);
+    let eof_col = *pt.symbol_to_index.get(&pt.eof_symbol).unwrap() as u16;
+
+    let compressed = make_compressed(
+        vec![
+            CompressedActionEntry::new(eof_col, Action::Accept),
+            CompressedActionEntry::new(1, Action::Shift(StateId(1))),
+        ],
+        vec![0, 2],
+        vec![Action::Error],
+        vec![],
+        vec![0, 0],
+    );
+
+    let json = serialize_language(&grammar, &pt, Some(&compressed)).unwrap();
+    let deser: SerializableLanguage = serde_json::from_str(&json).unwrap();
+
+    let row_start = deser.small_parse_table_map[0] as usize;
+    let row_end = deser.small_parse_table_map[1] as usize;
+    let row_slice = &deser.parse_table[row_start * 2..row_end * 2];
+
+    let has_accept_on_eof = row_slice
+        .chunks_exact(2)
+        .any(|chunk| chunk[0] == eof_col && chunk[1] == 0xFFFF);
+    assert!(
+        has_accept_on_eof,
+        "serialized parse_table must contain Accept (0xFFFF) on EOF symbol"
+    );
+}


### PR DESCRIPTION
### Motivation
- The compression → serialization → runtime decode pipeline risked losing the critical `Accept` action on EOF when packing ACTION rows into compressed entries, which can make a parser incorrectly reject complete input. 
- The change enforces the invariant that any state accepting on EOF in the source `ParseTable` must still have an `Accept` entry in the compressed/action-row representation so regressions are caught early.

### Description
- Implement `CompressedTables::validate(parse_table: &ParseTable)` to verify `action_table.row_offsets` shape, that the table exposes `eof_symbol`, and that every source state with `Accept` on EOF still has an `Accept` entry in the compressed rows, and add a helper `has_action` to inspect the compressed slice. 
- Add positive and negative unit tests for the validator in `tablegen/src/compress.rs` that assert acceptance when preserved and rejection when EOF `Accept` is removed. 
- Add integration roundtrip tests in `tablegen/tests/compression_roundtrip_comprehensive.rs` to exercise the pipeline and ensure the compressor preserves EOF-`Accept`, and add a serializer-level test in `tablegen/tests/serializer_comprehensive.rs` that asserts the serialized `parse_table` contains `(EOF, 0xFFFF)`. 
- Keep changes limited to tablegen and tests; no runtime parser logic or CLI/docs/dependencies were changed.

### Testing
- Ran formatting check with `cargo fmt --all --check`, which passed after fixes. 
- Ran `cargo test -p adze-tablegen --test compression_roundtrip_comprehensive -- --nocapture`, which passed (all tests in that test binary: 94 passed). 
- Ran `cargo test -p adze-tablegen --test serializer_comprehensive -- --nocapture`, which passed (75 passed). 
- Ran `cargo test -p adze-glr-core eof -- --nocapture`, which passed (all EOF-related tests passed). 
- Unit tests added include both acceptance and negative failure cases for EOF/Accept preservation and serializer assertions verifying `0xFFFF` appears for `Accept` on EOF.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a59684c83338221e5a069efcd6f)