### PR TITLE
Add minimal golden canary: stable node_types JSON test

### DIFF
--- a/golden-tests/Cargo.toml
+++ b/golden-tests/Cargo.toml
@@ -19,3 +19,6 @@ javascript-grammar = ["adze-javascript", "adze"]
 all-grammars = ["python-grammar", "javascript-grammar"]
 
 [dev-dependencies]
+adze-tool = { path = "../tool" }
+serde_json.workspace = true
+tempfile.workspace = true

--- a/golden-tests/README.md
+++ b/golden-tests/README.md
@@ -6,6 +6,10 @@ This directory contains golden-master tests that ensure adze parsers produce ide
 
 ```
 golden-tests/
+├── fixtures/
+│   └── minimal_json_grammar.json   # Tiny grammar fixture for stable node_types JSON
+├── expected/
+│   └── minimal_json_grammar.node_types.json
 ├── python/
 │   ├── fixtures/        # Python source files to parse
 │   └── expected/        # Expected S-expressions and hashes
@@ -58,6 +62,9 @@ This will:
 ### Run Golden Tests
 
 ```bash
+# Runs the default canary golden test (no grammar feature flags needed)
+cargo test -p adze-golden-tests
+
 # Run all golden tests (when grammars are integrated)
 cargo test --features all-grammars
 
@@ -101,10 +108,15 @@ fn python_my_new_test() -> Result<()> {
 
 ## How It Works
 
-1. **Reference Generation**: Uses official Tree-sitter to parse fixtures and save S-expressions
-2. **Hash Comparison**: Computes SHA256 of S-expressions for fast comparison
-3. **Detailed Diff**: On mismatch, saves actual output for debugging
-4. **CI Integration**: Tests run in CI to catch regressions
+1. **JSON canary (active by default)**: Builds a tiny grammar from `fixtures/minimal_json_grammar.json` and compares emitted `node_types_json` to `expected/minimal_json_grammar.node_types.json`.
+2. **Reference Generation (feature-gated)**: Uses official Tree-sitter to parse fixtures and save S-expressions
+3. **Hash Comparison**: Computes SHA256 of S-expressions for fast comparison
+4. **Detailed Diff**: On mismatch, saves actual output for debugging
+5. **CI Integration**: Tests run in CI to catch regressions
+
+## Current Harness Gap
+
+The language S-expression path in `src/lib.rs` currently soft-skips parse failures (`run_golden_test` prints `Skipping ...` and returns `Ok(())`). The default JSON canary exists so `cargo test -p adze-golden-tests` still proves one user-visible parser artifact is stable while the runtime grammar harness is being completed.
 
 ## Benefits
 

--- a/golden-tests/expected/minimal_json_grammar.node_types.json
+++ b/golden-tests/expected/minimal_json_grammar.node_types.json
@@ -1,0 +1,10 @@
+[
+  {
+    "type": "source_file",
+    "named": true
+  },
+  {
+    "type": "x",
+    "named": false
+  }
+]

--- a/golden-tests/fixtures/minimal_json_grammar.json
+++ b/golden-tests/fixtures/minimal_json_grammar.json
@@ -1,0 +1,9 @@
+{
+  "name": "golden_minimal_json",
+  "rules": {
+    "source_file": {
+      "type": "STRING",
+      "value": "x"
+    }
+  }
+}

--- a/golden-tests/src/lib.rs
+++ b/golden-tests/src/lib.rs
@@ -4,6 +4,7 @@ mod example_integration;
 mod tests {
     #![allow(dead_code)]
 
+    use adze_tool::pure_rust_builder::{BuildOptions, build_parser_from_json};
     use anyhow::{Context, Result};
     use sha2::{Digest, Sha256};
     use std::fs;
@@ -597,6 +598,61 @@ mod tests {
     fn unsupported_language_returns_error() {
         let result = parse_with_adze("cobol", "DISPLAY 'HELLO'");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn minimal_json_grammar_node_types_golden() -> Result<()> {
+        let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("fixtures")
+            .join("minimal_json_grammar.json");
+        let expected_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("expected")
+            .join("minimal_json_grammar.node_types.json");
+
+        let grammar_json = fs::read_to_string(&fixture_path)
+            .with_context(|| format!("Failed to read fixture: {}", fixture_path.display()))?;
+
+        let temp_out = tempfile::tempdir()?;
+        let options = BuildOptions {
+            out_dir: temp_out.path().to_string_lossy().into_owned(),
+            emit_artifacts: false,
+            compress_tables: false,
+        };
+
+        let result = build_parser_from_json(grammar_json, options)
+            .with_context(|| "Failed to build parser from JSON fixture")?;
+
+        let actual_pretty = serde_json::to_string_pretty(&serde_json::from_str::<
+            serde_json::Value,
+        >(&result.node_types_json)?)?;
+        if std::env::var("UPDATE_GOLDEN").is_ok() {
+            if let Some(parent) = expected_path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::write(&expected_path, &actual_pretty)?;
+            return Ok(());
+        }
+
+        let expected_pretty = fs::read_to_string(&expected_path).with_context(|| {
+            format!(
+                "Failed to read expected output: {}",
+                expected_path.display()
+            )
+        })?;
+
+        if actual_pretty != expected_pretty {
+            let actual_path = expected_path.with_extension("actual.json");
+            fs::write(&actual_path, actual_pretty)?;
+            anyhow::bail!(
+                "node_types JSON mismatch for fixture {}. \
+                 Expected: {}. Actual written to: {}",
+                fixture_path.display(),
+                expected_path.display(),
+                actual_path.display()
+            );
+        }
+
+        Ok(())
     }
 
     #[cfg(any(feature = "python-grammar", feature = "javascript-grammar"))]


### PR DESCRIPTION
### Motivation
- Provide a small, deterministic golden that proves one user-visible parser artifact is stable even while the language S-expression harness is feature-gated and may skip failures. 
- Keep the fixture tiny so diffs are small and human-reviewable and avoid adding large generated artifacts.

### Description
- Add a tiny JSON grammar fixture at `golden-tests/fixtures/minimal_json_grammar.json` defining a single literal terminal `"x"` as the `source_file` rule. 
- Add the expected pretty `node_types_json` at `golden-tests/expected/minimal_json_grammar.node_types.json` that the pure-Rust builder should emit. 
- Add a default-on test `minimal_json_grammar_node_types_golden` to `golden-tests/src/lib.rs` which runs `adze_tool::pure_rust_builder::build_parser_from_json`, pretty-normalizes `node_types_json`, compares it to the committed expected file, writes `*.actual.json` on mismatch, and supports `UPDATE_GOLDEN=1` to refresh the golden. 
- Add test-only dev-dependencies to `golden-tests/Cargo.toml` (`adze-tool`, `serde_json`, `tempfile`) and update `golden-tests/README.md` to document the new canary and note the current S-expression harness gap.

### Testing
- Ran `cargo test -p adze-golden-tests -- --nocapture` and observed the test suite pass including the new canary (`14 passed`).
- Ran `cargo fmt --all --check` and fixed formatting as needed so the check passes.
- Attempted `cargo test -p adze golden -- --nocapture` (full runtime build) but it is build-heavy and did not complete in a short interactive session (not required for the new JSON canary to be useful).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a7fbc5883338fabdc59ad5d4c41)