### PR TITLE
docs: add SUPPORT_TIERS.md and link from README/KNOWN_RED

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ complete walkthrough.
 
 ## Features
 
+> Capability overview only. For authoritative support tiers, proof commands, and CI coverage, see [`docs/status/SUPPORT_TIERS.md`](./docs/status/SUPPORT_TIERS.md).
+
 | Feature | Status | Description |
 |---------|--------|-------------|
 | **Typed extraction** | ✅ Stable | Grammar *is* your AST — parse directly into your Rust types |

--- a/docs/status/KNOWN_RED.md
+++ b/docs/status/KNOWN_RED.md
@@ -5,6 +5,7 @@
 This file tracks intentional exclusions from the supported lane:
 
 - Required PR gate: `just ci-supported` locally, `CI / ci-supported` in GitHub checks
+- Feature-by-feature support/proof mapping lives in [`docs/status/SUPPORT_TIERS.md`](./SUPPORT_TIERS.md)
 
 Rule: if something is excluded from the supported lane, it must be listed here with:
 - what is excluded

--- a/docs/status/SUPPORT_TIERS.md
+++ b/docs/status/SUPPORT_TIERS.md
@@ -1,0 +1,36 @@
+# Support Tiers and Proof Surface
+
+**Last updated:** 2026-04-26  
+**Source of truth for:** feature support tier, proof command, and CI lane coverage.
+
+This document aligns README capability claims with the currently enforced proof surface.
+
+## Tier definitions
+
+- **Stable**: Included in the required PR gate (`just ci-supported`) with repeatable proof.
+- **Experimental**: Implemented and testable, but **not** in the required PR gate.
+- **Advisory**: Exists and may have signal CI/workflows, but no merge-blocking proof contract.
+- **Intentionally excluded**: Explicitly out of the supported lane today (see `KNOWN_RED`).
+
+## Feature support map
+
+| Feature surface | Tier | Proof command (local) | CI lane | Notes / limitations |
+|---|---|---|---|---|
+| Typed extraction | **Stable** | `cargo test -p adze --lib --tests --bins` | `CI / ci-supported` | Core user promise; enforced through runtime crate tests in required gate. |
+| Pure-Rust parser (default backend) | **Stable** | `cargo test -p adze --lib --tests --bins` | `CI / ci-supported` | Required lane exercises default runtime path in `adze`; broader workspace permutations are outside required gate. |
+| GLR parsing | **Stable** | `cargo test -p adze-glr-core --lib --tests --bins` | `CI / ci-supported` | GLR algorithm/tablegen core is in supported 7-crate lane. |
+| Serialization | **Stable** (core scope) | `cargo test -p adze-glr-core --features serialization --doc` | `CI / ci-supported` | Required gate currently proves serialization via `adze-glr-core` doctests, not every serialization path in excluded crates. |
+| External scanners | **Experimental** | `cargo nextest run --workspace --features external_scanners` | `CI / Test (...)` in `.github/workflows/ci.yml` (non-required on PRs) | Signal exists, but not merge-blocking and not in `ci-supported`. |
+| Incremental parsing | **Experimental** | `cargo nextest run --workspace --features incremental_glr` | `CI / Test (...)` in `.github/workflows/ci.yml` (non-required on PRs) | Signal coverage exists; required gate does not enforce it. |
+| Tree-sitter interop (`ts-bridge`, parity/smoke lanes) | **Advisory** | `just smoke` (ts-bridge link smoke) | `ts-bridge-smoke`, `ts-bridge-parity` (optional workflows) | Platform/toolchain sensitive; excluded from required supported lane. |
+| WASM | **Advisory** | `cargo check --target wasm32-unknown-unknown -p adze --no-default-features` | `microcrate-ci / WASM Build (core crates)` and `pure-rust-ci / Test WASM Build` (non-required) | Useful signal but not required PR gate proof. |
+| CLI (`cli/`) | **Intentionally excluded** | `cargo check -p adze-cli` | No required lane | Tooling surface is listed as excluded in `KNOWN_RED`; not currently part of support contract. |
+| `runtime2/` | **Intentionally excluded** | `cargo check -p adze-runtime2` | `performance.yml` and other optional lanes | Alternate runtime path is still converging; explicitly excluded from supported lane. |
+| `grammars/*` | **Intentionally excluded** | `cargo test -p adze-grammar-python` (example per-grammar) | Optional/non-required workflows only | Valuable reference implementations, but not yet stable published contract. |
+| Golden tests (`golden-tests/`) | **Advisory** | `cd golden-tests && cargo test -- --test-threads=2` | `golden-tests.yml` (optional) | Useful parity signal, not required for merge because of runtime/cross-language weight. |
+| Benchmarks (`benchmarks/`) | **Advisory** | `cargo bench -p adze-benchmarks --no-run` | `performance.yml`, `criterion-smoke.yml` (optional) | Performance signal only; intentionally non-blocking today. |
+
+## Scope guardrail
+
+If a feature is advertised as stable in README, it should have a matching **Stable** row here and proof in `ci-supported`.  
+If not, mark it Experimental/Advisory/Excluded here first, then tighten README wording as needed.


### PR DESCRIPTION
### Motivation

- Align the README's advertised capability surface with the CI-enforced proof surface so contributors can tell which features are merge-blocking vs advisory or excluded. 
- Reduce trust friction caused by broad marketing claims that are not exercised by the required PR gate, and provide a single source-of-truth for feature proof commands and CI lanes. 

### Description

- Add `docs/status/SUPPORT_TIERS.md` which maps each major feature (typed extraction, pure-Rust parser, GLR, external scanners, incremental parsing, Tree-sitter interop, WASM, CLI, `runtime2`, grammars, golden tests, benchmarks, serialization) to a support tier, a local proof command, the CI lane that provides signal, and concise notes/limitations. 
- Update `README.md` to add a minimal pointer above the features table directing users to `docs/status/SUPPORT_TIERS.md` as the authoritative support/proof document. 
- Update `docs/status/KNOWN_RED.md` with a pointer to the new support-tier document so excluded/intentional-red surfaces and the support map are discoverable from the status docs. 
- The support matrix intentionally narrows some README claims to match proof coverage (e.g., Tree-sitter interop and WASM marked Advisory; CLI, `runtime2/`, and `grammars/*` marked Intentionally excluded; core runtime, GLR, and serialization remain Stable in the supported gate). 

### Testing

- Ran `rg -n "stable|experimental|advisory|supported|unsupported" README.md docs/status/KNOWN_RED.md docs/status/SUPPORT_TIERS.md` to validate the new doc and links are present and searchable, and this completed with expected hits. 
- Ran `git diff --check` to verify no whitespace or diff-check errors, and it reported no issues. 
- No code changes were made and no runtime unit tests were required for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a72f1448333b09c1a472c9c9ae9)