### PR TITLE
Expose incremental parse status (fallback/reuse) for GLR and pure parsers

### DIFF
--- a/docs/how-to/incremental-parsing.md
+++ b/docs/how-to/incremental-parsing.md
@@ -1,6 +1,10 @@
 # How to Use GLR Incremental Parsing in adze
 
-> **⚠️ Status**: The incremental parsing path is currently **disabled** and falls back to fresh parsing for consistency. The infrastructure documented here exists but has known issues. See `glr_incremental.rs` for details.
+> **⚠️ Status**: Incremental GLR currently uses conservative heuristics: it may
+> splice reusable prefix/suffix forest nodes for safe edits, or explicitly
+> fall back to a full reparse when safety checks fail. Inspect
+> `IncrementalGLRParser::last_parse_status()` after each parse for the exact
+> outcome.
 
 This guide documents adze's GLR incremental parsing infrastructure (implemented September 2025) with fork-aware subtree reuse and conservative fallback strategies.
 

--- a/docs/reference/known-limitations.md
+++ b/docs/reference/known-limitations.md
@@ -26,6 +26,10 @@ Tree-sitter compatible query support (`.scm` files) is under active development.
 ### 3. Incremental Parsing
 Reparsing only changed parts of a file is supported in the core engine but may fall back to full parses in complex GLR scenarios.
 - **Status**: Conservative fallback enabled; forest-splicing is experimental.
+- **Visibility**: `IncrementalGLRParser::last_parse_status()` and
+  `pure_incremental::IncrementalParser::last_parse_status()` expose whether the
+  last run reused nodes or explicitly fell back to full reparse, plus edit
+  invalidation ranges.
 
 ### 4. `transform` Closures
 There is a known bug (FR-005) where `transform` closures on leaf nodes are captured but not executed.

--- a/runtime/src/glr_incremental.rs
+++ b/runtime/src/glr_incremental.rs
@@ -88,6 +88,19 @@ pub fn get_reuse_count() -> usize {
     SUBTREE_REUSE_COUNT.load(Ordering::SeqCst)
 }
 
+/// Test-visible status for the most recent incremental parse attempt.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct IncrementalParseStatus {
+    /// True when incremental parsing explicitly fell back to a full reparse.
+    pub full_reparse_fallback: bool,
+    /// Number of forest nodes reused from the previous parse.
+    pub reused_node_count: usize,
+    /// Invalidated byte ranges derived from incoming edits.
+    pub invalidated_ranges: Vec<Range<usize>>,
+    /// Optional machine-readable reason for fallback.
+    pub fallback_reason: Option<&'static str>,
+}
+
 /// Helper function to tokenize source code for arithmetic grammar
 #[allow(dead_code)]
 fn tokenize_source(source: &[u8], _grammar: &Grammar) -> Vec<GLRToken> {
@@ -389,6 +402,8 @@ pub struct IncrementalGLRParser {
     tokens: Vec<GLRToken>,
     /// Edit byte delta (new_text.len() - old_text.len())
     edit_byte_delta: isize,
+    /// Status of the most recent parse attempt.
+    last_parse_status: IncrementalParseStatus,
 }
 
 /// Tracks fork relationships and dependencies
@@ -459,6 +474,7 @@ impl IncrementalGLRParser {
             chunk_suffix_len: 0,
             tokens: vec![],
             edit_byte_delta: 0,
+            last_parse_status: IncrementalParseStatus::default(),
         }
     }
 
@@ -481,7 +497,13 @@ impl IncrementalGLRParser {
             chunk_suffix_len: 0,
             tokens: vec![],
             edit_byte_delta: 0,
+            last_parse_status: IncrementalParseStatus::default(),
         }
+    }
+
+    /// Return status for the most recent incremental parse attempt.
+    pub fn last_parse_status(&self) -> &IncrementalParseStatus {
+        &self.last_parse_status
     }
 
     /// Parse with incremental reuse
@@ -490,6 +512,13 @@ impl IncrementalGLRParser {
         tokens: &[GLRToken],
         edits: &[GLREdit],
     ) -> Result<Arc<ForestNode>, String> {
+        self.last_parse_status = IncrementalParseStatus {
+            full_reparse_fallback: false,
+            reused_node_count: 0,
+            invalidated_ranges: edits.iter().map(|edit| edit.old_range.clone()).collect(),
+            fallback_reason: None,
+        };
+
         // If we have edits and a previous parse, try to reuse
         if !edits.is_empty() {
             // Check if we have an old forest to reuse from
@@ -500,10 +529,13 @@ impl IncrementalGLRParser {
                 self.reparse_with_edits(tokens, edits)
             } else {
                 // No previous parse, do fresh parse
+                self.last_parse_status.full_reparse_fallback = true;
+                self.last_parse_status.fallback_reason = Some("missing_old_forest");
                 self.parse_fresh(tokens)
             }
         } else {
             // No edits, fresh parse
+            self.last_parse_status.fallback_reason = Some("fresh_parse_no_edits");
             self.parse_fresh(tokens)
         }
     }
