### PR TITLE
Add wasm32 parser-facing compile smoke for wasm-demo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1082,6 +1082,10 @@ jobs:
             echo "Checking $crate..."
             cargo check --target wasm32-unknown-unknown -p "$crate"
           done
+      - name: WASM parser-facing smoke (wasm-demo)
+        run: |
+          cargo check --target wasm32-unknown-unknown -p adze-wasm-demo
+          cargo test --target wasm32-unknown-unknown -p adze-wasm-demo --no-run
 
   cross-platform:
     name: Cross-platform (${{ matrix.os }})

--- a/docs/status/KNOWN_RED.md
+++ b/docs/status/KNOWN_RED.md
@@ -36,7 +36,7 @@ Rule: if something is excluded from the supported lane, it must be listed here w
 
 This lane is intentionally bounded so it stays reliable and fast enough for day-to-day work.
 
-**Current status:** GREEN — all supported crates compile, lint clean, and tests pass. **2,460+ tests across feature combinations, 0 failures in supported lane.** Feature-combination matrix: 12/12 pass (all green). `cargo-audit` clean (0 vulnerabilities). WASM: all core crates compile for `wasm32-unknown-unknown`.
+**Current status:** GREEN — all supported crates compile, lint clean, and tests pass. **2,460+ tests across feature combinations, 0 failures in supported lane.** Feature-combination matrix: 12/12 pass (all green). `cargo-audit` clean (0 vulnerabilities). WASM: all core crates compile for `wasm32-unknown-unknown`; `wasm-demo` additionally has a parser-facing compile smoke (`cargo check` + `cargo test --no-run` on `wasm32-unknown-unknown`).
 
 ---
 

--- a/wasm-demo/src/lib.rs
+++ b/wasm-demo/src/lib.rs
@@ -2,7 +2,7 @@ use wasm_bindgen::prelude::*;
 
 // Called when the WASM module is instantiated
 #[wasm_bindgen(start)]
-pub fn main() {
+pub fn wasm_demo_start() {
     // Set panic hook for better error messages in browser console
     // console_error_panic_hook::set_once();
 
@@ -31,4 +31,17 @@ pub fn get_parser_stats() -> String {
     // This would need to be stored in a global or passed back differently
     // For now, just return a placeholder
     "Stats: To be implemented".to_string()
+}
+
+#[cfg(all(test, target_arch = "wasm32"))]
+mod wasm_smoke {
+    use super::*;
+
+    #[test]
+    fn test_wasm_parser_facing_smoke_compile() {
+        // Parser-facing smoke: ensure the exported entrypoint compiles for wasm32
+        // and reaches a real parse path from the demo surface.
+        let result = parse_arithmetic("1+2");
+        assert!(!result.is_empty());
+    }
 }


### PR DESCRIPTION
### Motivation

- The project advertises WASM support but previously only exercised crate-level compilation; we need a minimal parser-facing proof that exported parse entrypoints typecheck for `wasm32-unknown-unknown`.
- Keep changes small and local to the demo and CI, avoiding modifications to core runtime algorithms or heavy browser tooling.
- Provide an automated smoke that CI can run to signal parser-surface wiring for WASM without requiring a runtime/browser harness yet.

### Description

- Add a wasm-targeted parser-facing smoke test in `wasm-demo/src/lib.rs` (`test_wasm_parser_facing_smoke_compile`) that calls the demo export `parse_arithmetic("1+2")` to exercise the exported parse path at compile/test time.
- Rename the wasm module start function from `main` to `wasm_demo_start` to avoid duplicate `main` symbol errors when building tests for the `wasm32` target.
- Extend the CI `wasm-check` job in `.github/workflows/ci.yml` to run `cargo check --target wasm32-unknown-unknown -p adze-wasm-demo` and `cargo test --target wasm32-unknown-unknown -p adze-wasm-demo --no-run` as a parser-facing smoke.
- Update `docs/status/KNOWN_RED.md` to record that `wasm-demo` now has an explicit parser-facing compile smoke for the `wasm32-unknown-unknown` target.

### Testing

- Ran `cargo check -p adze-wasm-demo --target wasm32-unknown-unknown` locally and it completed successfully.
- Ran `cargo test -p adze-wasm-demo --target wasm32-unknown-unknown --no-run` locally and it completed successfully (test artifact built for `wasm32`).
- Ran `cargo fmt --all --check` and formatting check passed.

Outcome: this PR provides an explicit parser-facing compile smoke for `wasm-demo` on `wasm32-unknown-unknown` (proves exported parse entrypoint compiles and typechecks); it does not yet prove runtime parser execution inside a wasm runtime/browser, which remains a future step (add a wasm runtime/browser harness or wasm-bindgen test to exercise execution).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a8327c48333b86090af75d4331e)