### PR TITLE
Add wasm-demo parser-facing smoke check for wasm32 builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1082,6 +1082,8 @@ jobs:
             echo "Checking $crate..."
             cargo check --target wasm32-unknown-unknown -p "$crate"
           done
+      - name: Check wasm-demo parser-facing smoke entrypoint for WASM
+        run: cargo check --target wasm32-unknown-unknown -p adze-wasm-demo
 
   cross-platform:
     name: Cross-platform (${{ matrix.os }})

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ complete walkthrough.
 | **Pure Rust** | ✅ Stable | Default backend is 100% Rust; no C toolchain needed |
 | **GLR parsing** | ✅ Stable | Handles ambiguous grammars (C++, JavaScript, etc.) |
 | **Operator precedence** | ✅ Stable | `#[prec_left]`, `#[prec_right]` for disambiguation |
-| **WASM support** | ✅ Stable | Compile parsers to WebAssembly with `features = ["wasm"]` |
+| **WASM support** | ✅ Stable | Compile parsers to WebAssembly with `features = ["wasm"]`; `adze-wasm-demo` includes a parser-facing smoke entrypoint (`parser_smoke`) |
 | **Tree-sitter interop** | ✅ Stable | Import existing Tree-sitter grammars via `ts-bridge` |
 | **Serialization** | ✅ Stable | JSON and S-expression output with `features = ["serialization"]` |
 | **External scanners** | 🧪 Experimental | Custom tokenization via `ExternalScanner` trait |

--- a/docs/status/KNOWN_RED.md
+++ b/docs/status/KNOWN_RED.md
@@ -36,7 +36,7 @@ Rule: if something is excluded from the supported lane, it must be listed here w
 
 This lane is intentionally bounded so it stays reliable and fast enough for day-to-day work.
 
-**Current status:** GREEN — all supported crates compile, lint clean, and tests pass. **2,460+ tests across feature combinations, 0 failures in supported lane.** Feature-combination matrix: 12/12 pass (all green). `cargo-audit` clean (0 vulnerabilities). WASM: all core crates compile for `wasm32-unknown-unknown`.
+**Current status:** GREEN — all supported crates compile, lint clean, and tests pass. **2,460+ tests across feature combinations, 0 failures in supported lane.** Feature-combination matrix: 12/12 pass (all green). `cargo-audit` clean (0 vulnerabilities). WASM: all core crates compile for `wasm32-unknown-unknown`, and `adze-wasm-demo` now has a parser-facing smoke entrypoint (`parser_smoke`) checked with `cargo check -p adze-wasm-demo --target wasm32-unknown-unknown` in optional CI.
 
 ---
 

--- a/wasm-demo/src/lib.rs
+++ b/wasm-demo/src/lib.rs
@@ -25,10 +25,26 @@ pub fn parse_arithmetic(source: &str) -> String {
     }
 }
 
+/// Minimal parser-facing smoke entrypoint for WASM checks.
+///
+/// Returns `true` when the bundled arithmetic grammar can parse a tiny input.
+#[wasm_bindgen]
+pub fn parser_smoke() -> bool {
+    adze_example::arithmetic::grammar::parse("1 + 2 * 3").is_ok()
+}
+
 /// Get GLR statistics from the last parse
 #[wasm_bindgen]
 pub fn get_parser_stats() -> String {
     // This would need to be stored in a global or passed back differently
     // For now, just return a placeholder
     "Stats: To be implemented".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_parser_smoke_entrypoint() {
+        assert!(super::parser_smoke());
+    }
 }


### PR DESCRIPTION
### Motivation
- Provide a minimal, realistic proof that WASM support covers a parser-facing path rather than only crate compilation by exercising a bundled grammar in the wasm demo.
- Keep the change small and local to the demo/docs/CI surface without changing core runtime algorithms or adding heavy browser tooling.

### Description
- Add a WASM-exported smoke entrypoint `parser_smoke()` in `wasm-demo/src/lib.rs` that runs the bundled arithmetic parser on a tiny input and returns `bool`.
- Add a native unit test `test_parser_smoke_entrypoint` for `parser_smoke()` in `wasm-demo` to verify parser execution on normal test runs.
- Extend the `wasm-check` CI job to compile `adze-wasm-demo` for `wasm32-unknown-unknown` using `cargo check --target wasm32-unknown-unknown -p adze-wasm-demo` so the parser-facing smoke is compiled for WASM in optional CI.
- Update `README.md` and `docs/status/KNOWN_RED.md` to document the new parser-facing smoke coverage.

### Testing
- Ran `cargo fmt --all --check`, which succeeded.
- Ran `cargo test -p adze-wasm-demo --no-run`, which completed successfully.
- Ran `cargo test -p adze-wasm-demo test_parser_smoke_entrypoint`, which executed the unit test and passed (`1 passed; 0 failed`).
- Ran `cargo check -p adze-wasm-demo --target wasm32-unknown-unknown`, which completed successfully, proving the parser-facing compile smoke for `wasm32-unknown-unknown`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a8327c48333b86090af75d4331e)