### PR TITLE
docs: add SUPPORT_TIERS.md and align README / KNOWN_RED with CI proof surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,17 +74,19 @@ complete walkthrough.
 
 ## Features
 
+> Support/proof source of truth: [`SUPPORT_TIERS.md`](./SUPPORT_TIERS.md)
+
 | Feature | Status | Description |
 |---------|--------|-------------|
 | **Typed extraction** | ✅ Stable | Grammar *is* your AST — parse directly into your Rust types |
 | **Pure Rust** | ✅ Stable | Default backend is 100% Rust; no C toolchain needed |
 | **GLR parsing** | ✅ Stable | Handles ambiguous grammars (C++, JavaScript, etc.) |
 | **Operator precedence** | ✅ Stable | `#[prec_left]`, `#[prec_right]` for disambiguation |
-| **WASM support** | ✅ Stable | Compile parsers to WebAssembly with `features = ["wasm"]` |
-| **Tree-sitter interop** | ✅ Stable | Import existing Tree-sitter grammars via `ts-bridge` |
-| **Serialization** | ✅ Stable | JSON and S-expression output with `features = ["serialization"]` |
+| **Serialization** | 🧪 Experimental | Serialization proof is currently partial in required CI |
+| **WASM support** | 🧪 Experimental | Compile support exists; proof runs in optional CI lanes |
+| **Tree-sitter interop** | ℹ️ Advisory | `ts-bridge` is available but not in required merge gate |
 | **External scanners** | 🧪 Experimental | Custom tokenization via `ExternalScanner` trait |
-| **Incremental parsing** | 🧪 Experimental | Re-parse only edited regions (falls back to fresh parse) |
+| **Incremental parsing** | ℹ️ Advisory | Incremental path may fall back to fresh parsing |
 
 ### Cargo Features
 

--- a/SUPPORT_TIERS.md
+++ b/SUPPORT_TIERS.md
@@ -1,0 +1,43 @@
+# Support tiers and proof surface
+
+This document is the source of truth for what Adze supports today, how each
+surface is proven, and where that proof runs in CI.
+
+If a capability is not proven by a required lane, it must not be described as
+stable.
+
+## Tier definitions
+
+- **Stable**: Proven by the required PR gate (`just ci-supported` / `CI / ci-supported`).
+- **Experimental**: Implemented and useful, but proven only in optional lanes or partial checks.
+- **Advisory**: Documented and/or available for local use, but intentionally excluded from merge-blocking proof.
+
+## Feature-to-proof map
+
+| Surface | Tier | Proof command (local) | CI lane | Notes / limitations |
+|---|---|---|---|---|
+| Typed extraction | Stable | `just ci-supported` | `CI / ci-supported` (required) | Covered by runtime tests in supported crates (`adze`). |
+| Pure-Rust parser | Stable | `just ci-supported` | `CI / ci-supported` (required) | Default backend path is part of supported crate tests. |
+| GLR parsing | Stable | `just ci-supported` | `CI / ci-supported` (required) | Covered by `adze` + `adze-glr-core` tests and clippy in supported lane. |
+| Serialization | Experimental | `cargo test -p adze-glr-core --features serialization --doc` | `CI / ci-supported` (required, partial) | Required lane proves `adze-glr-core` serialization doctests; full end-to-end serialization behavior across non-supported surfaces is not a merge gate. |
+| External scanners | Experimental | `cargo test -p adze --features external_scanners` | Optional feature-matrix jobs in `CI` | API and grammar usage exist, but this is not in the required gate. |
+| Incremental parsing | Advisory | `cargo test -p adze --features incremental_glr` | Optional feature-matrix jobs in `CI` | Current path may fall back to fresh parse in complex cases; not merge-blocking. |
+| Tree-sitter interop (`ts-bridge`) | Advisory | `cargo build -p ts-bridge --release` | `ts-bridge-smoke`, `ts-bridge-parity` (optional) | Tooling is useful but excluded from required lane and workspace-default proof. |
+| WASM | Experimental | `cargo check --target wasm32-unknown-unknown -p adze -p adze-ir -p adze-glr-core -p adze-tablegen` | `CI / wasm-check` (optional) | Core crates are checked for wasm target in optional lane, not required gate. |
+| CLI (`cli/`) | Advisory | `cargo check -p adze-cli` | Optional/non-required jobs only | Developer tooling surface; excluded from supported lane. |
+| `runtime2/` | Advisory | `cargo test --manifest-path runtime2/Cargo.toml` | Optional/non-required jobs only | Alternate runtime path; explicitly excluded in Known Red until converged. |
+| Grammars (`grammars/*`) | Advisory | `cargo test -p adze-python -p adze-javascript -p adze-go` | Optional/non-required jobs only | Reference/validation grammars; not currently a stable published merge-gated surface. |
+| Golden tests | Advisory | `cargo test -p adze-golden-tests` | `golden-tests` workflow (optional) | Valuable compatibility contract, but intentionally excluded from required lane. |
+| Benchmarks | Advisory | `cargo bench -p adze-glr-core --no-run && cargo bench -p adze --lib --no-run` | `benchmarks`, `performance`, `criterion-smoke` (optional) | Performance signal only; non-blocking by policy. |
+
+## Policy
+
+When changing support claims in `README.md` or release notes:
+
+1. Update this table first.
+2. Ensure the proof command is reproducible locally.
+3. Promote a surface to **Stable** only after it is covered by the required lane.
+
+Related docs:
+- `README.md`
+- `docs/status/KNOWN_RED.md`

--- a/docs/status/KNOWN_RED.md
+++ b/docs/status/KNOWN_RED.md
@@ -5,6 +5,7 @@
 This file tracks intentional exclusions from the supported lane:
 
 - Required PR gate: `just ci-supported` locally, `CI / ci-supported` in GitHub checks
+- Support tier/source-of-truth mapping: [`SUPPORT_TIERS.md`](../../SUPPORT_TIERS.md)
 
 Rule: if something is excluded from the supported lane, it must be listed here with:
 - what is excluded


### PR DESCRIPTION
### Motivation

- Reduce overclaim risk by making feature stability claims explicitly tied to concrete proof commands and CI lanes. 
- Provide a single source-of-truth so contributors can tell which surfaces are merge-gated versus advisory/experimental. 
- Keep the change narrow and docs-only so the repository state and PR gate remain unchanged.

### Description

- Add `SUPPORT_TIERS.md` which maps major surfaces to a support tier, a local proof command, the CI lane where proof runs, and notes/limitations. 
- Update `README.md` features table to point readers at `SUPPORT_TIERS.md` and align several statuses with the actual proof surface. 
- Update `docs/status/KNOWN_RED.md` to reference `SUPPORT_TIERS.md` so exclusions and proof mapping are discoverable from the known-red file. 
- No code or behavior changes were made; this is strictly documentation and policy alignment.

### Testing

- No unit/integration test suites were executed because this is a docs-only change. 
- Performed repository validation checks including searching for stability keywords and running whitespace/format verification (`rg` checks and `git diff --check` style validation), which completed with no blocking issues. 
- The repository’s required PR gate remains `just ci-supported` and should be run by CI or locally to promote any surface to **Stable**.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a72f1448333b09c1a472c9c9ae9)