### PR TITLE
Expose incremental parse fallback/reuse metrics in runtime APIs

### DIFF
--- a/docs/reference/known-limitations.md
+++ b/docs/reference/known-limitations.md
@@ -26,6 +26,7 @@ Tree-sitter compatible query support (`.scm` files) is under active development.
 ### 3. Incremental Parsing
 Reparsing only changed parts of a file is supported in the core engine but may fall back to full parses in complex GLR scenarios.
 - **Status**: Conservative fallback enabled; forest-splicing is experimental.
+- **Visibility**: `glr_incremental::IncrementalGLRParser::last_parse_metrics()` and `pure_incremental::IncrementalParser::last_parse_metrics()` report whether the last call reused nodes or fell back, plus invalidated byte ranges.
 
 ### 4. `transform` Closures
 There is a known bug (FR-005) where `transform` closures on leaf nodes are captured but not executed.

--- a/runtime/src/glr_incremental.rs
+++ b/runtime/src/glr_incremental.rs
@@ -88,6 +88,25 @@ pub fn get_reuse_count() -> usize {
     SUBTREE_REUSE_COUNT.load(Ordering::SeqCst)
 }
 
+/// Outcome of an incremental GLR parse attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IncrementalParseOutcome {
+    /// A normal full parse (no edits or no prior forest available).
+    FreshParse,
+    /// Incremental path attempted but conservatively fell back to full reparse.
+    FullReparseFallback,
+    /// Direct forest splicing reused nodes.
+    Reused,
+}
+
+/// Test-visible metrics for the most recent parse.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IncrementalParseMetrics {
+    pub outcome: IncrementalParseOutcome,
+    pub reused_node_count: usize,
+    pub invalidated_ranges: Vec<Range<usize>>,
+}
+
 /// Helper function to tokenize source code for arithmetic grammar
 #[allow(dead_code)]
 fn tokenize_source(source: &[u8], _grammar: &Grammar) -> Vec<GLRToken> {
@@ -389,6 +408,8 @@ pub struct IncrementalGLRParser {
     tokens: Vec<GLRToken>,
     /// Edit byte delta (new_text.len() - old_text.len())
     edit_byte_delta: isize,
+    /// Metrics from the most recent incremental call.
+    last_parse_metrics: IncrementalParseMetrics,
 }
 
 /// Tracks fork relationships and dependencies
@@ -459,6 +480,11 @@ impl IncrementalGLRParser {
             chunk_suffix_len: 0,
             tokens: vec![],
             edit_byte_delta: 0,
+            last_parse_metrics: IncrementalParseMetrics {
+                outcome: IncrementalParseOutcome::FreshParse,
+                reused_node_count: 0,
+                invalidated_ranges: vec![],
+            },
         }
     }
 
@@ -481,7 +507,17 @@ impl IncrementalGLRParser {
             chunk_suffix_len: 0,
             tokens: vec![],
             edit_byte_delta: 0,
+            last_parse_metrics: IncrementalParseMetrics {
+                outcome: IncrementalParseOutcome::FreshParse,
+                reused_node_count: 0,
+                invalidated_ranges: vec![],
+            },
         }
+    }
+
+    /// Metrics from the most recent parse call.
+    pub fn last_parse_metrics(&self) -> &IncrementalParseMetrics {
+        &self.last_parse_metrics
     }
 
     /// Parse with incremental reuse
