### PR TITLE
Expose incremental parse status for reuse vs fallback

### DIFF
--- a/docs/reference/known-limitations.md
+++ b/docs/reference/known-limitations.md
@@ -26,6 +26,7 @@ Tree-sitter compatible query support (`.scm` files) is under active development.
 ### 3. Incremental Parsing
 Reparsing only changed parts of a file is supported in the core engine but may fall back to full parses in complex GLR scenarios.
 - **Status**: Conservative fallback enabled; forest-splicing is experimental.
+- **Visibility**: Runtime incremental APIs now expose last-parse status (`FreshParse`, `IncrementalReuse`, `FullReparseFallback`), reused node count, and invalidated edit ranges for tests/diagnostics.
 
 ### 4. `transform` Closures
 There is a known bug (FR-005) where `transform` closures on leaf nodes are captured but not executed.

--- a/runtime/src/glr_incremental.rs
+++ b/runtime/src/glr_incremental.rs
@@ -88,6 +88,38 @@ pub fn get_reuse_count() -> usize {
     SUBTREE_REUSE_COUNT.load(Ordering::SeqCst)
 }
 
+/// Outcome classification for the most recent incremental parse attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IncrementalParseMode {
+    /// Parsed without edits / no incremental attempt.
+    FreshParse,
+    /// Incremental path was used and reused nodes were spliced.
+    IncrementalReuse,
+    /// Incremental path was attempted but fell back to full reparse.
+    FullReparseFallback,
+}
+
+/// Test-visible status for the most recent parse attempt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IncrementalParseStatus {
+    /// Whether the parse used fresh parse, reuse, or fallback.
+    pub mode: IncrementalParseMode,
+    /// Number of nodes actually reused in the resulting forest.
+    pub reused_node_count: usize,
+    /// Invalidated byte ranges from the provided edits.
+    pub invalidated_ranges: Vec<Range<usize>>,
+}
+
+impl Default for IncrementalParseStatus {
+    fn default() -> Self {
+        Self {
+            mode: IncrementalParseMode::FreshParse,
+            reused_node_count: 0,
+            invalidated_ranges: vec![],
+        }
+    }
+}
+
 /// Helper function to tokenize source code for arithmetic grammar
 #[allow(dead_code)]
 fn tokenize_source(source: &[u8], _grammar: &Grammar) -> Vec<GLRToken> {
@@ -389,6 +421,8 @@ pub struct IncrementalGLRParser {
     tokens: Vec<GLRToken>,
     /// Edit byte delta (new_text.len() - old_text.len())
     edit_byte_delta: isize,
+    /// Status for the last parse attempt (test visibility / diagnostics).
+    last_status: IncrementalParseStatus,
 }
 
 /// Tracks fork relationships and dependencies
@@ -459,6 +493,7 @@ impl IncrementalGLRParser {
             chunk_suffix_len: 0,
             tokens: vec![],
             edit_byte_delta: 0,
+            last_status: IncrementalParseStatus::default(),
         }
     }
 
@@ -481,7 +516,13 @@ impl IncrementalGLRParser {
             chunk_suffix_len: 0,
             tokens: vec![],
             edit_byte_delta: 0,
+            last_status: IncrementalParseStatus::default(),
         }
+    }
+
+    /// Get status from the most recent parse call.
+    pub fn last_parse_status(&self) -> &IncrementalParseStatus {
+        &self.last_status
     }
 
     /// Parse with incremental reuse
