### PR TITLE
Add non-blocking advisory Product Proof CI lane

### DIFF
--- a/.github/workflows/product-proof.yml
+++ b/.github/workflows/product-proof.yml
@@ -1,0 +1,32 @@
+name: Product Proof (Advisory)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 5 * * 1'
+
+concurrency:
+  group: product-proof-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  ci-product-proof:
+    name: ci-product-proof
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    env:
+      CARGO_TERM_COLOR: always
+      CARGO_BUILD_JOBS: 2
+      RUST_TEST_THREADS: 2
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Show canary matrix
+        run: scripts/ci-product-proof.sh --list
+
+      - name: Run advisory product proof canaries
+        run: scripts/ci-product-proof.sh

--- a/docs/status/KNOWN_RED.md
+++ b/docs/status/KNOWN_RED.md
@@ -1,6 +1,6 @@
 # Known red
 
-**Last updated:** 2026-04-06
+**Last updated:** 2026-04-26
 
 This file tracks intentional exclusions from the supported lane:
 
@@ -22,6 +22,31 @@ Rule: if something is excluded from the supported lane, it must be listed here w
 
 ### Core pipeline crates
 - `adze-ir`, `adze-glr-core`, `adze-tablegen`, `adze-common`, `adze-macro`, `adze-tool` all pass `cargo check`, `cargo clippy`, and `cargo test`.
+
+---
+
+
+## Advisory product proof lane
+
+A new **non-blocking** workflow (`Product Proof (Advisory)`) runs on manual dispatch and weekly schedule.
+It provides bounded canaries for broader product surfaces without changing required merge gates.
+
+Canaries currently included:
+
+| Surface | Canary type | Command |
+|---|---|---|
+| Main runtime (`adze`) | smoke-test | `cargo test -p adze --lib` |
+| CLI (`adze-cli`) | compile-only | `cargo check -p adze-cli` |
+| Golden tests (`adze-golden-tests`) | compile-only | `cargo test -p adze-golden-tests --no-run` |
+| Benchmarks (`adze-benchmarks`) | compile-only | `cargo test -p adze-benchmarks --no-run` |
+| WASM demo (`adze-wasm-demo`) | compile-only | `cargo check -p adze-wasm-demo` |
+| One grammar (`adze-python-simple`) | compile-only | `cargo check -p adze-python-simple` |
+| Runtime2 (`runtime2/Cargo.toml`) | compile-only | `cargo test --manifest-path runtime2/Cargo.toml --no-run` |
+| One governance microcrate (`adze-runtime2-governance`) | compile-only | `cargo check -p adze-runtime2-governance` |
+
+Notes:
+- This lane is advisory and intentionally bounded; failures here should be treated as signal, not branch blockers.
+- If any surface is temporarily unable to run, the workflow still records that result without changing `ci-supported` protections.
 
 ---
 

--- a/justfile
+++ b/justfile
@@ -77,6 +77,11 @@ ci-supported:
     cargo test {{supported_crates}} --lib --tests --bins -- --test-threads="$RUST_TEST_THREADS"
     cargo test -p adze-glr-core --features serialization --doc -- --test-threads="$RUST_TEST_THREADS"
 
+
+# Advisory broad product-surface canaries (non-blocking lane counterpart)
+ci-product:
+    ./scripts/ci-product-proof.sh
+
 # Run mutation testing on adze-ir (quick check)
 mutate crate="adze-ir":
     cargo mutants -p {{crate}} --timeout-multiplier 2 -- --lib

