### PR TITLE
Enforce Accept-on-EOF preservation in tablegen compression and serializer roundtrips

### DIFF
--- a/tablegen/src/compress.rs
+++ b/tablegen/src/compress.rs
@@ -53,9 +53,56 @@ pub struct CompressedTables {
 impl CompressedTables {
     /// Validate compressed tables against original parse table
     #[must_use = "validation result must be checked"]
-    pub fn validate(&self, _parse_table: &ParseTable) -> Result<()> {
-        // TODO: Implement validation logic
-        // For now, just return Ok to make tests compile
+    pub fn validate(&self, parse_table: &ParseTable) -> Result<()> {
+        let state_count = parse_table.state_count;
+
+        if self.action_table.row_offsets.len() != state_count + 1 {
+            return Err(TableGenError::InvalidTable(format!(
+                "action row_offsets length {} must equal state_count + 1 ({})",
+                self.action_table.row_offsets.len(),
+                state_count + 1
+            )));
+        }
+
+        if self.goto_table.row_offsets.len() != state_count + 1 {
+            return Err(TableGenError::InvalidTable(format!(
+                "goto row_offsets length {} must equal state_count + 1 ({})",
+                self.goto_table.row_offsets.len(),
+                state_count + 1
+            )));
+        }
+
+        let eof_col = *parse_table
+            .symbol_to_index
+            .get(&parse_table.eof_symbol)
+            .ok_or_else(|| {
+                TableGenError::InvalidTable(format!(
+                    "EOF symbol {} not found in symbol_to_index",
+                    parse_table.eof_symbol.0
+                ))
+            })?;
+
+        for state in 0..state_count {
+            let original_has_accept_on_eof = parse_table
+                .action_table
+                .get(state)
+                .and_then(|row| row.get(eof_col))
+                .is_some_and(|cell| cell.iter().any(|a| matches!(a, Action::Accept)));
+
+            let compressed_has_accept_on_eof = self
+                .action_table
+                .actions_for_cell(state, eof_col)?
+                .iter()
+                .any(|a| matches!(a, Action::Accept));
+
+            if original_has_accept_on_eof != compressed_has_accept_on_eof {
+                return Err(TableGenError::InvalidTable(format!(
+                    "Accept-on-EOF mismatch at state {} (eof_col {}): original={}, compressed={}",
+                    state, eof_col, original_has_accept_on_eof, compressed_has_accept_on_eof
+                )));
+            }
+        }
+
         Ok(())
     }
 }
@@ -66,6 +113,36 @@ pub struct CompressedActionTable {
     pub data: Vec<CompressedActionEntry>,
     pub row_offsets: Vec<u16>,
     pub default_actions: Vec<Action>,
+}
+
+impl CompressedActionTable {
+    fn actions_for_cell(&self, state: usize, symbol: usize) -> Result<Vec<&Action>> {
+        let start = *self.row_offsets.get(state).ok_or_else(|| {
+            TableGenError::InvalidTable(format!("missing action row_offset for state {}", state))
+        })? as usize;
+        let end = *self.row_offsets.get(state + 1).ok_or_else(|| {
+            TableGenError::InvalidTable(format!(
+                "missing action row_offset sentinel for state {}",
+                state
+            ))
+        })? as usize;
+
+        if end < start || end > self.data.len() {
+            return Err(TableGenError::InvalidTable(format!(
+                "invalid action row range for state {}: start={}, end={}, data_len={}",
+                state,
+                start,
+                end,
+                self.data.len()
+            )));
+        }
+
+        Ok(self.data[start..end]
+            .iter()
+            .filter(|entry| entry.symbol as usize == symbol)
+            .map(|entry| &entry.action)
+            .collect())
+    }
 }
 
 /// Entry in the action table

--- a/tablegen/tests/compression_roundtrip_comprehensive.rs
+++ b/tablegen/tests/compression_roundtrip_comprehensive.rs
@@ -772,9 +772,78 @@ fn pipeline_validates_compressed_tables() {
             .start("start")
             .build()
     });
-    // validate() currently returns Ok unconditionally, but this tests the API
     let result = compressed.validate(&pt);
     assert!(result.is_ok(), "validation should pass: {:?}", result.err());
+}
+
+#[test]
+fn validate_preserves_accept_on_eof_for_all_accepting_states() {
+    let (pt, compressed) = pipeline(|| {
+        GrammarBuilder::new("accept_eof_validate")
+            .token("a", "a")
+            .rule("list", vec!["a"])
+            .rule("list", vec!["list", "a"])
+            .start("list")
+            .build()
+    });
+
+    let eof_col = *pt
+        .symbol_to_index
+        .get(&pt.eof_symbol)
+        .expect("EOF must be present");
+
+    let accepting_states: Vec<_> = (0..pt.state_count)
+        .filter(|&state| {
+            pt.action_table[state][eof_col]
+                .iter()
+                .any(|a| matches!(a, Action::Accept))
+        })
+        .collect();
+    assert!(
+        !accepting_states.is_empty(),
+        "expected at least one accepting state on EOF"
+    );
+
+    assert!(
+        compressed.validate(&pt).is_ok(),
+        "compressed table must preserve Accept-on-EOF"
+    );
+}
+
+#[test]
+fn validate_rejects_when_accept_on_eof_is_dropped() {
+    let (pt, mut compressed) = pipeline(|| {
+        GrammarBuilder::new("accept_eof_negative")
+            .token("a", "a")
+            .rule("start", vec!["a"])
+            .start("start")
+            .build()
+    });
+
+    let eof_col = *pt
+        .symbol_to_index
+        .get(&pt.eof_symbol)
+        .expect("EOF must be present") as u16;
+
+    if let Some(entry) = compressed
+        .action_table
+        .data
+        .iter_mut()
+        .find(|entry| entry.symbol == eof_col && matches!(entry.action, Action::Accept))
+    {
+        entry.action = Action::Error;
+    } else {
+        panic!("failed to locate Accept-on-EOF entry to corrupt");
+    }
+
+    let err = compressed
+        .validate(&pt)
+        .expect_err("validation should fail when Accept-on-EOF is removed");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Accept-on-EOF mismatch"),
+        "unexpected error message: {msg}"
+    );
 }
 
 #[test]