@@ -499,8 +540,14 @@ impl IncrementalGLRParser {
             if has_old_forest {
                 self.reparse_with_edits(tokens, edits)
             } else {
-                // No previous parse, do fresh parse
-                self.parse_fresh(tokens)
+                // No previous parse available for reuse, so this is a fallback.
+                let invalidated_ranges = edits.iter().map(|e| e.old_range.clone()).collect();
+                self.parse_fresh_with_status(
+                    tokens,
+                    IncrementalParseMode::FullReparseFallback,
+                    0,
+                    invalidated_ranges,
+                )
             }
         } else {
             // No edits, fresh parse
@@ -510,6 +557,17 @@ impl IncrementalGLRParser {
 
     /// Parse from scratch
     fn parse_fresh(&mut self, tokens: &[GLRToken]) -> Result<Arc<ForestNode>, String> {
+        self.parse_fresh_with_status(tokens, IncrementalParseMode::FreshParse, 0, vec![])
+    }
+
+    /// Parse from scratch while explicitly recording incremental status.
+    fn parse_fresh_with_status(
+        &mut self,
+        tokens: &[GLRToken],
+        mode: IncrementalParseMode,
+        reused_node_count: usize,
+        invalidated_ranges: Vec<Range<usize>>,
+    ) -> Result<Arc<ForestNode>, String> {
         // Reset state
         self.fork_tracker = ForkTracker::new();
         // GSS snapshots removed - using direct forest splicing instead
@@ -569,6 +627,11 @@ impl IncrementalGLRParser {
 
                 self.forest = Some(forest.clone());
                 self.previous_forest = Some(forest.clone());
+                self.last_status = IncrementalParseStatus {
+                    mode,
+                    reused_node_count,
+                    invalidated_ranges,
+                };
                 Ok(forest)
             }
             Err(e) => Err(format!("Parse error: {}", e)),
@@ -585,6 +648,9 @@ impl IncrementalGLRParser {
         // Instead of GSS snapshots, we parse only the edited middle segment
         // and directly splice it with preserved prefix/suffix forest nodes.
         // This avoids the 3-4x performance penalty of GSS restoration.
+
+        let invalidated_ranges: Vec<Range<usize>> =
+            edits.iter().map(|edit| edit.old_range.clone()).collect();
 
         // Get the old forest and old tokens from the first edit
         let old_forest = edits
@@ -671,7 +737,12 @@ impl IncrementalGLRParser {
                     might_introduce_ambiguity
                 );
                 // Fall back to full parsing to ensure ambiguity is correctly handled
-                return self.parse_fresh(tokens);
+                return self.parse_fresh_with_status(
+                    tokens,
+                    IncrementalParseMode::FullReparseFallback,
+                    0,
+                    invalidated_ranges.clone(),
+                );
             }
 
             if should_splice && middle_len < tokens.len() {
@@ -773,7 +844,12 @@ impl IncrementalGLRParser {
                         }
                         _ => {
                             // Middle segment failed to parse - fall back to full parse
-                            return self.parse_fresh(tokens);
+                            return self.parse_fresh_with_status(
+                                tokens,
+                                IncrementalParseMode::FullReparseFallback,
+                                0,
+                                invalidated_ranges.clone(),
+                            );
                         }
                     }
                 };
@@ -815,14 +891,29 @@ impl IncrementalGLRParser {
 
                 self.forest = Some(spliced_forest.clone());
                 self.previous_forest = Some(spliced_forest.clone());
+                self.last_status = IncrementalParseStatus {
+                    mode: IncrementalParseMode::IncrementalReuse,
+                    reused_node_count: reuse_count,
+                    invalidated_ranges,
+                };
                 Ok(spliced_forest)
             } else {
                 // No benefit from splicing - do a full parse
-                self.parse_fresh(tokens)
+                self.parse_fresh_with_status(
+                    tokens,
+                    IncrementalParseMode::FullReparseFallback,
+                    0,
+                    invalidated_ranges,
+                )
             }
         } else {
             // No old forest, do fresh parse
-            self.parse_fresh(tokens)
+            self.parse_fresh_with_status(
+                tokens,
+                IncrementalParseMode::FullReparseFallback,
+                0,
+                invalidated_ranges,
+            )
         }
     }
 

--- a/runtime/src/pure_incremental.rs
+++ b/runtime/src/pure_incremental.rs
@@ -8,6 +8,21 @@ use std::ops::Range;
 // Re-export Point so tests can keep using pure_incremental::Point
 pub use crate::pure_parser::Point;
 
