### PR TITLE
docs: add SUPPORT_TIERS mapping and align README / KNOWN_RED claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,20 @@ See the [Getting Started tutorial](./docs/tutorials/getting-started.md) for a fu
 
 Adze is under active development. The core parser pipeline is working and tested. Some broader surfaces — WASM, grammar crates, golden tests, benchmarks, Tree-sitter bridge — are still being hardened.
 
+Support tiers, proof commands, and CI lanes are tracked in [`docs/status/SUPPORT_TIERS.md`](./docs/status/SUPPORT_TIERS.md).
+
+| Feature | Tier | Description |
+|---------|--------|-------------|
+| **Typed extraction** | ✅ Stable | Grammar *is* your AST — parse directly into your Rust types |
+| **Pure Rust** | ✅ Stable | Default backend is 100% Rust; no C toolchain needed |
+| **GLR parsing** | ✅ Stable | Handles ambiguous grammars (C++, JavaScript, etc.) |
+| **Operator precedence** | ✅ Stable | `#[prec_left]`, `#[prec_right]` for disambiguation |
+| **WASM support** | 📎 Advisory | Compile parsers to WebAssembly with `features = ["wasm"]` |
+| **Tree-sitter interop** | 📎 Advisory | Import existing Tree-sitter grammars via `ts-bridge` |
+| **Serialization** | ✅ Stable | JSON and S-expression output with `features = ["serialization"]` |
+| **External scanners** | 🧪 Experimental | Custom tokenization via `ExternalScanner` trait |
+| **Incremental parsing** | 🧪 Experimental | Re-parse only edited regions (falls back to fresh parse) |
+
 | Surface                     | Status                      | Notes                                                                                            |
 | --------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------ |
 | Pure-Rust parser generation | Supported / hardening       | Default path for generated parsers.                                                              |

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,4 +64,5 @@ Welcome to the Adze documentation. Adze (formerly `rust-sitter`) is a Rust-nativ
 - [**Friction Log**](./status/FRICTION_LOG.md) - Current developer pain points we are burning down.
 - [**Now / Next / Later**](./status/NOW_NEXT_LATER.md) - Rolling execution plan.
 - [**Known Red**](./status/KNOWN_RED.md) - Exclusions from the supported CI lane.
+- [**Support Tiers**](./status/SUPPORT_TIERS.md) - Feature support level, proof command, CI lane, and limitations.
 - [**PR Template**](./PR_TEMPLATE.md) - Checklist for contributors.