@@ -671,6 +703,8 @@ impl IncrementalGLRParser {
                     might_introduce_ambiguity
                 );
                 // Fall back to full parsing to ensure ambiguity is correctly handled
+                self.last_parse_status.full_reparse_fallback = true;
+                self.last_parse_status.fallback_reason = Some("ambiguity_safety_fallback");
                 return self.parse_fresh(tokens);
             }
 
@@ -773,6 +807,9 @@ impl IncrementalGLRParser {
                         }
                         _ => {
                             // Middle segment failed to parse - fall back to full parse
+                            self.last_parse_status.full_reparse_fallback = true;
+                            self.last_parse_status.fallback_reason =
+                                Some("middle_segment_parse_failed");
                             return self.parse_fresh(tokens);
                         }
                     }
@@ -812,16 +849,21 @@ impl IncrementalGLRParser {
                 if reuse_count > 0 {
                     SUBTREE_REUSE_COUNT.fetch_add(reuse_count, Ordering::SeqCst);
                 }
+                self.last_parse_status.reused_node_count = reuse_count;
 
                 self.forest = Some(spliced_forest.clone());
                 self.previous_forest = Some(spliced_forest.clone());
                 Ok(spliced_forest)
             } else {
                 // No benefit from splicing - do a full parse
+                self.last_parse_status.full_reparse_fallback = true;
+                self.last_parse_status.fallback_reason = Some("no_splice_benefit");
                 self.parse_fresh(tokens)
             }
         } else {
             // No old forest, do fresh parse
+            self.last_parse_status.full_reparse_fallback = true;
+            self.last_parse_status.fallback_reason = Some("missing_old_forest");
             self.parse_fresh(tokens)
         }
     }

--- a/runtime/src/pure_incremental.rs
+++ b/runtime/src/pure_incremental.rs
@@ -39,6 +39,17 @@ pub struct ReusableNode {
     is_error: bool,
 }
 
