### PR TITLE
test(go): add smoke coverage for language loading and parse blocker

### DIFF
--- a/grammars/go/src/lib.rs
+++ b/grammars/go/src/lib.rs
@@ -128,9 +128,23 @@ pub mod grammar {
 
 #[cfg(test)]
 mod tests {
+    use super::grammar;
+    use adze::pure_parser::Parser;
+
     #[test]
-    fn test_simple_go() {
-        // Grammar builds successfully
-        assert!(true);
+    fn test_language_object_can_be_loaded() {
+        let mut parser = Parser::new();
+        parser
+            .set_language(grammar::language())
+            .expect("go language should load into pure parser");
+    }
+
+    #[test]
+    fn test_parse_api_reports_current_blocker() {
+        let result = grammar::parse("package main");
+        assert!(
+            result.is_err(),
+            "go smoke grammar currently should report tokenization errors for spaced input"
+        );
     }
 }


### PR DESCRIPTION
### Motivation
- Promote one small real grammar crate toward smoke-proven status by proving it builds and can at least construct a parser language object without changing shared runtime internals.
- Make the current parse limitation explicit instead of leaving a placeholder test that claimed nothing about runtime behavior.

### Description
- Replaced the placeholder `test_simple_go` with a test that constructs an `adze::pure_parser::Parser` and calls `grammar::language()` to ensure the generated language object loads (`grammars/go/src/lib.rs`).
- Added a second smoke test that calls `grammar::parse("package main")` and asserts it currently returns an error to document the known tokenization/parsing blocker instead of pretending a successful fixture parse exists.
- No changes were made to shared runtime, macro, tablegen, or tool internals; this focuses only on the `adze-go` crate tests.

### Testing
- Ran `cargo test -p adze-go` and observed all tests in that crate pass (`2 passed; 0 failed`).
- Ran `cargo test -p adze-go --no-run` which builds the crate tests successfully.
- Ran `cargo fmt --all --check` which succeeded with no formatting changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a7aefc08333b19b8345e7026dad)