### PR TITLE
Add wasm-demo parser-facing wasm32 smoke check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1082,6 +1082,8 @@ jobs:
             echo "Checking $crate..."
             cargo check --target wasm32-unknown-unknown -p "$crate"
           done
+      - name: Check parser-facing wasm-demo smoke for WASM
+        run: cargo check --manifest-path wasm-demo/Cargo.toml --target wasm32-unknown-unknown
 
   cross-platform:
     name: Cross-platform (${{ matrix.os }})

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ complete walkthrough.
 | **Pure Rust** | ✅ Stable | Default backend is 100% Rust; no C toolchain needed |
 | **GLR parsing** | ✅ Stable | Handles ambiguous grammars (C++, JavaScript, etc.) |
 | **Operator precedence** | ✅ Stable | `#[prec_left]`, `#[prec_right]` for disambiguation |
-| **WASM support** | ✅ Stable | Compile parsers to WebAssembly with `features = ["wasm"]` |
+| **WASM support** | ✅ Stable | Parser-facing compile smoke on `wasm32-unknown-unknown` (`wasm-demo` arithmetic entrypoint) |
 | **Tree-sitter interop** | ✅ Stable | Import existing Tree-sitter grammars via `ts-bridge` |
 | **Serialization** | ✅ Stable | JSON and S-expression output with `features = ["serialization"]` |
 | **External scanners** | 🧪 Experimental | Custom tokenization via `ExternalScanner` trait |

--- a/docs/status/KNOWN_RED.md
+++ b/docs/status/KNOWN_RED.md
@@ -36,7 +36,7 @@ Rule: if something is excluded from the supported lane, it must be listed here w
 
 This lane is intentionally bounded so it stays reliable and fast enough for day-to-day work.
 
-**Current status:** GREEN — all supported crates compile, lint clean, and tests pass. **2,460+ tests across feature combinations, 0 failures in supported lane.** Feature-combination matrix: 12/12 pass (all green). `cargo-audit` clean (0 vulnerabilities). WASM: all core crates compile for `wasm32-unknown-unknown`.
+**Current status:** GREEN — all supported crates compile, lint clean, and tests pass. **2,460+ tests across feature combinations, 0 failures in supported lane.** Feature-combination matrix: 12/12 pass (all green). `cargo-audit` clean (0 vulnerabilities). WASM: all core crates compile for `wasm32-unknown-unknown`, plus `wasm-demo` has a parser-facing compile smoke entrypoint (`parser_facing_smoke` for arithmetic grammar).
 
 ---
 

--- a/wasm-demo/src/lib.rs
+++ b/wasm-demo/src/lib.rs
@@ -2,7 +2,7 @@ use wasm_bindgen::prelude::*;
 
 // Called when the WASM module is instantiated
 #[wasm_bindgen(start)]
-pub fn main() {
+pub fn init_wasm_demo() {
     // Set panic hook for better error messages in browser console
     // console_error_panic_hook::set_once();
 
@@ -25,10 +25,29 @@ pub fn parse_arithmetic(source: &str) -> String {
     }
 }
 
+/// Minimal parser-facing WASM smoke path.
+///
+/// This proves `wasm-demo` can compile a parser entrypoint that calls into
+/// generated parsing code (for arithmetic grammar).
+#[wasm_bindgen]
+pub fn parser_facing_smoke() -> bool {
+    adze_example::arithmetic::grammar::parse("1 + 2 * 3").is_ok()
+}
+
 /// Get GLR statistics from the last parse
 #[wasm_bindgen]
 pub fn get_parser_stats() -> String {
     // This would need to be stored in a global or passed back differently
     // For now, just return a placeholder
     "Stats: To be implemented".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parser_facing_smoke() {
+        assert!(parser_facing_smoke());
+    }
 }


### PR DESCRIPTION
### Motivation
- Provide stronger WASM proof than a compile-only check by exposing a parser-facing entrypoint that calls generated parser code. 
- Keep changes minimal and local to the `wasm-demo` smoke path and status docs while avoiding changes to core runtime algorithms. 

### Description
- Add `parser_facing_smoke()` to `wasm-demo/src/lib.rs` which calls `adze_example::arithmetic::grammar::parse("1 + 2 * 3")` and returns a boolean indicating success. 
- Add a unit test `test_parser_facing_smoke()` under `wasm-demo` that exercises the new smoke path. 
- Rename the wasm start function from `main` to `init_wasm_demo()` to avoid duplicate `main` symbol when building wasm test artifacts. 
- Add a CI step to the `wasm-check` job to run `cargo check --manifest-path wasm-demo/Cargo.toml --target wasm32-unknown-unknown` so the parser-facing smoke is checked in automation. 
- Update `README.md` and `docs/status/KNOWN_RED.md` to document that WASM coverage now includes a parser-facing compile smoke via `wasm-demo`. 

### Testing
- Ran `cargo fmt --all --check` and it succeeded. 
- Ran `cargo check --manifest-path wasm-demo/Cargo.toml --target wasm32-unknown-unknown` (installed `wasm32-unknown-unknown` target when needed) and it completed successfully. 
- Ran `cargo test --manifest-path wasm-demo/Cargo.toml --target wasm32-unknown-unknown --no-run` and the test artifacts were produced successfully. 

Outcome: this PR upgrades the WASM proof from “crate compiles” to an explicit **parser-facing compile smoke** for `wasm32-unknown-unknown` (arithmetic parser entrypoint). End-to-end runtime execution in a browser or `wasm-bindgen` test harness is still out of scope for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a8327c48333b86090af75d4331e)