### PR TITLE
Add adze-go smoke parsing canaries and STATUS note

### DIFF
--- a/grammars/go/STATUS.md
+++ b/grammars/go/STATUS.md
@@ -1,0 +1,16 @@
+# adze-go smoke status
+
+## Current proof (2026-04-26)
+
+`adze-go` now has smoke tests that:
+
+- construct the generated language object, and
+- parse a minimal fixture (`package main`) through the pure parser with no reported parse errors.
+
+These tests prove the generated grammar can be constructed and can parse at least one concrete fixture successfully in the crate test suite.
+
+## What is not yet proven
+
+Known blocker: parsing `package main var answer int` currently reports declaration-position errors in the pure parser smoke test, so declaration parsing is not yet smoke-proven.
+
+This is still **not** a stability claim. The crate still needs resolution of the declaration parse blocker, typed extraction checks, broader fixture coverage (for example function declarations, blocks, calls, and returns), negative/error-case expectations, and compatibility checks before it can be treated as stable.

--- a/grammars/go/src/lib.rs
+++ b/grammars/go/src/lib.rs
@@ -124,13 +124,65 @@ pub mod grammar {
         #[adze::leaf(pattern = r"[a-zA-Z_][a-zA-Z0-9_]*")]
         pub name: (),
     }
+
+    #[adze::extra]
+    pub enum Extra {
+        #[adze::leaf(pattern = r"\s+")]
+        Whitespace,
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::grammar;
+    use adze::pure_parser::Parser;
+
     #[test]
-    fn test_simple_go() {
-        // Grammar builds successfully
-        assert!(true);
+    fn smoke_build_language_and_parse_minimal_fixture() {
+        let source = "package main";
+
+        let mut parser = Parser::new();
+        parser
+            .set_language(grammar::language())
+            .expect("failed to construct adze-go language");
+
+        let parse_result = parser.parse_bytes(source.as_bytes());
+        assert!(
+            parse_result.root.is_some(),
+            "expected parse root for minimal Go fixture"
+        );
+        assert!(
+            parse_result.errors.is_empty(),
+            "unexpected parse errors: {:?}",
+            parse_result.errors
+        );
+    }
+
+    #[test]
+    fn smoke_known_blocker_package_with_declaration_fixture_reports_errors() {
+        let source = "package main var answer int";
+
+        let mut parser = Parser::new();
+        parser
+            .set_language(grammar::language())
+            .expect("failed to construct adze-go language");
+        let parse_result = parser.parse_bytes(source.as_bytes());
+
+        assert!(
+            parse_result.root.is_some(),
+            "expected parse root for package + var fixture"
+        );
+        assert!(
+            !parse_result.errors.is_empty(),
+            "expected current declaration parsing blocker to report errors"
+        );
+        assert!(
+            parse_result
+                .errors
+                .iter()
+                .any(|error| error.position >= "package main".len()),
+            "expected errors at or after declaration start, got: {:?}",
+            parse_result.errors
+        );
     }
 }


### PR DESCRIPTION
### Motivation
- Promote a small real grammar crate toward smoke-proven status by proving language construction and at least one concrete parse without changing shared runtime/tool internals. 
- Prefer a minimal grammar to minimize required surface area while giving a clear, reproducible canary for future work.

### Description
- Selected `grammars/go` (`adze-go`) and added a grammar-level whitespace `#[adze::extra]` so space-separated fixtures tokenize correctly. 
- Replaced the placeholder unit test with two parser smoke canaries that use the pure parser API: one that constructs the generated language and parses `"package main"` with no errors, and one that runs `"package main var answer int"` and asserts the current declaration parsing blocker reports errors. 
- Added `grammars/go/STATUS.md` documenting what is smoke-proven and the known declaration parsing blocker so the crate status is explicit. 
- Changes made only inside the `grammars/go` crate: `grammars/go/src/lib.rs` and new `grammars/go/STATUS.md`.

### Testing
- Ran `cargo test -p adze-go --no-run` which completed successfully. 
- Ran `cargo test -p adze-go` where the two new tests passed (final result: 2 passed; 0 failed). 
- Ran `cargo fmt --all --check` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a7aefc08333b19b8345e7026dad)