### PR TITLE
wasm-demo: add parser-facing wasm32 smoke (compile + unit) and CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1082,6 +1082,8 @@ jobs:
             echo "Checking $crate..."
             cargo check --target wasm32-unknown-unknown -p "$crate"
           done
+      - name: Check wasm-demo parser-facing smoke for WASM
+        run: cargo check --manifest-path wasm-demo/Cargo.toml --target wasm32-unknown-unknown
 
   cross-platform:
     name: Cross-platform (${{ matrix.os }})

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ complete walkthrough.
 | **Pure Rust** | ✅ Stable | Default backend is 100% Rust; no C toolchain needed |
 | **GLR parsing** | ✅ Stable | Handles ambiguous grammars (C++, JavaScript, etc.) |
 | **Operator precedence** | ✅ Stable | `#[prec_left]`, `#[prec_right]` for disambiguation |
-| **WASM support** | ✅ Stable | Compile parsers to WebAssembly with `features = ["wasm"]` |
+| **WASM support** | ✅ Stable | Compile parsers to WebAssembly with `features = ["wasm"]`; `wasm-demo` includes a parser-facing wasm32 smoke path |
 | **Tree-sitter interop** | ✅ Stable | Import existing Tree-sitter grammars via `ts-bridge` |
 | **Serialization** | ✅ Stable | JSON and S-expression output with `features = ["serialization"]` |
 | **External scanners** | 🧪 Experimental | Custom tokenization via `ExternalScanner` trait |

--- a/docs/status/KNOWN_RED.md
+++ b/docs/status/KNOWN_RED.md
@@ -36,7 +36,7 @@ Rule: if something is excluded from the supported lane, it must be listed here w
 
 This lane is intentionally bounded so it stays reliable and fast enough for day-to-day work.
 
-**Current status:** GREEN — all supported crates compile, lint clean, and tests pass. **2,460+ tests across feature combinations, 0 failures in supported lane.** Feature-combination matrix: 12/12 pass (all green). `cargo-audit` clean (0 vulnerabilities). WASM: all core crates compile for `wasm32-unknown-unknown`.
+**Current status:** GREEN — all supported crates compile, lint clean, and tests pass. **2,460+ tests across feature combinations, 0 failures in supported lane.** Feature-combination matrix: 12/12 pass (all green). `cargo-audit` clean (0 vulnerabilities). WASM: all core crates compile for `wasm32-unknown-unknown`, and optional CI now includes a parser-facing `wasm-demo` smoke compile for `wasm32-unknown-unknown`.
 
 ---
 

--- a/wasm-demo/src/lib.rs
+++ b/wasm-demo/src/lib.rs
@@ -1,7 +1,7 @@
 use wasm_bindgen::prelude::*;
 
 // Called when the WASM module is instantiated
-#[wasm_bindgen(start)]
+#[cfg_attr(not(test), wasm_bindgen(start))]
 pub fn main() {
     // Set panic hook for better error messages in browser console
     // console_error_panic_hook::set_once();
@@ -25,10 +25,29 @@ pub fn parse_arithmetic(source: &str) -> String {
     }
 }
 
+// Compile-time smoke for wasm32 builds: ensure the exported parser-facing entrypoint
+// has the expected signature and remains available.
+#[cfg(target_arch = "wasm32")]
+const _PARSE_ARITHMETIC_ENTRYPOINT: fn(&str) -> String = parse_arithmetic;
+
 /// Get GLR statistics from the last parse
 #[wasm_bindgen]
 pub fn get_parser_stats() -> String {
     // This would need to be stored in a global or passed back differently
     // For now, just return a placeholder
     "Stats: To be implemented".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_arithmetic;
+
+    #[test]
+    fn test_parse_arithmetic_smoke_success() {
+        let output = parse_arithmetic("1 + 2");
+        assert!(
+            output.contains("Parse successful!"),
+            "expected parser success output, got: {output}"
+        );
+    }
 }


### PR DESCRIPTION
### Motivation
- Prove that WASM support is parser-facing (not just crate compile) by adding a minimal, realistic smoke that validates an exported parse entrypoint for `wasm32-unknown-unknown`.
- Keep changes small and local to the demo/docs/CI surface so core runtime algorithms are not altered and heavy browser tooling is avoided.

### Description
- Added a wasm-facing smoke in `wasm-demo/src/lib.rs` that keeps `parse_arithmetic` as the exported entrypoint and adds a compile-time signature check `const _PARSE_ARITHMETIC_ENTRYPOINT: fn(&str) -> String = parse_arithmetic` for `target_arch = "wasm32"`.
- Added a unit smoke test `test_parse_arithmetic_smoke_success` in `wasm-demo/src/lib.rs` that invokes `parse_arithmetic("1 + 2")` to assert parser behavior during test builds.
- Made the wasm start hook test-friendly by changing `#[wasm_bindgen(start)]` to `#[cfg_attr(not(test), wasm_bindgen(start))]` so wasm test builds compile cleanly.
- Extended the optional CI `wasm-check` job to run `cargo check --manifest-path wasm-demo/Cargo.toml --target wasm32-unknown-unknown` and updated `README.md` and `docs/status/KNOWN_RED.md` to reflect the parser-facing wasm smoke.

### Testing
- Ran `cargo fmt --all --check` which succeeded.
- Added the wasm target with `rustup target add wasm32-unknown-unknown` and then ran `cargo check --manifest-path wasm-demo/Cargo.toml --target wasm32-unknown-unknown` which compiled successfully.
- Ran `cargo test --manifest-path wasm-demo/Cargo.toml --no-run` and `cargo test --manifest-path wasm-demo/Cargo.toml --target wasm32-unknown-unknown --no-run` which both compiled the demo and its tests (no runtime test execution in CI).
- Outcome: the repository now includes an explicit parser-facing compile smoke for `wasm32-unknown-unknown` (and a native unit parse smoke in `wasm-demo`) while leaving in-wasm runtime/browser execution as future work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a8327c48333b86090af75d4331e)