--- a/docs/status/KNOWN_RED.md
+++ b/docs/status/KNOWN_RED.md
@@ -11,6 +11,8 @@ Rule: if something is excluded from the supported lane, it must be listed here w
 - why
 - how it becomes supported (or why it won't)
 
+Support tiers and proof commands for major surfaces are tracked in [`docs/status/SUPPORT_TIERS.md`](./SUPPORT_TIERS.md).
+
 ---
 
 ## ✅ Previously broken — now fixed

--- a/docs/status/SUPPORT_TIERS.md
+++ b/docs/status/SUPPORT_TIERS.md
@@ -1,0 +1,35 @@
+# Support Tiers and Proof Surface
+
+**Last updated:** 2026-04-26
+**Source of truth for:** README feature claims, `docs/status/KNOWN_RED.md`, and CI expectations.
+
+This document maps major Adze surfaces to four tiers:
+
+- **Stable** — part of the required support contract (`just ci-supported` / `CI / ci-supported`).
+- **Experimental** — implemented, but not part of the required merge gate; behavior may change.
+- **Advisory** — useful signal exists (optional CI lane, smoke, benchmark, etc.) but is non-blocking.
+- **Intentionally excluded** — tracked in `KNOWN_RED`; not currently a merge requirement.
+
+## Feature-to-proof map
+
+| Surface | Tier | Proof command | CI lane | Notes / limitations |
+|---|---|---|---|---|
+| Typed extraction | **Stable** | `cargo test -p adze --lib --tests --bins` (via `just ci-supported`) | `CI / ci-supported` | Core user contract via `adze` runtime tests in supported lane. |
+| Pure-Rust parser | **Stable** | `just ci-supported` | `CI / ci-supported` | Supported gate exercises pure-Rust core crates as the required contract. |
+| GLR parsing | **Stable** | `cargo test -p adze-glr-core --lib --tests --bins` (via `just ci-supported`) | `CI / ci-supported` | GLR generation/runtime core is in required gate. |
+| Serialization | **Stable** | `cargo test -p adze-glr-core --features serialization --doc` (via `just ci-supported`) | `CI / ci-supported` | Supported proof is currently `adze-glr-core` serialization doctests, not a full workspace serialization matrix. |
+| External scanners | **Experimental** | `cargo test -p adze --features external_scanners` | `CI / feature-matrix`, `CI / miri` (non-blocking/optional) | Not in required gate; coverage exists but is broad-lane signal. |
+| Incremental parsing | **Experimental** | `cargo test --workspace --features incremental_glr` | `CI / feature-matrix-extras` (non-blocking/optional) | Exists and tested in broad CI; still outside supported merge contract. |
+| Tree-sitter interop | **Advisory** | `./scripts/smoke-link.sh ts-bridge` | `smoke-ts-bridge / smoke`, `ts-bridge-smoke` | Interop/bridge proof is smoke-level and optional; not part of required lane. |
+| WASM | **Advisory** | `cargo check --target wasm32-unknown-unknown -p adze` (and core crates) | `CI / wasm-check`, `microcrate-ci / wasm-check` | Compile-check signal exists, but WASM is not in required branch-protection gate. |
+| CLI (`cli/`) | **Intentionally excluded** | `cargo check -p adze-cli` | No required lane | Tooling/prototype surface; excluded from supported lane per `KNOWN_RED`. |
+| runtime2 (`runtime2/`) | **Intentionally excluded** | `cargo check -p adze-runtime2` | No required lane | Alternate runtime path still converging; excluded from supported lane. |
+| Grammars (`grammars/*`) | **Intentionally excluded** | `cargo test -p adze-grammar-python` (and peers) | No required lane | Valuable examples/integration surfaces, but not yet a stable supported contract. |
+| Golden tests | **Advisory** | `cd golden-tests && cargo test --features <lang>-grammar -- --nocapture` | `golden-tests / golden-tests`, `pure-rust-ci / golden-tests` | High-value parity signal, but intentionally non-blocking for merges. |
+| Benchmarks | **Advisory** | `cargo bench -p adze --bench glr_parser_bench --no-run` | `CI / benchmarks`, `benchmarks / benchmark`, `performance` | Performance signal only; never treated as merge-blocking proof of correctness. |
+
+## How to use this file
+
+- If you change support scope, update this file and `docs/status/KNOWN_RED.md` in the same PR.
+- If README capability wording changes, ensure each claim maps to a row here.
+- If a surface lacks a repeatable proof command and lane, it must not be labeled **Stable**.


### PR DESCRIPTION
### Motivation

- Provide a single contributor-facing source of truth that maps major Adze surfaces to a support tier, a repeatable proof command, the CI lane that provides the signal, and notable limitations. 
- Make README capability claims and `docs/status/KNOWN_RED.md` assertions consistent with the enforced CI proof surface to avoid overclaiming. 
- Surface which features are stable, experimental, advisory, or intentionally excluded so new contributors can quickly understand the contract.

### Description

- Add `docs/status/SUPPORT_TIERS.md` which maps typed extraction, pure-Rust parser, GLR, external scanners, incremental parsing, Tree-sitter interop, WASM, CLI, `runtime2`, grammars, golden tests, benchmarks, and serialization to a tier, a proof command, a CI lane, and notes. 
- Update `README.md` features section to point to `docs/status/SUPPORT_TIERS.md` for proof mapping and mark `WASM` and `Tree-sitter interop` as `Advisory` to avoid stable overclaims. 
- Update `docs/README.md` to include a link to the new `Support Tiers` doc for discoverability. 
- Update `docs/status/KNOWN_RED.md` to reference `docs/status/SUPPORT_TIERS.md` so exclusions and proof mappings are cross-linked, and make no code changes.

### Testing

- Ran a targeted keyword search with `rg -n "stable|experimental|advisory|supported|unsupported" README.md docs/status/KNOWN_RED.md docs/status/SUPPORT_TIERS.md` and it returned the new mappings, indicating the README and status docs reference the new doc. 
- Ran `git diff --check HEAD~1..HEAD` to validate there are no whitespace or diff check failures and it succeeded. 
- No runtime or unit tests were changed because this PR contains documentation-only changes and no source code modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a72f1448333b09c1a472c9c9ae9)