### PR TITLE
Add advisory product-proof CI lane with bounded canaries

### DIFF
--- a/.github/workflows/product-proof.yml
+++ b/.github/workflows/product-proof.yml
@@ -1,0 +1,37 @@
+name: product-proof
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '15 4 * * 1'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  product-proof:
+    name: Advisory product canaries
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Shell syntax check
+        run: bash -n scripts/ci-product.sh
+
+      - name: Product proof canaries (advisory)
+        run: scripts/ci-product.sh
+
+      - name: Trailing whitespace / merge marker guard
+        run: git diff --check

--- a/docs/status/KNOWN_RED.md
+++ b/docs/status/KNOWN_RED.md
@@ -1,6 +1,6 @@
 # Known red
 
-**Last updated:** 2026-04-06
+**Last updated:** 2026-04-26
 
 This file tracks intentional exclusions from the supported lane:
 
@@ -61,6 +61,26 @@ These may run as optional signal (nightly/manual/canary), but are not required f
 - deployment workflows (mdBook / pages)
 - performance regression canaries
 - All other `.github/workflows/ci.yml` jobs are optional unless explicitly promoted in settings.
+
+### Advisory product proof lane
+
+- New non-blocking workflow: `.github/workflows/product-proof.yml`
+- Script entrypoint: `scripts/ci-product.sh`
+- Triggering: `workflow_dispatch` and weekly schedule
+- Policy: advisory only (`continue-on-error: true`), does **not** change required gates.
+
+The lane is intentionally bounded and currently provides smoke/compile canaries for:
+
+- `adze` runtime (test listing smoke)
+- `adze-cli` (compile-only)
+- `adze-golden-tests` (compile-only via `--no-run`)
+- `adze-benchmarks` (compile-only via `cargo bench --no-run`)
+- `adze-wasm-demo` (compile-only for `wasm32-unknown-unknown`)
+- one grammar crate: `adze-python-simple` (compile-only)
+- `runtime2` surface via `adze-runtime` (compile-only via `--no-run`)
+- one governance/BDD microcrate: `adze-bdd-contract` (compile-only)
+
+This lane is designed to close the support/proof gap without widening the required PR gate.
 
 ---
 

--- a/scripts/ci-product.sh
+++ b/scripts/ci-product.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -u
+
+# Advisory product-surface canaries.
+# This script intentionally runs bounded compile/smoke checks and is designed
+# to be used from a non-blocking CI workflow.
+
+run_check() {
+  local name="$1"
+  local proof_type="$2"
+  shift 2
+
+  echo ""
+  echo "==> ${name} [${proof_type}]"
+  echo "+ $*"
+
+  if "$@"; then
+    RESULTS+=("PASS|${name}|${proof_type}")
+    return 0
+  fi
+
+  RESULTS+=("FAIL|${name}|${proof_type}")
+  return 1
+}
+
+RESULTS=()
+FAILURES=0
+
+# Global sanity check.
+run_check "workspace metadata" "compile-only" cargo metadata --format-version 1 >/dev/null || FAILURES=$((FAILURES + 1))
+
+# 1) Main runtime surface (adze) canary.
+run_check "adze runtime smoke" "smoke-test" cargo test -p adze --lib -- --list || FAILURES=$((FAILURES + 1))
+
+# 2) CLI canary.
+run_check "adze-cli" "compile-only" cargo check -p adze-cli --locked || FAILURES=$((FAILURES + 1))
+
+# 3) Golden tests surface canary.
+run_check "adze-golden-tests" "compile-only" cargo test -p adze-golden-tests --no-run --locked || FAILURES=$((FAILURES + 1))
+
+# 4) Benchmarks surface canary.
+run_check "adze-benchmarks" "compile-only" cargo bench -p adze-benchmarks --no-run --locked || FAILURES=$((FAILURES + 1))
+
+# 5) Wasm demo canary.
+run_check "adze-wasm-demo" "compile-only" cargo check -p adze-wasm-demo --target wasm32-unknown-unknown --locked || FAILURES=$((FAILURES + 1))
+
+# 6) One grammar surface canary.
+run_check "grammar smoke (adze-python-simple)" "compile-only" cargo check -p adze-python-simple --locked || FAILURES=$((FAILURES + 1))
+
+# 7) runtime2 surface canary.
+run_check "runtime2 smoke (adze-runtime)" "compile-only" cargo test -p adze-runtime --no-run --locked || FAILURES=$((FAILURES + 1))
+
+# 8) One governance/BDD microcrate canary.
+run_check "microcrate smoke (adze-bdd-contract)" "compile-only" cargo check -p adze-bdd-contract --locked || FAILURES=$((FAILURES + 1))
+
+echo ""
+echo "Product proof summary:"
+echo "status|canary|proof"
+for row in "${RESULTS[@]}"; do
+  echo "$row"
+done
+
+if [[ "$FAILURES" -gt 0 ]]; then
+  echo ""
+  echo "Advisory canary failures: ${FAILURES}"
+  exit 1
+fi
+
+echo ""
+echo "All advisory product canaries passed."


### PR DESCRIPTION
### Motivation
- Close the support/proof gap by adding a non-blocking, advisory CI lane that exercises a small canary for each broader product surface outside the narrow `ci-supported` lane. 
- Provide maintainers a single manual/scheduled proof that surfaces compile/smoke signal for runtime, tooling, grammars, wasm, benchmarks and governance microcrates without changing required PR gates.

### Description
- Add a new advisory workflow `.github/workflows/product-proof.yml` that is triggered by `workflow_dispatch` and a weekly schedule and runs with `continue-on-error: true` so required gates are unchanged. 
- Add `scripts/ci-product.sh`, a bounded canary runner that aggregates pass/fail for these canaries: `adze` runtime (smoke-test), `adze-cli` (compile-only), `adze-golden-tests` (no-run compile), `adze-benchmarks` (no-run compile), `adze-wasm-demo` (wasm32 compile-only), `adze-python-simple` (grammar compile-only), `adze-runtime` (runtime2 no-run compile), and `adze-bdd-contract` (microcrate compile-only). 
- Update `docs/status/KNOWN_RED.md` to document the advisory lane, list the covered canaries, and note that the lane is advisory and does not widen `ci-supported`.

### Testing
- `bash -n scripts/ci-product.sh` was run and returned success for shell syntax validation. 
- `cargo metadata --format-version 1` was executed and succeeded as a workspace sanity check. 
- `scripts/ci-product.sh` was started locally to exercise canaries and confirmed successful completion for `adze runtime smoke`, `adze-cli` (compile), and `adze-golden-tests` (no-run compile); other canaries began compilation in the environment but the run was interrupted due to long compile time in the ephemeral session. 
- `git diff --check` passed (trailing whitespace/merge-marker guard).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a6fccd88333829d4ea6c2470b75)