### PR TITLE
Enforce Accept-on-EOF preservation through tablegen compression + serialization

### DIFF
--- a/tablegen/src/compress.rs
+++ b/tablegen/src/compress.rs
@@ -53,9 +53,86 @@ pub struct CompressedTables {
 impl CompressedTables {
     /// Validate compressed tables against original parse table
     #[must_use = "validation result must be checked"]
-    pub fn validate(&self, _parse_table: &ParseTable) -> Result<()> {
-        // TODO: Implement validation logic
-        // For now, just return Ok to make tests compile
+    pub fn validate(&self, parse_table: &ParseTable) -> Result<()> {
+        // Allow trivially empty parse tables used by a few unit tests.
+        if parse_table.state_count == 0 {
+            return Ok(());
+        }
+
+        let expected_rows = parse_table.state_count + 1;
+        if self.action_table.row_offsets.len() != expected_rows {
+            return Err(TableGenError::Compression(format!(
+                "action row_offsets length mismatch: got {}, expected {}",
+                self.action_table.row_offsets.len(),
+                expected_rows
+            )));
+        }
+        if self.goto_table.row_offsets.len() != expected_rows {
+            return Err(TableGenError::Compression(format!(
+                "goto row_offsets length mismatch: got {}, expected {}",
+                self.goto_table.row_offsets.len(),
+                expected_rows
+            )));
+        }
+        if self.action_table.default_actions.len() != parse_table.state_count {
+            return Err(TableGenError::Compression(format!(
+                "default_actions length mismatch: got {}, expected {}",
+                self.action_table.default_actions.len(),
+                parse_table.state_count
+            )));
+        }
+
+        // Core invariant: every original accepting state must still expose Accept on EOF
+        // after compression.
+        let eof_col = *parse_table
+            .symbol_to_index
+            .get(&parse_table.eof_symbol)
+            .ok_or_else(|| {
+                TableGenError::Compression(format!(
+                    "EOF symbol {} missing from symbol_to_index",
+                    parse_table.eof_symbol.0
+                ))
+            })?;
+
+        let mut missing_accept_states = Vec::new();
+        for state in 0..parse_table.state_count {
+            let original_accepts_eof = parse_table.action_table[state]
+                .get(eof_col)
+                .is_some_and(|cell| cell.iter().any(|a| matches!(a, Action::Accept)));
+            if !original_accepts_eof {
+                continue;
+            }
+
+            let row_start = self.action_table.row_offsets[state] as usize;
+            let row_end = self.action_table.row_offsets[state + 1] as usize;
+            if row_end > self.action_table.data.len() || row_start > row_end {
+                return Err(TableGenError::Compression(format!(
+                    "invalid action row slice for state {}: {}..{} (len={})",
+                    state,
+                    row_start,
+                    row_end,
+                    self.action_table.data.len()
+                )));
+            }
+
+            let compressed_accepts_eof =
+                self.action_table.data[row_start..row_end]
+                    .iter()
+                    .any(|entry| {
+                        entry.symbol as usize == eof_col && matches!(entry.action, Action::Accept)
+                    });
+            if !compressed_accepts_eof {
+                missing_accept_states.push(state);
+            }
+        }
+
+        if !missing_accept_states.is_empty() {
+            return Err(TableGenError::Compression(format!(
+                "Accept-on-EOF lost for states {:?}",
+                missing_accept_states
+            )));
+        }
+
         Ok(())
     }
 }

--- a/tablegen/tests/compression_roundtrip_comprehensive.rs
+++ b/tablegen/tests/compression_roundtrip_comprehensive.rs
@@ -50,6 +50,17 @@ fn single_action_table(rows: Vec<Vec<Action>>) -> Vec<Vec<Vec<Action>>> {
         .collect()
 }
 
+fn accepting_states_on_eof(table: &adze_glr_core::ParseTable) -> Vec<usize> {
+    let eof_col = table.symbol_to_index[&table.eof_symbol];
+    (0..table.state_count)
+        .filter(|&state| {
+            table.action_table[state]
+                .get(eof_col)
+                .is_some_and(|cell| cell.iter().any(|a| matches!(a, Action::Accept)))
+        })
+        .collect()
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // 1. Compression of parse tables from simple grammars
 // ═══════════════════════════════════════════════════════════════════════════
@@ -772,9 +783,63 @@ fn pipeline_validates_compressed_tables() {
             .start("start")
             .build()
     });
-    // validate() currently returns Ok unconditionally, but this tests the API
     let result = compressed.validate(&pt);
     assert!(result.is_ok(), "validation should pass: {:?}", result.err());
+}
+
+#[test]
+fn pipeline_preserves_accept_on_eof_for_each_accepting_state() {
+    let (pt, compressed) = pipeline(|| {
+        GrammarBuilder::new("accept_eof_roundtrip")
+            .token("a", "a")
+            .rule("start", vec!["a"])
+            .start("start")
+            .build()
+    });
+
+    let accepting_states = accepting_states_on_eof(&pt);
+    assert!(
+        !accepting_states.is_empty(),
+        "source parse table must have at least one accepting state on EOF"
+    );
+
+    compressed
+        .validate(&pt)
+        .expect("compressed table should preserve Accept on EOF");
+}
+
+#[test]
+fn validation_rejects_missing_accept_on_eof_after_tamper() {
+    let (pt, mut compressed) = pipeline(|| {
+        GrammarBuilder::new("accept_eof_negative")
+            .token("a", "a")
+            .rule("start", vec!["a"])
+            .start("start")
+            .build()
+    });
+
+    let eof_col = pt.symbol_to_index[&pt.eof_symbol] as u16;
+    let accept_state = accepting_states_on_eof(&pt)
+        .into_iter()
+        .next()
+        .expect("expected at least one accepting state");
+
+    let row_start = compressed.action_table.row_offsets[accept_state] as usize;
+    let row_end = compressed.action_table.row_offsets[accept_state + 1] as usize;
+    let accept_entry_index = compressed.action_table.data[row_start..row_end]
+        .iter()
+        .position(|entry| entry.symbol == eof_col && matches!(entry.action, Action::Accept))
+        .expect("accept action for EOF must exist before tampering");
+    compressed.action_table.data[row_start + accept_entry_index].action = Action::Error;
+
+    let err = compressed
+        .validate(&pt)
+        .expect_err("validation must fail when Accept-on-EOF is removed");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Accept-on-EOF lost"),
+        "error should mention Accept-on-EOF loss, got: {msg}"
+    );
 }
 
 #[test]

