### PR TITLE
docs: add support-tier proof matrix and align README/status claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,15 +74,17 @@ complete walkthrough.
 
 ## Features
 
+> Support tiers, proof commands, and CI lane mapping live in [`docs/status/SUPPORT_TIERS.md`](./docs/status/SUPPORT_TIERS.md).
+
 | Feature | Status | Description |
 |---------|--------|-------------|
 | **Typed extraction** | ✅ Stable | Grammar *is* your AST — parse directly into your Rust types |
 | **Pure Rust** | ✅ Stable | Default backend is 100% Rust; no C toolchain needed |
 | **GLR parsing** | ✅ Stable | Handles ambiguous grammars (C++, JavaScript, etc.) |
 | **Operator precedence** | ✅ Stable | `#[prec_left]`, `#[prec_right]` for disambiguation |
-| **WASM support** | ✅ Stable | Compile parsers to WebAssembly with `features = ["wasm"]` |
-| **Tree-sitter interop** | ✅ Stable | Import existing Tree-sitter grammars via `ts-bridge` |
-| **Serialization** | ✅ Stable | JSON and S-expression output with `features = ["serialization"]` |
+| **Serialization** | ✅ Stable (core lane) | JSON and S-expression output with `features = ["serialization"]` |
+| **WASM support** | 🧪 Experimental | Compile parsers to WebAssembly with `features = ["wasm"]` |
+| **Tree-sitter interop** | 🧪 Experimental | Import existing Tree-sitter grammars via `ts-bridge` |
 | **External scanners** | 🧪 Experimental | Custom tokenization via `ExternalScanner` trait |
 | **Incremental parsing** | 🧪 Experimental | Re-parse only edited regions (falls back to fresh parse) |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,4 +64,5 @@ Welcome to the Adze documentation. Adze (formerly `rust-sitter`) is a Rust-nativ
 - [**Friction Log**](./status/FRICTION_LOG.md) - Current developer pain points we are burning down.
 - [**Now / Next / Later**](./status/NOW_NEXT_LATER.md) - Rolling execution plan.
 - [**Known Red**](./status/KNOWN_RED.md) - Exclusions from the supported CI lane.
+- [**Support Tiers**](./status/SUPPORT_TIERS.md) - Feature-by-feature support tier, proof command, and CI lane mapping.
 - [**PR Template**](./PR_TEMPLATE.md) - Checklist for contributors.