+/// Test-visible status for the most recent incremental parse attempt.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct IncrementalParseStatus {
+    /// True when incremental parsing fell back to a full parse.
+    pub full_reparse_fallback: bool,
+    /// Number of reusable nodes discovered from the previous tree.
+    pub reused_node_count: usize,
+    /// Invalidated byte ranges derived from incoming edits.
+    pub invalidated_ranges: Vec<Range<usize>>,
+}
+
 impl Tree {
     /// Create a new tree from a parse result
     pub fn new(root: ParsedNode, language: &'static TSLanguage, source: &[u8]) -> Self {
@@ -112,6 +123,7 @@ impl Tree {
 pub struct IncrementalParser {
     parser: Parser,
     previous_tree: Option<Tree>,
+    last_parse_status: IncrementalParseStatus,
 }
 
 impl Default for IncrementalParser {
@@ -126,7 +138,13 @@ impl IncrementalParser {
         IncrementalParser {
             parser: Parser::new(),
             previous_tree: None,
+            last_parse_status: IncrementalParseStatus::default(),
         }
+    }
+
+    /// Return status for the most recent parse attempt.
+    pub fn last_parse_status(&self) -> &IncrementalParseStatus {
+        &self.last_parse_status
     }
 
     /// Set the language for parsing
@@ -146,12 +164,17 @@ impl IncrementalParser {
 
     /// Parse with incremental reuse
     pub fn parse(&mut self, source: &str, old_tree: Option<&Tree>) -> ParseResult {
+        self.last_parse_status.full_reparse_fallback = false;
+        self.last_parse_status.reused_node_count = 0;
+
         // If we have an old tree, try to reuse nodes
         if let Some(tree) = old_tree {
             self.previous_tree = Some(tree.clone());
 
             // Get reusable nodes
-            let _reusable_nodes = tree.get_reusable_nodes();
+            let reusable_nodes = tree.get_reusable_nodes();
+            self.last_parse_status.reused_node_count = reusable_nodes.len();
+            self.last_parse_status.full_reparse_fallback = true;
 
             // TODO: Implement actual incremental parsing logic
             // For now, fall back to full reparse
@@ -177,6 +200,11 @@ impl IncrementalParser {
         mut old_tree: Option<Tree>,
         edits: &[Edit],
     ) -> ParseResult {
+        self.last_parse_status.invalidated_ranges = edits
+            .iter()
+            .map(|edit| edit.start_byte..edit.old_end_byte)
+            .collect();
+
         // Apply edits to the old tree
         if let Some(ref mut tree) = old_tree {
             for edit in edits {

--- a/runtime/tests/glr_incremental_comprehensive.rs
+++ b/runtime/tests/glr_incremental_comprehensive.rs
@@ -473,6 +473,10 @@ mod tests {
         reset_reuse_counter();
         let new_forest = p.parse_incremental(&old_toks, &[edit]).unwrap();
         assert!(!new_forest.alternatives.is_empty());
+        let status = p.last_parse_status();
+        assert_eq!(status.invalidated_ranges, vec![1..1]);
+        assert!(!status.full_reparse_fallback);
+        assert!(status.reused_node_count > 0);
     }
 
     // ─── Test 14: Replace first token ───────────────────────────────
@@ -698,6 +702,36 @@ mod tests {
             get_reuse_count() > 0,
             "compatible incremental edit should reuse at least one subtree"
         );
+        assert!(get_reuse_count() <= new_toks.len());
+        let status = p.last_parse_status();
+        assert!(!status.full_reparse_fallback);
+        assert!(status.reused_node_count > 0);
+        assert_eq!(status.invalidated_ranges, vec![start..end]);
+    }
+
+    #[test]
+    fn test_status_reports_explicit_fallback_when_old_forest_missing() {
+        let g = arith_grammar();
+        let mut p = make_parser(&g);
+        let new_toks = to_glr(&tokenize(&g, "1+2"));
+
+        let edit = GLREdit {
+            old_range: 0..0,
+            new_text: b"1+2".to_vec(),
+            old_token_range: 0..0,
+            new_tokens: new_toks.clone(),
+            old_tokens: vec![],
+            old_forest: None,
+        };
+
+        let forest = p.parse_incremental(&new_toks, &[edit]).unwrap();
+        assert!(!forest.alternatives.is_empty());
+
+        let status = p.last_parse_status();
+        assert!(status.full_reparse_fallback);
+        assert_eq!(status.reused_node_count, 0);
+        assert_eq!(status.invalidated_ranges, vec![0..0]);
+        assert_eq!(status.fallback_reason, Some("missing_old_forest"));
     }
 
     // ─── Test 23: Parse error on invalid input ──────────────────────


### PR DESCRIPTION
### Motivation

- Make incremental parsing outcomes observable to tests so callers can distinguish genuine subtree reuse from a conservative full-reparse fallback.

### Description

- Add a test-visible `IncrementalParseStatus` type and `last_parse_status()` accessor to `IncrementalGLRParser` in `runtime/src/glr_incremental.rs` that reports `full_reparse_fallback`, `reused_node_count`, `invalidated_ranges`, and an optional `fallback_reason`.
- Add an analogous `IncrementalParseStatus` and `last_parse_status()` to the pure-Rust incremental surface in `runtime/src/pure_incremental.rs` and populate `invalidated_ranges`, reuse counts and fallback flags where applicable.
- Wire status updates at the key decision points in `parse_incremental` / `reparse_with_edits` (ambiguity safety checks, middle-segment parse failure, no-splice/ missing-old-forest branches) and update the `SUBTREE_REUSE_COUNT` semantics to populate `reused_node_count` when splicing succeeds.
- Update `runtime/tests/glr_incremental_comprehensive.rs` to assert status semantics for successful reuse and for explicit fallback cases, and make minimal doc edits in `docs/reference/known-limitations.md` and `docs/how-to/incremental-parsing.md` to point users at `last_parse_status()` for authoritative behavior.

### Testing

- Ran `cargo test -p adze --features incremental_glr --test glr_incremental_comprehensive -- --nocapture` and the targeted incremental GLR comprehensive test binary completed with all tests passing (34 passed, 0 failed). 
- Ran `cargo test -p adze --features incremental_glr --test glr_incremental_comprehensive --no-run` to validate test compilation for the feature-gated suite and it succeeded.
- Ran `cargo fmt --all --check` which reported no formatting issues.

Notes: these changes only add test-visible status and do not attempt to complete full forest-splicing across all edit classes; conservative fallbacks remain in place and are now explicitly reported by the new status fields.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a67d5608333b957fd5b536bc92e)