### PR TITLE
Expose incremental-parse telemetry: report reuse vs full-reparse fallback

### DIFF
--- a/docs/reference/known-limitations.md
+++ b/docs/reference/known-limitations.md
@@ -26,6 +26,7 @@ Tree-sitter compatible query support (`.scm` files) is under active development.
 ### 3. Incremental Parsing
 Reparsing only changed parts of a file is supported in the core engine but may fall back to full parses in complex GLR scenarios.
 - **Status**: Conservative fallback enabled; forest-splicing is experimental.
+- **Observability**: `IncrementalGLRParser::last_parse_report()` exposes whether the last call reused nodes or explicitly fell back, plus reused node count and invalidated ranges.
 
 ### 4. `transform` Closures
 There is a known bug (FR-005) where `transform` closures on leaf nodes are captured but not executed.

--- a/runtime/src/glr_incremental.rs
+++ b/runtime/src/glr_incremental.rs
@@ -88,6 +88,25 @@ pub fn get_reuse_count() -> usize {
     SUBTREE_REUSE_COUNT.load(Ordering::SeqCst)
 }
 
+/// How the most recent incremental parse request was executed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IncrementalExecution {
+    /// Parsed from scratch (no edits or no reusable baseline).
+    FreshParse,
+    /// Incremental request fell back to full reparse for correctness.
+    FullReparseFallback,
+    /// Incremental chunk splicing path executed and reused nodes.
+    IncrementalReuse,
+}
+
+/// Test-visible telemetry for the latest parse invocation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IncrementalParseReport {
+    pub execution: IncrementalExecution,
+    pub reused_node_count: usize,
+    pub invalidated_ranges: Vec<Range<usize>>,
+}
+
 /// Helper function to tokenize source code for arithmetic grammar
 #[allow(dead_code)]
 fn tokenize_source(source: &[u8], _grammar: &Grammar) -> Vec<GLRToken> {
@@ -389,6 +408,8 @@ pub struct IncrementalGLRParser {
     tokens: Vec<GLRToken>,
     /// Edit byte delta (new_text.len() - old_text.len())
     edit_byte_delta: isize,
+    /// Telemetry for last parse invocation.
+    last_report: Option<IncrementalParseReport>,
 }
 
 /// Tracks fork relationships and dependencies
@@ -459,6 +480,7 @@ impl IncrementalGLRParser {
             chunk_suffix_len: 0,
             tokens: vec![],
             edit_byte_delta: 0,
+            last_report: None,
         }
     }
 
@@ -481,6 +503,7 @@ impl IncrementalGLRParser {
             chunk_suffix_len: 0,
             tokens: vec![],
             edit_byte_delta: 0,
+            last_report: None,
         }
     }
 