--- a/docs/status/KNOWN_RED.md
+++ b/docs/status/KNOWN_RED.md
@@ -11,6 +11,8 @@ Rule: if something is excluded from the supported lane, it must be listed here w
 - why
 - how it becomes supported (or why it won't)
 
+For per-feature support tiers and proof commands, see [`docs/status/SUPPORT_TIERS.md`](./SUPPORT_TIERS.md).
+
 ---
 
 ## ✅ Previously broken — now fixed

--- a/docs/status/SUPPORT_TIERS.md
+++ b/docs/status/SUPPORT_TIERS.md
@@ -1,0 +1,34 @@
+# Support Tiers and Proof Surface
+
+**Last updated:** 2026-04-26
+
+This is the source-of-truth mapping between advertised features and what is currently proven in CI.
+
+## Tier definitions
+
+- **Stable**: Proven by the required PR gate (`just ci-supported` / `CI / ci-supported`).
+- **Experimental**: Has automated proof in CI, but outside the required PR gate.
+- **Advisory**: Exists and can be checked manually (or in optional lanes), but is not currently part of a reliable merge-blocking contract.
+- **Intentionally excluded**: Explicitly outside the supported lane until promoted.
+
+## Feature-to-proof matrix
+
+| Surface | Tier | Proof command | CI lane | Notes / limitations |
+|---|---|---|---|---|
+| Typed extraction | **Stable** | `cargo test -p adze --lib --tests --bins` (via `just ci-supported`) | `CI / ci-supported` | User-facing core contract in the supported lane. |
+| Pure-Rust parser | **Stable** | `cargo test -p adze --lib --tests --bins` (default features) | `CI / ci-supported` | Default backend in supported crates only. |
+| GLR parsing | **Stable** | `cargo test -p adze-glr-core --lib --tests --bins` + `cargo test -p adze` (via `just ci-supported`) | `CI / ci-supported` | Core GLR crates are in the required gate. |
+| Serialization | **Stable** (core) | `cargo test -p adze-glr-core --features serialization --doc` | `CI / ci-supported` | Required-gate proof is currently `adze-glr-core` doctests with `serialization`; broader serialization surface remains outside required gate. |
+| External scanners | **Experimental** | `cargo nextest run --workspace --features external_scanners` | `CI / Test (... / --features external_scanners / ...)` | Automated, but not in required PR gate; lane only runs in non-supported/full CI paths. |
+| Incremental parsing | **Experimental** | `cargo nextest run --workspace --features incremental_glr` | `CI / Test (... / --features incremental_glr / ...)` | Automated, but not in required PR gate; fallback behavior and broader runtime integration still evolving. |
+| Tree-sitter interop | **Experimental** | `cargo test -p adze --features "ts-compat pure-rust" --test ts_compat_equiv` | `CI / Tree-sitter Compatibility API` | Feature-specific CI exists, but not required for merge. |
+| WASM | **Experimental** | `cargo check --target wasm32-unknown-unknown -p adze-ir -p adze-glr-core -p adze-tablegen -p adze-common` | `CI / WASM Build Verification` | Lane is optional (`continue-on-error`) and not in required gate; proof is compile-focused. |
+| CLI (`cli/`) | **Advisory** | `cargo run -p adze-cli -- --help` | *(none required)* | Tooling surface exists but is intentionally outside supported lane today. |
+| runtime2 (`runtime2/`) | **Advisory** | `cargo test -p adze-runtime --features "test-utils,glr"` | *(none required)* | Alternate runtime path; explicitly excluded from supported lane in `KNOWN_RED`. |
+| Grammars (`grammars/*`) | **Advisory** | `cargo test -p adze-python` / `cargo test -p adze-javascript` / `cargo test -p adze-go` | Optional broad CI (`CI / Test` workspace lanes) | Valuable validation surface, but not a stable published support contract yet. |
+| Golden tests | **Advisory** | `cargo test -p adze --test golden_tests -- --ignored` (from `runtime/`) | `Pure Rust Implementation CI / Golden Tests` | Requires Tree-sitter CLI/tooling; useful parity signal, intentionally outside required gate. |
+| Benchmarks | **Advisory** | `cargo bench -p adze-benchmarks --bench incremental_bench --no-run` | `CI / Benchmark Compilation`, `benchmarks.yml` | Signal for performance only; not merge-blocking correctness proof. |
+
+## Relationship to `KNOWN_RED`
+
+Surfaces marked **Advisory** here should also appear in [`docs/status/KNOWN_RED.md`](./KNOWN_RED.md) until they are promoted into the supported lane.


### PR DESCRIPTION
### Motivation

- Make README claims, known-red status, and CI proof surface consistent so contributors can tell what is proven by the required PR gate and what is advisory or experimental. 
- Provide a single source-of-truth mapping from advertised features to their support tier, the exact proof command, and the CI lane that exercises that proof. 
- Avoid code changes and avoid overclaiming by surfacing limitations and where proof is only provided in optional CI lanes.

### Description

- Add `docs/status/SUPPORT_TIERS.md` containing a feature-to-proof matrix that maps each major surface to a tier, exact proof command, CI lane, and notes/limitations. 
- Update `README.md` feature table to point readers at the new support-tier document and downgrade `WASM` and `Tree-sitter interop` from `Stable` to `Experimental` while clarifying `Serialization` as `Stable (core lane)`. 
- Add a link to the new matrix from `docs/README.md` and add a cross-reference from `docs/status/KNOWN_RED.md` to the new matrix. 
- No code was modified; this PR is documentation-only and the feature-status changes are: downgraded — `WASM`, `Tree-sitter interop`; clarified scope — `Serialization` (stable for core lane); unchanged — `Typed extraction`, `Pure-Rust parser`, `GLR parsing`, `Operator precedence`; `External scanners` and `Incremental parsing` remain experimental.

### Testing

- Ran repository searches (`rg -n "stable|experimental|advisory|supported|unsupported" README.md docs/status/KNOWN_RED.md docs/status/SUPPORT_TIERS.md`) to validate the new wording and links, which returned the expected occurrences. 
- Ran `git diff --check` to ensure there are no whitespace or diff-check issues, which produced no errors. 
- No code tests were changed or required because this is a documentation-only change; CI will continue to validate the supported lane as before (`just ci-supported`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a72f1448333b09c1a472c9c9ae9)