--- a/tablegen/tests/serializer_comprehensive.rs
+++ b/tablegen/tests/serializer_comprehensive.rs
@@ -9,7 +9,10 @@
 
 use std::collections::BTreeMap;
 
-use adze_glr_core::{Action, GotoIndexing, LexMode, ParseTable};
+use adze_glr_core::{
+    Action, FirstFollowSets, GotoIndexing, LexMode, ParseTable, build_lr1_automaton,
+};
+use adze_ir::builder::GrammarBuilder;
 use adze_ir::{
     ExternalToken, FieldId, Grammar, ProductionId, Rule, RuleId, StateId, Symbol, SymbolId, Token,
     TokenPattern,
@@ -19,6 +22,7 @@ use adze_tablegen::compress::{
     CompressedTables,
 };
 use adze_tablegen::serializer::{SerializableLanguage, SerializableLexState, serialize_language};
+use adze_tablegen::{TableCompressor, collect_token_indices, eof_accepts_or_reduces};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -600,6 +604,56 @@ fn serialize_compressed_tables_row_offsets_preserved() {
     assert_eq!(offsets[0].as_u64().unwrap(), 0);
     assert_eq!(offsets[1].as_u64().unwrap(), 2);
     assert_eq!(offsets[2].as_u64().unwrap(), 3);
+}
+
+#[test]
+fn serialize_compressed_tables_preserves_accept_on_eof_entries() {
+    let mut grammar = GrammarBuilder::new("serialize_accept_eof")
+        .token("a", "a")
+        .rule("start", vec!["a"])
+        .start("start")
+        .build();
+    let ff = FirstFollowSets::compute_normalized(&mut grammar).expect("first/follow");
+    let parse_table = build_lr1_automaton(&grammar, &ff).expect("lr automaton");
+    let token_indices = collect_token_indices(&grammar, &parse_table);
+    let compressed = TableCompressor::new()
+        .compress(
+            &parse_table,
+            &token_indices,
+            eof_accepts_or_reduces(&parse_table),
+        )
+        .expect("compress");
+
+    let eof_col = parse_table.symbol_to_index[&parse_table.eof_symbol] as u16;
+    let accepting_states: Vec<_> = (0..parse_table.state_count)
+        .filter(|&state| {
+            parse_table.action_table[state][eof_col as usize]
+                .iter()
+                .any(|a| matches!(a, Action::Accept))
+        })
+        .collect();
+    assert!(
+        !accepting_states.is_empty(),
+        "expected at least one accepting state on EOF before serialization"
+    );
+
+    let json = adze_tablegen::serializer::serialize_compressed_tables(&compressed).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let entries = v["action_table"]["entries"].as_array().unwrap();
+    let row_offsets = v["action_table"]["row_offsets"].as_array().unwrap();
+
+    for state in accepting_states {
+        let row_start = row_offsets[state].as_u64().unwrap() as usize;
+        let row_end = row_offsets[state + 1].as_u64().unwrap() as usize;
+        let has_accept_on_eof = (row_start..row_end).any(|i| {
+            let pair = entries[i].as_array().unwrap();
+            pair[0].as_u64().unwrap() as u16 == eof_col && pair[1].as_str().unwrap() == "Accept"
+        });
+        assert!(
+            has_accept_on_eof,
+            "serialized compressed row for state {state} lost Accept on EOF"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- Parse table compression and serialization previously had no strong validator ensuring an original Accept on EOF remained present after transformation, which can cause parsers to reject complete input.
- The compressed action-table (and its serialized form) is the highest-risk representation for silently losing EOF Accept entries and needs an invariant check in tablegen.

### Description
- Implemented `CompressedTables::validate` in `tablegen/src/compress.rs` to perform structural checks and enforce the Accept-on-EOF invariant across compression, returning a clear `TableGenError::Compression` when violated.
- The validator checks `row_offsets`/`default_actions` lengths, verifies EOF is present in `symbol_to_index`, and ensures every state that originally had `Accept` on EOF still has an explicit `Accept` entry in the compressed action rows.
- Added tests in `tablegen/tests/compression_roundtrip_comprehensive.rs` that (a) assert Accept-on-EOF is preserved after compression and (b) mutate a compressed row to remove the Accept and assert validation fails.
- Added a serialization-level test in `tablegen/tests/serializer_comprehensive.rs` that compresses a table, serializes the compressed tables to JSON, and asserts serialized rows still contain `(EOF, "Accept")` entries for accepting states.

### Testing
- Ran `cargo test -p adze-tablegen --test compression_roundtrip_comprehensive -- --nocapture` and the suite passed (new positive/negative tests exercised and passed).
- Ran `cargo test -p adze-tablegen --test serializer_comprehensive -- --nocapture` and the suite passed (serialization-level Accept-on-EOF checks passed).
- Ran `cargo test -p adze-glr-core eof -- --nocapture` and the EOF handling tests passed.
- Ran `cargo fmt --all --check` (formatting check passed).
- Ran `cargo test -p adze --test test_normalization decoded_table_has_accept_and_same_sizes -- --ignored --nocapture`; this runtime decode-side test failed (known issue) and was left unchanged per constraints not to change runtime parser logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a59684c83338221e5a069efcd6f)