--- a/scripts/ci-product-proof.sh
+++ b/scripts/ci-product-proof.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Advisory product-surface proof lane.
+# Intentionally bounded to compile/smoke checks so it stays fast and non-blocking.
+
+if [[ "${1:-}" == "--list" ]]; then
+  cat <<'LIST'
+canary,type,command
+adze-runtime,smoke-test,cargo test -p adze --lib -- --test-threads=2
+adze-cli,compile-only,cargo check -p adze-cli
+adze-golden-tests,compile-only,cargo test -p adze-golden-tests --no-run
+adze-benchmarks,compile-only,cargo test -p adze-benchmarks --no-run
+wasm-demo,compile-only,cargo check -p adze-wasm-demo
+grammar-python-simple,compile-only,cargo check -p adze-python-simple
+runtime2,compile-only,cargo test --manifest-path runtime2/Cargo.toml --no-run
+microcrate-governance,compile-only,cargo check -p adze-runtime2-governance
+LIST
+  exit 0
+fi
+
+export CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-2}"
+export RUST_TEST_THREADS="${RUST_TEST_THREADS:-2}"
+
+failures=0
+
+run_canary() {
+  local name="$1"
+  local proof_type="$2"
+  shift 2
+
+  echo
+  echo "=== ${name} (${proof_type}) ==="
+  if "$@"; then
+    echo "PASS: ${name}"
+  else
+    echo "FAIL: ${name}"
+    failures=$((failures + 1))
+  fi
+}
+
+run_canary "adze-runtime" "smoke-test" cargo test -p adze --lib -- --test-threads="$RUST_TEST_THREADS"
+run_canary "adze-cli" "compile-only" cargo check -p adze-cli
+run_canary "adze-golden-tests" "compile-only" cargo test -p adze-golden-tests --no-run
+run_canary "adze-benchmarks" "compile-only" cargo test -p adze-benchmarks --no-run
+run_canary "wasm-demo" "compile-only" cargo check -p adze-wasm-demo
+run_canary "grammar-python-simple" "compile-only" cargo check -p adze-python-simple
+run_canary "runtime2" "compile-only" cargo test --manifest-path runtime2/Cargo.toml --no-run
+run_canary "microcrate-governance" "compile-only" cargo check -p adze-runtime2-governance
+
+echo
+if [[ "$failures" -eq 0 ]]; then
+  echo "All product-proof canaries passed."
+else
+  echo "Product-proof canaries failed: ${failures}"
+  exit 1
+fi


### PR DESCRIPTION
### Motivation
- Provide a lightweight, non-blocking advisory lane that exercises one bounded canary for each broader product surface outside the narrow `ci-supported` gate. 
- Surface-level canaries give maintainers fast signal on runtime, CLI, golden-tests, benchmarks, wasm demo, grammars, runtime2, and one governance/BDD microcrate without changing required CI gates.
- Keep the lane advisory and inexpensive so failures are informational, not merge blockers.

### Description
- Add a new advisory GitHub Actions workflow `Product Proof (Advisory)` at `.github/workflows/product-proof.yml` triggered by `workflow_dispatch` and a weekly `schedule`, with `continue-on-error: true` to keep it non-blocking.  
- Add `scripts/ci-product-proof.sh`, an executable script that enumerates and runs bounded canaries (with a `--list` mode and per-canary pass/fail reporting).  
- Add a local `just` recipe `ci-product` to run the canaries via `just ci-product`.  
- Update `docs/status/KNOWN_RED.md` to document the advisory lane and list each canary and its proof type; the included canaries are: `adze` (smoke-test), `adze-cli` (compile-only), `adze-golden-tests` (compile-only, `--no-run`), `adze-benchmarks` (compile-only, `--no-run`), `adze-wasm-demo` (compile-only), `adze-python-simple` (compile-only), `runtime2` (compile-only via `--manifest-path` `--no-run`), and `adze-runtime2-governance` (compile-only). 

### Testing
- Ran syntax check for the script with `bash -n scripts/ci-product-proof.sh`, which completed successfully.  
- Verified workspace metadata with `cargo metadata --format-version 1` which completed successfully.  
- Verified canary list output with `scripts/ci-product-proof.sh --list`, which produced the expected matrix and succeeded.  
- Ran repository hygiene check `git diff --check`, which produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a6fccd88333829d4ea6c2470b75)