### PR TITLE
Enforce valid external scanner symbols at dispatch

### DIFF
--- a/runtime/src/external_scanner.rs
+++ b/runtime/src/external_scanner.rs
@@ -132,6 +132,21 @@ impl ExternalScannerRuntime {
 
         // Scan for external tokens
         if let Some(result) = scanner.scan(lexer, &valid_symbols) {
+            let emitted = result.symbol;
+            let by_index = usize::from(emitted);
+            let is_valid = valid_symbols.get(by_index).copied().unwrap_or(false)
+                || self
+                    .external_tokens
+                    .iter()
+                    .position(|token| *token == emitted)
+                    .and_then(|idx| valid_symbols.get(idx))
+                    .copied()
+                    .unwrap_or(false);
+
+            if !is_valid {
+                return None;
+            }
+
             // Serialize updated state
             self.state.data.clear();
             scanner.serialize(&mut self.state.data);

--- a/runtime/src/parser.rs
+++ b/runtime/src/parser.rs
@@ -439,12 +439,14 @@ impl Parser {
             }
 
             if success && lexer.result_symbol > 0 {
+                let symbol_index = lexer.result_symbol as usize;
+                if symbol_index >= external_token_count || !valid_symbols[symbol_index] {
+                    return None;
+                }
+
                 // Map external symbol to actual symbol
                 let symbol = if !lang.external_scanner.symbol_map.is_null() {
-                    *lang
-                        .external_scanner
-                        .symbol_map
-                        .add(lexer.result_symbol as usize)
+                    *lang.external_scanner.symbol_map.add(symbol_index)
                 } else {
                     lexer.result_symbol
                 };

--- a/runtime/src/parser_v4.rs
+++ b/runtime/src/parser_v4.rs
@@ -1209,6 +1209,20 @@ impl Parser {
         self.external_scanner = Some(scanner);
 
         if let Some(result) = scan_result {
+            let emitted_symbol = SymbolId(result.symbol);
+            let valid_for_state = self
+                .grammar
+                .externals
+                .iter()
+                .position(|external| external.symbol_id == emitted_symbol)
+                .and_then(|idx| valid_symbols.get(idx))
+                .copied()
+                .unwrap_or(false);
+
+            if !valid_for_state {
+                return Ok(None);
+            }
+
             // Extract token text
             let end = self.position + result.length;
             let text = if end <= self.input.len() {
@@ -1218,7 +1232,7 @@ impl Parser {
             };
 
             Ok(Some(LexerToken {
-                symbol: SymbolId(result.symbol),
+                symbol: emitted_symbol,
                 text,
                 start: self.position,
                 end,
@@ -1818,6 +1832,86 @@ mod tests {
         assert_eq!(scanned.end, 2);
         // Text is empty because position advanced past input during scan
         assert!(scanned.text.is_empty());
+    }
+
+    #[test]
+    fn test_external_scanner_result_must_be_valid_for_state() {
+        #[derive(Default)]
+        struct InvalidScanner;
+
+        impl crate::external_scanner::ExternalScanner for InvalidScanner {
+            fn scan(
+                &mut self,
+                _lexer: &mut dyn crate::external_scanner::Lexer,
+                _valid_symbols: &[bool],
+            ) -> Option<crate::external_scanner::ScanResult> {
+                // Emit DEDENT, even though only NEWLINE is valid in state 0.
+                Some(crate::external_scanner::ScanResult {
+                    symbol: 2,
+                    length: 1,
+                })
+            }
+
+            fn serialize(&self, _buffer: &mut Vec<u8>) {}
+
+            fn deserialize(&mut self, _buffer: &[u8]) {}
+        }
+
+        let language_name = "test_external_scanner_result_must_be_valid_for_state".to_string();
+        ExternalScannerBuilder::new(language_name.clone()).register_rust::<InvalidScanner>();
+
+        let mut grammar = Grammar::new(language_name.clone());
+        grammar.externals.push(adze_ir::ExternalToken {
+            name: "NEWLINE".to_string(),
+            symbol_id: SymbolId(0),
+        });
+        grammar.externals.push(adze_ir::ExternalToken {
+            name: "INDENT".to_string(),
+            symbol_id: SymbolId(1),
+        });
+        grammar.externals.push(adze_ir::ExternalToken {
+            name: "DEDENT".to_string(),
+            symbol_id: SymbolId(2),
+        });
+
+        let parse_table = ParseTable {
+            action_table: vec![],
+            goto_table: vec![],
+            symbol_metadata: vec![],
+            state_count: 0,
+            symbol_count: 0,
+            symbol_to_index: std::collections::BTreeMap::new(),
+            index_to_symbol: vec![],
+            external_scanner_states: vec![vec![true, false, false]],
+            rules: vec![],
+            nonterminal_to_index: std::collections::BTreeMap::new(),
+            goto_indexing: adze_glr_core::GotoIndexing::NonterminalMap,
+            eof_symbol: SymbolId(0),
+            start_symbol: SymbolId(1),
+            grammar: Grammar::default(),
+            initial_state: StateId(0),
+            token_count: 0,
+            external_token_count: 0,
+            lex_modes: vec![],
+            extras: vec![],
+            dynamic_prec_by_rule: vec![],
+            rule_assoc_by_rule: vec![],
+            alias_sequences: vec![],
+            field_names: vec![],
+            field_map: std::collections::BTreeMap::new(),
+        };
+
+        let mut parser = Parser::new(grammar, parse_table, language_name);
+        parser.input = b"
+"
+        .to_vec();
+        parser.position = 0;
+
+        let scanned = parser
+            .try_external_scanner(StateId(0))
+            .expect("external scanner dispatch should run");
+
+        assert!(scanned.is_none());
     }
 
     #[test]

--- a/runtime/src/pure_parser.rs
+++ b/runtime/src/pure_parser.rs
@@ -818,20 +818,20 @@ impl Parser {
                     && ext_lexer.result_symbol > 0
                     && (ext_lexer.result_symbol as usize) <= external_count
                 {
-                    let symbol = if !language.external_scanner.symbol_map.is_null() {
-                        *language
-                            .external_scanner
-                            .symbol_map
-                            .add(ext_lexer.result_symbol as usize)
-                    } else {
-                        ext_lexer.result_symbol
-                    };
+                    let symbol_index = ext_lexer.result_symbol as usize;
+                    if valid_symbols.get(symbol_index).copied().unwrap_or(0) != 0 {
+                        let symbol = if !language.external_scanner.symbol_map.is_null() {
+                            *language.external_scanner.symbol_map.add(symbol_index)
+                        } else {
+                            ext_lexer.result_symbol
+                        };
 
-                    return Token {
-                        symbol,
-                        length: ext_lexer.token_end,
-                        is_extra: false,
-                    };
+                        return Token {
+                            symbol,
+                            length: ext_lexer.token_end,
+                            is_extra: false,
+                        };
+                    }
                 }
             }
         }

--- a/runtime/tests/external_scanner_api_comprehensive.rs
+++ b/runtime/tests/external_scanner_api_comprehensive.rs
@@ -544,6 +544,54 @@ fn runtime_scan_builds_valid_symbols_from_tokens() {
 }
 
 #[test]
+fn runtime_rejects_token_not_enabled_by_valid_symbols() {
+    struct InvalidEmitter;
+    impl ExternalScanner for InvalidEmitter {
+        fn scan(&mut self, _lexer: &mut dyn Lexer, _valid_symbols: &[bool]) -> Option<ScanResult> {
+            // Emit token index 1 even when only index 0 is valid.
+            Some(ScanResult {
+                symbol: 1,
+                length: 1,
+            })
+        }
+        fn serialize(&self, _buffer: &mut Vec<u8>) {}
+        fn deserialize(&mut self, _buffer: &[u8]) {}
+    }
+
+    let mut runtime = ExternalScannerRuntime::new(vec![10, 20]);
+    let mut scanner = InvalidEmitter;
+    let mut lexer = TestLexer::new(b"x");
+    let valid: HashSet<u16> = [10].into_iter().collect();
+
+    let result = runtime.scan(&mut scanner, &mut lexer, &valid);
+    assert_eq!(result, None);
+}
+
+#[test]
+fn runtime_rejects_symbol_id_not_enabled_by_valid_symbols() {
+    struct InvalidEmitter;
+    impl ExternalScanner for InvalidEmitter {
+        fn scan(&mut self, _lexer: &mut dyn Lexer, _valid_symbols: &[bool]) -> Option<ScanResult> {
+            // Emit symbol id 20 while only symbol id 10 is valid.
+            Some(ScanResult {
+                symbol: 20,
+                length: 1,
+            })
+        }
+        fn serialize(&self, _buffer: &mut Vec<u8>) {}
+        fn deserialize(&mut self, _buffer: &[u8]) {}
+    }
+
+    let mut runtime = ExternalScannerRuntime::new(vec![10, 20]);
+    let mut scanner = InvalidEmitter;
+    let mut lexer = TestLexer::new(b"x");
+    let valid: HashSet<u16> = [10].into_iter().collect();
+
+    let result = runtime.scan(&mut scanner, &mut lexer, &valid);
+    assert_eq!(result, None);
+}
+
+#[test]
 fn runtime_persists_state_across_scans() {
     struct CountingScanner {
         counter: u8,


### PR DESCRIPTION
### Motivation
- Prevent external scanners from emitting tokens that are not legal in the current parser state by enforcing `valid_symbols` at each scanner dispatch point.
- Close a correctness hole where scanners that ignored `valid_symbols` could inject illegal externals and break parsing or recovery, without changing scanner internals or Python indentation semantics.

### Description
- Add post-scan validation in `ExternalScannerRuntime::scan` to reject emitted tokens that are not enabled by the `valid_symbols` view (supports both index-style and symbol-id-style emissions).
- Enforce validity in the FFI C-path by validating the emitted external-token index against the built `valid_symbols` before accepting it in `runtime/src/parser.rs` and `runtime/src/pure_parser.rs`.
- Enforce validity in the parser-v4 Rust scanner dispatch by mapping the emitted symbol back to the grammar's external token slot and ignoring emissions that are not valid for the current state in `runtime/src/parser_v4.rs`.
- Add focused regression/contract tests that simulate scanners with multiple possible external tokens and verify invalid emissions are dropped, and a parser-v4 test ensuring an invalid scanner emission is ignored; keep all changes localized to dispatch and tests.
- Intentionally avoid stabilizing Python indentation behavior; this change only hardens dispatch correctness and documents remaining integration TODOs.

### Testing
- Ran `cargo fmt --all --check` and it succeeded.
- Ran `cargo test -p adze --features external_scanners external -- --nocapture` and the targeted tests passed.
- Ran `cargo test -p adze --features external_scanners --test external_scanner_api_comprehensive runtime_rejects_ -- --nocapture` and the new runtime contract tests passed.
- Ran `cargo test -p adze-python-simple --no-run` which built successfully (tests not executed), verifying grammar crate compiles.

What changed in practice: the parser computes valid externals → builds the `valid_symbols` mask → passes it to the scanner → after the scanner returns the runtime now re-validates the emitted token and drops it if it isn't permitted for the current parse state, preventing scanners from forcing invalid externals through the parse flow.

Remaining work: `glr-core`/Tree-sitter lexer wrapper still has a TODO for wiring `_valid_symbols` into that lex path, and full Python indentation scanner maturity is out of scope for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a640f5483339efb551ce79dc705)