@@ -490,8 +513,14 @@ impl IncrementalGLRParser {
         tokens: &[GLRToken],
         edits: &[GLREdit],
     ) -> Result<Arc<ForestNode>, String> {
+        let reuse_before = get_reuse_count();
+        let invalidated_ranges = edits
+            .iter()
+            .map(|e| e.old_range.clone())
+            .collect::<Vec<_>>();
+
         // If we have edits and a previous parse, try to reuse
-        if !edits.is_empty() {
+        let result = if !edits.is_empty() {
             // Check if we have an old forest to reuse from
             let has_old_forest =
                 edits.iter().any(|e| e.old_forest.is_some()) || self.previous_forest.is_some();
@@ -505,11 +534,36 @@ impl IncrementalGLRParser {
         } else {
             // No edits, fresh parse
             self.parse_fresh(tokens)
+        };
+
+        if result.is_ok() {
+            let execution = if edits.is_empty() {
+                IncrementalExecution::FreshParse
+            } else if self.chunk_prefix_len > 0 || self.chunk_suffix_len > 0 {
+                IncrementalExecution::IncrementalReuse
+            } else {
+                IncrementalExecution::FullReparseFallback
+            };
+
+            self.last_report = Some(IncrementalParseReport {
+                execution,
+                reused_node_count: get_reuse_count().saturating_sub(reuse_before),
+                invalidated_ranges,
+            });
         }
+
+        result
+    }
+
+    /// Returns the report from the most recent parse call.
+    pub fn last_parse_report(&self) -> Option<&IncrementalParseReport> {
+        self.last_report.as_ref()
     }
 
     /// Parse from scratch
     fn parse_fresh(&mut self, tokens: &[GLRToken]) -> Result<Arc<ForestNode>, String> {
+        self.chunk_prefix_len = 0;
+        self.chunk_suffix_len = 0;
         // Reset state
         self.fork_tracker = ForkTracker::new();
         // GSS snapshots removed - using direct forest splicing instead
@@ -613,6 +667,9 @@ impl IncrementalGLRParser {
             let edit_delta =
                 (edits[0].new_text.len() as isize) - (edits[0].old_range.len() as isize);
             let suffix_len = chunk_id.find_suffix_boundary(&old_tokens, tokens, edit_delta);
+            self.chunk_prefix_len = prefix_len;
+            self.chunk_suffix_len = suffix_len;
+            self.edit_byte_delta = edit_delta;
 
             // Debug chunk boundaries for troubleshooting
             debug_trace!(
@@ -822,6 +879,8 @@ impl IncrementalGLRParser {
             }
         } else {
             // No old forest, do fresh parse
+            self.chunk_prefix_len = 0;
+            self.chunk_suffix_len = 0;
             self.parse_fresh(tokens)
         }
     }

--- a/runtime/src/pure_incremental.rs
+++ b/runtime/src/pure_incremental.rs
@@ -39,6 +39,26 @@ pub struct ReusableNode {
     is_error: bool,
 }
 
+/// Mode used by the last incremental parse attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IncrementalParseMode {
+    /// Parsing was performed from scratch with no old tree context.
+    FreshParse,
+    /// An incremental parse was requested but implementation fell back to full reparse.
+    FullReparseFallback,
+}
+
+/// Test-visible report for the last parse attempt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IncrementalParseReport {
+    /// Whether parse ran fresh or as an explicit full-reparse fallback.
+    pub mode: IncrementalParseMode,
+    /// Number of nodes discovered as theoretically reusable from the previous tree.
+    pub reusable_nodes_found: usize,
+    /// Byte ranges invalidated by edits, if parse_with_edits was used.
+    pub invalidated_ranges: Vec<Range<usize>>,
+}
+
 impl Tree {
     /// Create a new tree from a parse result
     pub fn new(root: ParsedNode, language: &'static TSLanguage, source: &[u8]) -> Self {
@@ -112,6 +132,7 @@ impl Tree {
 pub struct IncrementalParser {
     parser: Parser,
     previous_tree: Option<Tree>,
+    last_report: Option<IncrementalParseReport>,
 }
 
 impl Default for IncrementalParser {
@@ -126,6 +147,7 @@ impl IncrementalParser {
         IncrementalParser {
             parser: Parser::new(),
             previous_tree: None,
+            last_report: None,
         }
     }
 
@@ -146,12 +168,17 @@ impl IncrementalParser {
 
     /// Parse with incremental reuse
     pub fn parse(&mut self, source: &str, old_tree: Option<&Tree>) -> ParseResult {
+        let mut mode = IncrementalParseMode::FreshParse;
+        let mut reusable_nodes_found = 0;
+
         // If we have an old tree, try to reuse nodes
         if let Some(tree) = old_tree {
             self.previous_tree = Some(tree.clone());
 
             // Get reusable nodes
-            let _reusable_nodes = tree.get_reusable_nodes();
+            let reusable_nodes = tree.get_reusable_nodes();
+            reusable_nodes_found = reusable_nodes.len();
+            mode = IncrementalParseMode::FullReparseFallback;
 
             // TODO: Implement actual incremental parsing logic
             // For now, fall back to full reparse
@@ -166,6 +193,12 @@ impl IncrementalParser {
         {
             self.previous_tree = Some(Tree::new(root.clone(), language, source.as_bytes()));
         }
+
+        self.last_report = Some(IncrementalParseReport {
+            mode,
+            reusable_nodes_found,
+            invalidated_ranges: Vec::new(),
+        });
 
         result
     }
@@ -185,7 +218,20 @@ impl IncrementalParser {
         }
 
         // Parse with the edited tree
-        self.parse(source, old_tree.as_ref())
+        let result = self.parse(source, old_tree.as_ref());
+        if let Some(report) = &mut self.last_report {
+            report.invalidated_ranges = edits
+                .iter()
+                .map(|e| e.start_byte..e.old_end_byte)
+                .collect::<Vec<_>>();
+        }
+        // Keep signature unchanged and return parse result.
+        result
+    }
+
+    /// Return telemetry for the last parse invocation.
+    pub fn last_parse_report(&self) -> Option<&IncrementalParseReport> {
+        self.last_report.as_ref()
     }
 }
 

--- a/runtime/tests/glr_incremental_comprehensive.rs
+++ b/runtime/tests/glr_incremental_comprehensive.rs
@@ -9,7 +9,7 @@
 mod tests {
     use adze::glr_incremental::{
         ChunkIdentifier, Edit, ForestNode, ForkAlternative, GLREdit, GLRToken,
-        IncrementalGLRParser, get_reuse_count, reset_reuse_counter,
+        IncrementalExecution, IncrementalGLRParser, get_reuse_count, reset_reuse_counter,
     };
     use adze::glr_lexer::{GLRLexer, TokenWithPosition};
     use adze::subtree::{Subtree, SubtreeNode};
@@ -694,7 +694,7 @@ mod tests {
         reset_reuse_counter();
         let f = p.parse_incremental(&new_toks, &[edit]).unwrap();
         assert!(!f.alternatives.is_empty());
-        assert!(get_reuse_count() <= new_toks.len());
+        assert!(get_reuse_count() > 0);
     }
 
     // ─── Test 23: Parse error on invalid input ──────────────────────
@@ -926,5 +926,54 @@ mod tests {
         assert_eq!(n2.byte_range, 5..15);
         let dbg = format!("{:?}", n2);
         assert!(dbg.contains("ForestNode"));
+    }
+
+    // ─── Test 34: Report marks explicit fallback when no reuse baseline ─────
+
+    #[test]
+    fn test_incremental_report_full_reparse_fallback() {
+        let g = arith_grammar();
+        let mut p = make_parser(&g);
+        let toks = to_glr(&tokenize(&g, "1+2+3"));
+        let edit = GLREdit {
+            old_range: 2..3,
+            new_text: b"9".to_vec(),
+            old_token_range: 1..2,
+            new_tokens: vec![make_token(1, b"9", 2)],
+            old_tokens: vec![],
+            old_forest: None,
+        };
+
+        let _ = p.parse_incremental(&toks, &[edit]).unwrap();
+        let report = p.last_parse_report().expect("report should be recorded");
+        assert_eq!(report.execution, IncrementalExecution::FullReparseFallback);
+        assert_eq!(report.invalidated_ranges, vec![2..3]);
+        assert_eq!(report.reused_node_count, 0);
+    }
+
+    // ─── Test 35: Report marks reuse path and captures invalidated range ─────
+
+    #[test]
+    fn test_incremental_report_reuse_path() {
+        let g = arith_grammar();
+        let mut p = make_parser(&g);
+        let (old_toks, old_forest) = fresh_parse(&mut p, &g, "1+2+3");
+        let new_toks = to_glr(&tokenize(&g, "1+9+3"));
+        reset_reuse_counter();
+
+        let edit = GLREdit {
+            old_range: 2..3,
+            new_text: b"9".to_vec(),
+            old_token_range: 2..3,
+            new_tokens: vec![new_toks[2].clone()],
+            old_tokens: old_toks,
+            old_forest: Some(old_forest),
+        };
+
+        let _ = p.parse_incremental(&new_toks, &[edit]).unwrap();
+        let report = p.last_parse_report().expect("report should be recorded");
+        assert_eq!(report.execution, IncrementalExecution::IncrementalReuse);
+        assert_eq!(report.invalidated_ranges, vec![2..3]);
+        assert!(report.reused_node_count > 0);
     }
 }


### PR DESCRIPTION
### Motivation
- Make the current conservative incremental behavior observable so tests and callers can tell when the system actually reused subtrees versus when it conservatively fell back to a full reparse.
- Surface simple, test-visible metrics (reuse count, invalidated ranges, and execution mode) without implementing a full forest-splicing completion beyond the already-present conservative splicing heuristics.

### Description
- Add test-visible telemetry types and accessors: `IncrementalParseReport` and `IncrementalExecution` in `runtime/src/glr_incremental.rs` and `IncrementalParseReport`/`IncrementalParseMode` in `runtime/src/pure_incremental.rs`, plus `last_parse_report()` accessors.
- Populate reports from `parse_incremental`/`parse` with per-call reuse delta (node-level), execution classification (`FreshParse` / `FullReparseFallback` / `IncrementalReuse`), and `invalidated_ranges` derived from edits.
- Compute reuse deltas using the existing `SUBTREE_REUSE_COUNT` counter so tests can assert whether reuse actually occurred during a parse invocation.
- Update `runtime/tests/glr_incremental_comprehensive.rs` to assert fallback vs reuse reporting and to capture invalidated ranges, and adjust a reuse-count assertion to reflect node-level reuse semantics.
- Add a brief docs note in `docs/reference/known-limitations.md` pointing users at `IncrementalGLRParser::last_parse_report()` for observability of fallback vs reuse.

### Testing
- Ran `cargo test -p adze incremental -- --nocapture`, which completed successfully and exercised the incremental test subset. 
- Built the comprehensive test binary with `cargo test -p adze --test glr_incremental_comprehensive --no-run`, which compiled successfully. 
- Ran the feature-enabled GLR incremental integration tests with `cargo test -p adze --features incremental_glr --test glr_incremental_comprehensive -- --nocapture`, and the suite passed (`35 passed; 0 failed`).
- Ran formatting check with `cargo fmt --all --check`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a67d5608333b957fd5b536bc92e)