### PR TITLE
Add advisory product-proof workflow with bounded canaries

### DIFF
--- a/.github/workflows/product-proof.yml
+++ b/.github/workflows/product-proof.yml
@@ -1,0 +1,36 @@
+name: product-proof
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '20 4 * * 1' # weekly advisory run
+
+permissions:
+  contents: read
+
+jobs:
+  ci-product:
+    name: ci-product (advisory)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: bash -n ci-product-proof script
+        run: bash -n scripts/ci-product-proof.sh
+
+      - name: cargo metadata
+        run: cargo metadata --format-version 1 > /tmp/cargo-metadata.json
+
+      - name: Run advisory product-proof canaries
+        run: scripts/ci-product-proof.sh
+
+      - name: git diff --check
+        run: git diff --check

--- a/docs/status/KNOWN_RED.md
+++ b/docs/status/KNOWN_RED.md
@@ -1,6 +1,6 @@
 # Known red
 
-**Last updated:** 2026-04-06
+**Last updated:** 2026-04-26
 
 This file tracks intentional exclusions from the supported lane:
 
@@ -39,6 +39,15 @@ This lane is intentionally bounded so it stays reliable and fast enough for day-
 **Current status:** GREEN — all supported crates compile, lint clean, and tests pass. **2,460+ tests across feature combinations, 0 failures in supported lane.** Feature-combination matrix: 12/12 pass (all green). `cargo-audit` clean (0 vulnerabilities). WASM: all core crates compile for `wasm32-unknown-unknown`.
 
 ---
+
+
+## Advisory product proof lane
+
+A non-blocking `product-proof` workflow now provides bounded canaries for broader product surfaces (`runtime`, `cli`, `golden-tests`, `benchmarks`, `wasm-demo`, one grammar crate, `runtime2`, and one governance/BDD microcrate).
+
+- It is **advisory only** (`workflow_dispatch` + weekly schedule) and does not change required branch protection gates.
+- It reports compile/smoke proof status per surface and keeps running even when some canaries fail.
+- Current lane design intentionally uses compile/no-run checks rather than full behavioral proof to stay fast and bounded.
 
 ## What is excluded (and why)
 