--- a/tablegen/tests/serializer_comprehensive.rs
+++ b/tablegen/tests/serializer_comprehensive.rs
@@ -236,6 +236,27 @@ fn serialize_accept_action_encoding() {
 }
 
 #[test]
+fn serialize_roundtrip_preserves_accept_on_eof_encoding() {
+    let grammar = Grammar::new("accept_eof_roundtrip".to_string());
+    let pt = make_empty_table(1, 0, 1, 0);
+
+    let compressed = make_compressed(
+        vec![CompressedActionEntry::new(0, Action::Accept)],
+        vec![0, 1],
+        vec![Action::Error],
+        vec![],
+        vec![0, 0],
+    );
+
+    let json = serialize_language(&grammar, &pt, Some(&compressed)).unwrap();
+    let deser: SerializableLanguage = serde_json::from_str(&json).unwrap();
+
+    // Action entry layout is [symbol, action_code], and Accept must be encoded as 0xFFFF.
+    assert_eq!(deser.parse_table[0], 0);
+    assert_eq!(deser.parse_table[1], 0xFFFF);
+}
+
+#[test]
 fn serialize_error_action_encoding() {
     let compressed = make_compressed(
         vec![CompressedActionEntry::new(1, Action::Error)],


### PR DESCRIPTION
### Motivation
- Previous `CompressedTables::validate` was a no-op, allowing compressed representations to silently lose Accept-on-EOF information which can cause parsers to reject otherwise-complete input. 
- The goal is to ensure the compression → serialization → decode pipeline preserves the Accept-on-EOF invariant across representations.
- Add validators and tests in `tablegen` so the tablegen stage rejects transformed tables that drop Accept-on-EOF before they reach runtime.

### Description
- Implemented `CompressedTables::validate` in `tablegen/src/compress.rs` to perform structural checks and enforce Accept-on-EOF preservation by state, including verifying `row_offsets` lengths for action/goto tables and resolving EOF column via `parse_table.eof_symbol`. 
- Added `CompressedActionTable::actions_for_cell` to safely read actions for a given `(state, symbol)` with bounds and range validation, and used it from the new validator. 
- Added tests in `tablegen/tests/compression_roundtrip_comprehensive.rs` to assert a positive invariant that accepting states keep `Accept` on EOF after compression and a negative test that corrupts a compressed table and expects validation to fail with an Accept-on-EOF mismatch. 
- Added a serializer unit test in `tablegen/tests/serializer_comprehensive.rs` to ensure the Accept action encodes as `0xFFFF` and survives JSON serialization/deserialization for compressed tables.

### Testing
- Ran `cargo test -p adze-tablegen --test compression_roundtrip_comprehensive -- --nocapture` and all tests passed (94 passed, 0 failed). 
- Ran `cargo test -p adze-tablegen --test serializer_comprehensive -- --nocapture` and all tests passed (75 passed, 0 failed). 
- Ran `cargo fmt --all --check` which succeeded after formatting changes. 
- Note: an attempt to run `cargo test -p adze-glr-core eof -- --nocapture` did not complete in the session used for this change, but the `tablegen` coverage now enforces Accept-on-EOF preservation earlier in the pipeline so the invariant is caught at compression/serialization time.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a59684c83338221e5a069efcd6f)