+/// Outcome classification for the last parse call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IncrementalParseMode {
+    FreshParse,
+    FullReparseFallback,
+}
+
+/// Test-visible status for the last parse call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IncrementalParseStatus {
+    pub mode: IncrementalParseMode,
+    pub reused_node_count: usize,
+    pub invalidated_ranges: Vec<Range<usize>>,
+}
+
 /// Edit operation for incremental parsing
 #[derive(Debug, Clone)]
 pub struct Edit {
@@ -112,6 +127,7 @@ impl Tree {
 pub struct IncrementalParser {
     parser: Parser,
     previous_tree: Option<Tree>,
+    last_status: IncrementalParseStatus,
 }
 
 impl Default for IncrementalParser {
@@ -126,6 +142,11 @@ impl IncrementalParser {
         IncrementalParser {
             parser: Parser::new(),
             previous_tree: None,
+            last_status: IncrementalParseStatus {
+                mode: IncrementalParseMode::FreshParse,
+                reused_node_count: 0,
+                invalidated_ranges: vec![],
+            },
         }
     }
 
@@ -146,6 +167,15 @@ impl IncrementalParser {
 
     /// Parse with incremental reuse
     pub fn parse(&mut self, source: &str, old_tree: Option<&Tree>) -> ParseResult {
+        self.parse_with_invalidated_ranges(source, old_tree, vec![])
+    }
+
+    fn parse_with_invalidated_ranges(
+        &mut self,
+        source: &str,
+        old_tree: Option<&Tree>,
+        invalidated_ranges: Vec<Range<usize>>,
+    ) -> ParseResult {
         // If we have an old tree, try to reuse nodes
         if let Some(tree) = old_tree {
             self.previous_tree = Some(tree.clone());
@@ -155,6 +185,17 @@ impl IncrementalParser {
 
             // TODO: Implement actual incremental parsing logic
             // For now, fall back to full reparse
+            self.last_status = IncrementalParseStatus {
+                mode: IncrementalParseMode::FullReparseFallback,
+                reused_node_count: 0,
+                invalidated_ranges,
+            };
+        } else {
+            self.last_status = IncrementalParseStatus {
+                mode: IncrementalParseMode::FreshParse,
+                reused_node_count: 0,
+                invalidated_ranges,
+            };
         }
 
         // Parse from scratch
@@ -168,6 +209,11 @@ impl IncrementalParser {
         }
 
         result
+    }
+
+    /// Returns status from the most recent parse call.
+    pub fn last_parse_status(&self) -> &IncrementalParseStatus {
+        &self.last_status
     }
 
     /// Parse with edits
@@ -185,7 +231,11 @@ impl IncrementalParser {
         }
 
         // Parse with the edited tree
-        self.parse(source, old_tree.as_ref())
+        let invalidated_ranges = edits
+            .iter()
+            .map(|edit| edit.start_byte..edit.old_end_byte)
+            .collect();
+        self.parse_with_invalidated_ranges(source, old_tree.as_ref(), invalidated_ranges)
     }
 }
 
@@ -197,6 +247,10 @@ mod tests {
     fn test_incremental_parser_creation() {
         let parser = IncrementalParser::new();
         assert!(parser.previous_tree.is_none());
+        assert_eq!(
+            parser.last_parse_status().mode,
+            IncrementalParseMode::FreshParse
+        );
     }
 
     #[test]

--- a/runtime/tests/glr_incremental_comprehensive.rs
+++ b/runtime/tests/glr_incremental_comprehensive.rs
@@ -9,7 +9,7 @@
 mod tests {
     use adze::glr_incremental::{
         ChunkIdentifier, Edit, ForestNode, ForkAlternative, GLREdit, GLRToken,
-        IncrementalGLRParser, get_reuse_count, reset_reuse_counter,
+        IncrementalGLRParser, IncrementalParseMode, get_reuse_count, reset_reuse_counter,
     };
     use adze::glr_lexer::{GLRLexer, TokenWithPosition};
     use adze::subtree::{Subtree, SubtreeNode};
@@ -473,6 +473,34 @@ mod tests {
         reset_reuse_counter();
         let new_forest = p.parse_incremental(&old_toks, &[edit]).unwrap();
         assert!(!new_forest.alternatives.is_empty());
+        let status = p.last_parse_status();
+        assert_eq!(status.mode, IncrementalParseMode::IncrementalReuse);
+        assert!(status.reused_node_count > 0);
+        assert_eq!(status.invalidated_ranges, vec![1..1]);
+    }
+
+    #[test]
+    fn test_incremental_reports_full_reparse_fallback() {
+        let g = arith_grammar();
+        let mut p = make_parser(&g);
+        let (old_toks, old_forest) = fresh_parse(&mut p, &g, "1+2+3+4+5+6");
+        let new_toks = to_glr(&tokenize(&g, "7*8*9*10*11*12"));
+
+        let edit = GLREdit {
+            old_range: 0..11,
+            new_text: b"7*8*9*10*11*12".to_vec(),
+            old_token_range: 0..old_toks.len(),
+            new_tokens: new_toks.clone(),
+            old_tokens: old_toks,
+            old_forest: Some(old_forest),
+        };
+
+        let forest = p.parse_incremental(&new_toks, &[edit]).unwrap();
+        assert!(!forest.alternatives.is_empty());
+        let status = p.last_parse_status();
+        assert_eq!(status.mode, IncrementalParseMode::FullReparseFallback);
+        assert_eq!(status.reused_node_count, 0);
+        assert_eq!(status.invalidated_ranges, vec![0..11]);
     }
 
     // ─── Test 14: Replace first token ───────────────────────────────


### PR DESCRIPTION
### Motivation
- Make incremental parsing behavior testable by distinguishing true subtree reuse from conservative full-reparse fallbacks.
- Provide tests and runtime visibility so callers can assert whether an incremental path actually reused nodes or fell back to a full parse.

### Description
- Added `IncrementalParseMode` and `IncrementalParseStatus` to `runtime/src/glr_incremental.rs` and a smaller status type to `runtime/src/pure_incremental.rs` to classify the last parse as `FreshParse`, `IncrementalReuse`, or `FullReparseFallback` and to record `reused_node_count` and `invalidated_ranges`.
- Tracked `last_status` on `IncrementalGLRParser` and `IncrementalParser` and exposed it via `last_parse_status()` for tests/diagnostics, and propagated status updates through fresh-parse, splice-success (reuse), and conservative-fallback branches.
- Updated `runtime/tests/glr_incremental_comprehensive.rs` to assert both a successful reuse case reports `IncrementalReuse` with non-zero reused nodes and a large-edit case reports `FullReparseFallback` with zero reuse and the expected invalidated range.
- Made a minimal docs note in `docs/reference/known-limitations.md` describing the new runtime visibility; no parser_v4 or tablegen changes and no attempt to finish full forest-splicing semantics.

### Testing
- Ran `cargo fmt --all --check` and fixed formatting issues (now passing).
- Built and ran the comprehensive GLR incremental test executable and executed `cargo test -p adze --features incremental_glr --test glr_incremental_comprehensive`, which completed with all tests passing (`34 passed; 0 failed`).
- Prepared `cargo test -p adze --test glr_incremental_comprehensive --no-run` successfully; an attempt to run `cargo test -p adze incremental -- --nocapture` was started but long-running in this environment and was not completed within the session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a67d5608333b957fd5b536bc92e)