### PR TITLE
Add smoke canary test and status note for test-vec-wrapper grammar

### DIFF
--- a/grammars/test-vec-wrapper/SMOKE_STATUS.md
+++ b/grammars/test-vec-wrapper/SMOKE_STATUS.md
@@ -1,0 +1,19 @@
+# Smoke status (test-vec-wrapper)
+
+- **Date:** 2026-04-26
+- **Status:** Smoke-proven (language-object canary)
+
+## Proven now
+
+- The generated language object can be constructed (`grammar::language()` reports symbols).
+
+## Not yet proven (so not stable yet)
+
+- A strict parse fixture can be asserted without skip logic. For example, a direct
+  `grammar::parse("7")` check currently fails with `ParseError { reason:
+  UnexpectedToken("end"), start: 1, end: 1 }` in this environment.
+- Behavior on representative larger inputs.
+- Error recovery and ambiguity behavior under malformed input.
+- Long-term stability of this crate's typed surface as a published contract.
+
+Treat this as a canary-level smoke proof, not a stability guarantee.

--- a/grammars/test-vec-wrapper/tests/smoke.rs
+++ b/grammars/test-vec-wrapper/tests/smoke.rs
@@ -1,0 +1,10 @@
+use test_vec_wrapper::grammar;
+
+#[test]
+fn test_smoke_language_object_constructs() {
+    let lang = grammar::language();
+    assert!(
+        lang.symbol_count > 0,
+        "generated language should expose symbols"
+    );
+}


### PR DESCRIPTION
### Motivation

- Provide a low-risk smoke proof for a small real grammar crate to separate "crate exists" from "crate builds/parses a fixture". 
- Keep changes local to a single grammar crate and avoid touching shared runtimes, macros, tablegen, or tool internals.

### Description

- Add `grammars/test-vec-wrapper/tests/smoke.rs` containing a focused canary test that calls `grammar::language()` and asserts `lang.symbol_count > 0` to prove the generated language object can be constructed. 
- Add `grammars/test-vec-wrapper/SMOKE_STATUS.md` documenting what is now proven (language object construction) and what remains (strict parse fixture currently fails with `UnexpectedToken("end")`, broader fixtures, recovery/ambiguity). 
- No changes were made to shared libraries or tooling; all edits are confined to the `test-vec-wrapper` crate.

### Testing

- Ran `cargo test -p test-vec-wrapper --test smoke`, which succeeded and the new smoke test passed. 
- Ran `cargo test -p test-vec-wrapper --no-run` to verify test artifacts build, which completed successfully. 
- Ran `cargo fmt --all --check` and formatting checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a7aefc08333b19b8345e7026dad)