--- a/scripts/ci-product-proof.sh
+++ b/scripts/ci-product-proof.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -u -o pipefail
+
+# Advisory canary lane for product surfaces outside ci-supported.
+# This script is intentionally bounded to compile/smoke checks.
+
+declare -i failures=0
+dry_run=false
+
+declare -a labels=()
+declare -a proof_types=()
+declare -a commands=()
+declare -a statuses=()
+declare -a notes=()
+
+run_canary() {
+  local label="$1"
+  local proof_type="$2"
+  local command="$3"
+  local note="$4"
+
+  echo
+  echo "==> ${label} (${proof_type})"
+  echo "    $command"
+
+  local status
+  if [[ "$dry_run" == "true" ]]; then
+    status="DRY-RUN"
+  elif eval "$command"; then
+    status="PASS"
+  else
+    status="FAIL"
+    failures+=1
+  fi
+
+  labels+=("$label")
+  proof_types+=("$proof_type")
+  commands+=("$command")
+  statuses+=("$status")
+  notes+=("$note")
+}
+
+summary_file=""
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run)
+      dry_run=true
+      ;;
+    *)
+      if [[ -z "$summary_file" ]]; then
+        summary_file="$arg"
+      else
+        echo "unexpected argument: $arg" >&2
+        exit 2
+      fi
+      ;;
+  esac
+done
+
+run_canary \
+  "adze runtime typed parse surface" \
+  "compile-only" \
+  "cargo check -p adze --locked" \
+  "Confirms runtime crate compiles in the advisory lane."
+
+run_canary \
+  "adze-cli" \
+  "compile-only" \
+  "cargo check -p adze-cli --locked" \
+  "CLI wiring compiles without executing commands."
+
+run_canary \
+  "adze-golden-tests" \
+  "smoke-test (no-run)" \
+  "cargo test -p adze-golden-tests --features all-grammars --no-run --locked" \
+  "Builds golden-test harness without downloading external references or running parity suite."
+
+run_canary \
+  "adze-benchmarks" \
+  "compile-only (bench --no-run)" \
+  "cargo bench -p adze-benchmarks --no-run --locked" \
+  "Ensures benchmark targets compile; no perf assertions are executed."
+
+run_canary \
+  "adze-wasm-demo" \
+  "compile-only" \
+  "cargo check -p adze-wasm-demo --target wasm32-unknown-unknown --locked" \
+  "Requires wasm32 target; validates demo crate compiles for web target."
+
+run_canary \
+  "grammar canary (adze-python)" \
+  "compile-only" \
+  "cargo check -p adze-python --locked" \
+  "One representative grammar surface canary."
+
+run_canary \
+  "runtime2 canary (adze-runtime)" \
+  "compile-only" \
+  "cargo check -p adze-runtime --no-default-features --features glr --locked" \
+  "runtime2 crate/package is named adze-runtime."
+
+run_canary \
+  "governance/BDD microcrate canary (adze-bdd-governance-core)" \
+  "compile-only" \
+  "cargo check -p adze-bdd-governance-core --locked" \
+  "Representative governance/BDD microcrate smoke canary."
+
+if [[ -z "$summary_file" && -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  summary_file="$GITHUB_STEP_SUMMARY"
+fi
+
+{
+  echo "## Product proof canary summary"
+  echo
+  echo "| Surface | Proof type | Status | Command | Notes |"
+  echo "|---|---|---|---|---|"
+  for i in "${!labels[@]}"; do
+    echo "| ${labels[$i]} | ${proof_types[$i]} | ${statuses[$i]} | ${commands[$i]} | ${notes[$i]} |"
+  done
+  echo
+  if [[ "$dry_run" == "true" ]]; then
+    echo "> Advisory result: dry-run completed; no cargo commands were executed."
+  elif (( failures > 0 )); then
+    echo "> Advisory result: ${failures} canary check(s) failed. This lane is non-blocking by design."
+  else
+    echo "> Advisory result: all canary checks passed."
+  fi
+} | tee /tmp/ci-product-proof-summary.md
+
+if [[ -n "$summary_file" ]]; then
+  cat /tmp/ci-product-proof-summary.md >> "$summary_file"
+fi
+
+# Always exit 0 so the advisory lane can publish a full matrix of PASS/FAIL signals.
+exit 0


### PR DESCRIPTION
### Motivation

- Provide a non-blocking, advisory CI lane that gives quick canary signal across broader product surfaces that are intentionally excluded from the narrow `ci-supported` gate. 
- Keep the lane lightweight and bounded (compile/no-run or small smoke checks) so it is useful for maintainers without becoming merge-blocking.

### Description

- Add a new advisory workflow `product-proof` (`.github/workflows/product-proof.yml`) that is `workflow_dispatch` and scheduled weekly, runs on `ubuntu-latest`, and is configured as advisory (`continue-on-error: true`).
- Add `scripts/ci-product-proof.sh`, which runs a set of bounded canaries and emits a summary table; the script supports `--dry-run`, writes to `GITHUB_STEP_SUMMARY` when available, and always exits 0 so failures remain advisory and visible.
- The canaries cover representative surfaces and proof types: `adze` (compile-only), `adze-cli` (compile-only), `adze-golden-tests` (smoke `--no-run`), `adze-benchmarks` (compile-only `--no-run`), `adze-wasm-demo` (wasm-target compile), one grammar crate `adze-python` (compile-only), runtime2 surface `adze-runtime` (compile-only with `--features glr`), and a governance/BDD microcrate `adze-bdd-governance-core` (compile-only).
- Document the advisory lane in `docs/status/KNOWN_RED.md` clarifying it is advisory, bounded, and does not change required branch-protection gates.

### Testing

- `bash -n scripts/ci-product-proof.sh` — succeeded.
- `cargo metadata --format-version 1 > /tmp/cargo-metadata.json` — succeeded.
- `scripts/ci-product-proof.sh --dry-run /tmp/product-proof-summary.md` — succeeded and produced the expected summary table in dry-run mode.
- `git diff --check` — succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a6fccd88333829d4ea6c2470b75)