@@ -490,6 +526,11 @@ impl IncrementalGLRParser {
         tokens: &[GLRToken],
         edits: &[GLREdit],
     ) -> Result<Arc<ForestNode>, String> {
+        self.last_parse_metrics.invalidated_ranges =
+            edits.iter().map(|e| e.old_range.clone()).collect();
+        self.last_parse_metrics.reused_node_count = 0;
+        self.last_parse_metrics.outcome = IncrementalParseOutcome::FreshParse;
+
         // If we have edits and a previous parse, try to reuse
         if !edits.is_empty() {
             // Check if we have an old forest to reuse from
@@ -510,6 +551,14 @@ impl IncrementalGLRParser {
 
     /// Parse from scratch
     fn parse_fresh(&mut self, tokens: &[GLRToken]) -> Result<Arc<ForestNode>, String> {
+        let had_edits = !self.last_parse_metrics.invalidated_ranges.is_empty();
+        self.last_parse_metrics.outcome = if had_edits {
+            IncrementalParseOutcome::FullReparseFallback
+        } else {
+            IncrementalParseOutcome::FreshParse
+        };
+        self.last_parse_metrics.reused_node_count = 0;
+
         // Reset state
         self.fork_tracker = ForkTracker::new();
         // GSS snapshots removed - using direct forest splicing instead
@@ -812,6 +861,8 @@ impl IncrementalGLRParser {
                 if reuse_count > 0 {
                     SUBTREE_REUSE_COUNT.fetch_add(reuse_count, Ordering::SeqCst);
                 }
+                self.last_parse_metrics.outcome = IncrementalParseOutcome::Reused;
+                self.last_parse_metrics.reused_node_count = reuse_count;
 
                 self.forest = Some(spliced_forest.clone());
                 self.previous_forest = Some(spliced_forest.clone());

--- a/runtime/src/pure_incremental.rs
+++ b/runtime/src/pure_incremental.rs
@@ -39,6 +39,25 @@ pub struct ReusableNode {
     is_error: bool,
 }
 
+/// Outcome of an incremental parse attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IncrementalParseOutcome {
+    /// A normal full parse (no previous tree provided).
+    FreshParse,
+    /// Incremental API was used, but implementation fell back to full reparse.
+    FullReparseFallback,
+    /// Incremental reuse happened.
+    Reused,
+}
+
+/// Test-visible metrics describing the most recent parse.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IncrementalParseMetrics {
+    pub outcome: IncrementalParseOutcome,
+    pub reused_node_count: usize,
+    pub invalidated_ranges: Vec<Range<usize>>,
+}
+
 impl Tree {
     /// Create a new tree from a parse result
     pub fn new(root: ParsedNode, language: &'static TSLanguage, source: &[u8]) -> Self {
@@ -112,6 +131,7 @@ impl Tree {
 pub struct IncrementalParser {
     parser: Parser,
     previous_tree: Option<Tree>,
+    last_parse_metrics: IncrementalParseMetrics,
 }
 
 impl Default for IncrementalParser {
@@ -126,6 +146,11 @@ impl IncrementalParser {
         IncrementalParser {
             parser: Parser::new(),
             previous_tree: None,
+            last_parse_metrics: IncrementalParseMetrics {
+                outcome: IncrementalParseOutcome::FreshParse,
+                reused_node_count: 0,
+                invalidated_ranges: vec![],
+            },
         }
     }
 
@@ -144,14 +169,25 @@ impl IncrementalParser {
         self.parser.set_cancellation_flag(flag);
     }
 
+    /// Metrics from the most recent parse call.
+    pub fn last_parse_metrics(&self) -> &IncrementalParseMetrics {
+        &self.last_parse_metrics
+    }
+
     /// Parse with incremental reuse
     pub fn parse(&mut self, source: &str, old_tree: Option<&Tree>) -> ParseResult {
+        let mut outcome = IncrementalParseOutcome::FreshParse;
+        let mut reused_node_count = 0;
+        let invalidated_ranges = vec![];
+
         // If we have an old tree, try to reuse nodes
         if let Some(tree) = old_tree {
             self.previous_tree = Some(tree.clone());
 
             // Get reusable nodes
-            let _reusable_nodes = tree.get_reusable_nodes();
+            let reusable_nodes = tree.get_reusable_nodes();
+            reused_node_count = reusable_nodes.len();
+            outcome = IncrementalParseOutcome::FullReparseFallback;
 
             // TODO: Implement actual incremental parsing logic
             // For now, fall back to full reparse
@@ -166,6 +202,15 @@ impl IncrementalParser {
         {
             self.previous_tree = Some(Tree::new(root.clone(), language, source.as_bytes()));
         }
+
+        self.last_parse_metrics = IncrementalParseMetrics {
+            outcome,
+            reused_node_count: match outcome {
+                IncrementalParseOutcome::Reused => reused_node_count,
+                _ => 0,
+            },
+            invalidated_ranges,
+        };
 
         result
     }
@@ -184,8 +229,15 @@ impl IncrementalParser {
             }
         }
 
+        let invalidated_ranges = edits
+            .iter()
+            .map(|edit| edit.start_byte..edit.old_end_byte)
+            .collect::<Vec<_>>();
+
         // Parse with the edited tree
-        self.parse(source, old_tree.as_ref())
+        let result = self.parse(source, old_tree.as_ref());
+        self.last_parse_metrics.invalidated_ranges = invalidated_ranges;
+        result
     }
 }
 

--- a/runtime/tests/glr_incremental_comprehensive.rs
+++ b/runtime/tests/glr_incremental_comprehensive.rs
@@ -9,7 +9,7 @@
 mod tests {
     use adze::glr_incremental::{
         ChunkIdentifier, Edit, ForestNode, ForkAlternative, GLREdit, GLRToken,
-        IncrementalGLRParser, get_reuse_count, reset_reuse_counter,
+        IncrementalGLRParser, IncrementalParseOutcome, get_reuse_count, reset_reuse_counter,
     };
     use adze::glr_lexer::{GLRLexer, TokenWithPosition};
     use adze::subtree::{Subtree, SubtreeNode};
@@ -926,5 +926,40 @@ mod tests {
         assert_eq!(n2.byte_range, 5..15);
         let dbg = format!("{:?}", n2);
         assert!(dbg.contains("ForestNode"));
+    }
+
+    #[test]
+    fn test_incremental_metrics_fresh_parse_without_edits() {
+        let g = arith_grammar();
+        let mut parser = make_parser(&g);
+        let tokens = to_glr(&tokenize(&g, "1+2"));
+        let _forest = parser.parse_incremental(&tokens, &[]).unwrap();
+        let metrics = parser.last_parse_metrics();
+        assert_eq!(metrics.outcome, IncrementalParseOutcome::FreshParse);
+        assert_eq!(metrics.reused_node_count, 0);
+        assert!(metrics.invalidated_ranges.is_empty());
+    }
+
+    #[test]
+    fn test_incremental_metrics_explicit_fallback_without_old_forest() {
+        let g = arith_grammar();
+        let mut parser = make_parser(&g);
+        let tokens = to_glr(&tokenize(&g, "1+9"));
+        let edit = GLREdit {
+            old_range: 2..3,
+            new_text: b"9".to_vec(),
+            old_token_range: 2..3,
+            new_tokens: vec![tokens[2].clone()],
+            old_tokens: vec![],
+            old_forest: None,
+        };
+        let _forest = parser.parse_incremental(&tokens, &[edit]).unwrap();
+        let metrics = parser.last_parse_metrics();
+        assert_eq!(
+            metrics.outcome,
+            IncrementalParseOutcome::FullReparseFallback
+        );
+        assert_eq!(metrics.reused_node_count, 0);
+        assert_eq!(metrics.invalidated_ranges, vec![2..3]);
     }
 }


### PR DESCRIPTION
### Motivation

- Tests and tooling need to distinguish between true incremental reuse and conservative full-reparse fallbacks so incremental behavior is honest and observable.
- Existing experimental incremental surfaces collected reusable nodes but silently fell back to full reparse, making it impossible for tests to assert whether reuse occurred.

### Description

- Add `IncrementalParseOutcome` and `IncrementalParseMetrics` to `runtime/src/glr_incremental.rs` and `runtime/src/pure_incremental.rs` to represent `FreshParse`, `FullReparseFallback`, or `Reused`, plus `reused_node_count` and `invalidated_ranges`.
- Store metrics on parser state and expose them via `IncrementalGLRParser::last_parse_metrics()` and `IncrementalParser::last_parse_metrics()` so callers/tests can inspect the most recent parse outcome.
- Wire metrics into existing control flow so the GLR path sets `Reused` when the splice path reuses prefix/suffix nodes and sets `FullReparseFallback` when the conservative fallback/full parse path is taken; the pure incremental path records fallback and invalidated ranges for edits.
- Add focused tests in `runtime/tests/glr_incremental_comprehensive.rs` to assert metrics for a fresh parse and for an explicit fallback case, and add a short doc note in `docs/reference/known-limitations.md` pointing to the new metrics API.

### Testing

- Ran `cargo fmt --all --check` and the repository formatting check passed.
- Built the GLR incremental test binary with `cargo test -p adze --test glr_incremental_comprehensive --no-run` which completed successfully.
- Ran the feature-gated incremental tests with `cargo test -p adze --features incremental_glr --test glr_incremental_comprehensive test_incremental_metrics_ -- --nocapture` and the new, focused tests passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a67d5608333b957fd5b536bc92e)