### PR TITLE
Clarify benchmark scope and mark placeholder benches explicitly

### DIFF
--- a/benchmarks/benches/glr_performance_real.rs
+++ b/benchmarks/benches/glr_performance_real.rs
@@ -102,12 +102,12 @@ fn benchmark_real_parsing(c: &mut Criterion) {
     group.finish();
 }
 
-/// Benchmark fixture loading overhead (should be ~0ns with include_str!)
+/// Utility microbenchmark: fixture loading overhead (should be ~0ns with include_str!)
 ///
 /// This validates that compile-time embedding works correctly.
 /// With `include_str!()`, this should be just a pointer dereference.
 fn benchmark_fixture_loading(c: &mut Criterion) {
-    c.bench_function("fixture_loading_small", |b| {
+    c.bench_function("utility_fixture_loading_small", |b| {
         b.iter(|| {
             // With include_str!(), this is just a pointer dereference
             // Expected time: < 1 ns
@@ -116,7 +116,7 @@ fn benchmark_fixture_loading(c: &mut Criterion) {
         });
     });
 
-    c.bench_function("fixture_loading_large", |b| {
+    c.bench_function("utility_fixture_loading_large", |b| {
         b.iter(|| {
             let source = ARITH_LARGE;
             black_box(source)
@@ -124,15 +124,14 @@ fn benchmark_fixture_loading(c: &mut Criterion) {
     });
 }
 
-/// Benchmark parse result validation (tree traversal overhead)
+/// Utility microbenchmark: parse result flag check (not parser throughput)
 ///
-/// Measures cost of validating parse trees, which will be important
-/// for correctness testing alongside performance benchmarks.
+/// Measures only `Result::is_ok()` on a precomputed parse result.
 fn benchmark_parse_validation(c: &mut Criterion) {
     // Pre-parse once to get a tree for validation benchmarks
     let small_result = parse(ARITH_SMALL);
 
-    c.bench_function("validate_parse_result", |b| {
+    c.bench_function("utility_parse_result_is_ok", |b| {
         b.iter(|| {
             // Simulate validation: check if parse succeeded and extract result
             let is_valid = small_result.is_ok();

--- a/benchmarks/benches/parse_bench.rs
+++ b/benchmarks/benches/parse_bench.rs
@@ -1,11 +1,13 @@
-// TODO: Fix benchmarks after pure_parser API stabilization
-// This file is temporarily disabled while we stabilize the parser API
+// Placeholder benchmark while parser API migration is in progress.
+//
+// IMPORTANT: This does NOT exercise parser behavior. It exists only to keep
+// the benchmark target compiling until real parser benches are reintroduced.
 
 use criterion::{criterion_group, criterion_main};
 
-fn dummy_bench(c: &mut criterion::Criterion) {
-    c.bench_function("dummy", |b| b.iter(|| 1 + 1));
+fn placeholder_api_migration_smoke(c: &mut criterion::Criterion) {
+    c.bench_function("placeholder_no_parser_work", |b| b.iter(|| 1 + 1));
 }
 
-criterion_group!(benches, dummy_bench);
+criterion_group!(benches, placeholder_api_migration_smoke);
 criterion_main!(benches);

--- a/docs/status/PERFORMANCE.md
+++ b/docs/status/PERFORMANCE.md
@@ -13,14 +13,15 @@ benchmarking, and known limitations of adze's parsing infrastructure.
 | GLR with few conflicts | O(n) amortized | ~224 µs for 200-op expressions | Fork/merge overhead is constant per conflict site |
 | GLR with pervasive ambiguity | O(n³) worst case | Varies widely | Every token triggers forking; avoid if possible |
 
-The arithmetic grammar benchmarks illustrate typical scaling:
+The arithmetic grammar benchmarks illustrate **indicative scaling on the
+arithmetic fixture set** (not a universal SLA for all grammars/hardware):
 
 - **Small** (~100 LOC, ~88 expressions): 10–100 µs
 - **Medium** (~2,000 LOC, ~1,914 expressions): 200 µs – 2 ms
 - **Large** (~10,000 LOC, ~9,606 expressions): 1–10 ms
 
-These numbers come from `benchmarks/benches/glr_performance_real.rs` using valid
-arithmetic expression fixtures.
+These numbers come from `cargo bench -p adze-benchmarks --bench glr_performance_real`
+using valid arithmetic expression fixtures.
 
 ### Memory Usage Patterns
 
@@ -141,19 +142,41 @@ cargo bench -p adze-tablegen
 cargo bench -p adze-benchmarks
 ```
 
-**Benchmark suites across the workspace:**
+### Benchmark Inventory (Truth-in-labeling)
 
-| Crate | Benchmark | What It Measures |
+Legend for **Class**: real parser workload, tablegen workload, compression/decode
+workload, GLR forest/fork workload, placeholder/mock, utility microbenchmark.
+
+| Path | Class | Notes |
 |---|---|---|
-| `adze-benchmarks` | `glr_performance.rs` | End-to-end GLR parsing of arithmetic fixtures |
-| `adze-benchmarks` | `glr_performance_real.rs` | Release-gated real parsing benchmarks |
-| `adze-glr-core` | `automaton.rs` | LR(1) automaton construction time |
-| `adze-glr-core` | `perf_snapshot.rs` | GLR core performance snapshots |
-| `adze-tablegen` | `compression.rs` | Parse table compression speed |
-| `runtime` | `glr_parser_bench.rs` | GLR parser with ambiguous grammars |
-| `runtime` | `parser_benchmark.rs` | General parser benchmarks |
-| `runtime` | `pure_rust_bench.rs` | Pure-Rust backend performance |
-| `runtime` | `incremental_benchmark.rs` | Incremental parsing overhead |
+| `benchmarks/benches/glr_hot.rs` | real parser workload | Parses valid arithmetic fixtures with generated parser. |
+| `benchmarks/benches/glr_performance.rs` | real parser workload | Same fixture family as `glr_hot`, size sweep small→large. |
+| `benchmarks/benches/glr_performance_real.rs` | real parser workload + utility microbenchmark | Main group is real parse throughput; `utility_*` benches are non-parse helpers. |
+| `benchmarks/benches/core_baselines.rs` | tablegen workload | IR normalize, FIRST/FOLLOW, LR(1) automaton build, compression. |
+| `benchmarks/benches/arena_vs_box_allocation.rs` | utility microbenchmark | Allocation strategy benchmark, not parsing end-to-end. |
+| `benchmarks/benches/stack_optimization.rs` | GLR forest/fork workload | Stack fork/memory-pool mechanics; synthetic but parser-adjacent. |
+| `benchmarks/benches/optimization_bench.rs` | utility microbenchmark | Pool/arena simulation workload, not parser correctness throughput. |
+| `benchmarks/benches/incremental_bench.rs` | GLR forest/fork workload | Incremental edit-path behaviors over arithmetic token stream. |
+| `benchmarks/benches/parse_bench.rs` | placeholder/mock | Explicit placeholder during parser API migration (`placeholder_no_parser_work`). |
+| `runtime/benches/glr_parser_bench.rs` | GLR forest/fork workload | Ambiguous grammar parse path/fork pressure. |
+| `runtime/benches/runtime_parse_serialize_bench.rs` | real parser workload + utility microbenchmark | Real parse plus serialization/traversal costs. |
+| `runtime/benches/parser_benchmark.rs` | real parser workload | Macro-defined arithmetic grammar parser calls. |
+| `runtime/benches/simple_bench.rs` | utility microbenchmark | Lexer-focused throughput on synthetic snippets. |
+| `runtime/benches/parser_bench.rs` | placeholder/mock | Gated unstable API migration bench; not active in default runs. |
+| `runtime/benches/perf_benchmark.rs` | placeholder/mock | Legacy scaffold with removed parser/lexer paths in comments. |
+| `runtime/benches/pure_rust_bench.rs` | placeholder/mock | Temporary API-migration stub executable. |
+| `runtime/benches/incremental_benchmark.rs` | GLR forest/fork workload | Incremental parser edit replay; feature-gated unstable bench. |
+| `runtime/benches/incremental_parsing.rs` | GLR forest/fork workload | Incremental token edit cases; unstable bench. |
+| `runtime/benches/incremental_simple.rs` | GLR forest/fork workload | Simplified incremental edit workload; unstable bench. |
+| `glr-core/benches/automaton.rs` | tablegen workload | FIRST/FOLLOW and LR(1) automaton construction. |
+| `glr-core/benches/perf_snapshot.rs` | utility microbenchmark | EOF-only driver hot-path snapshot (`micro_eof_only_parse`). |
+| `tablegen/benches/compression.rs` | compression/decode workload | Parse-table compression across grammar shapes/sizes. |
+
+### Still-missing Real Benchmark Categories
+
+- Real-world language grammar parse fixtures (Python/JavaScript/Go) beyond arithmetic.
+- Compression **decode**/lookup runtime benchmarks (current suite is compression-build heavy).
+- End-to-end incremental parsing benchmark with validated token edit mapping from real source edits.
 
 ### Interpreting Results
 

--- a/glr-core/benches/perf_snapshot.rs
+++ b/glr-core/benches/perf_snapshot.rs
@@ -22,7 +22,7 @@ pub fn bench_parse_small(c: &mut Criterion) {
         g.warm_up_time(Duration::from_secs(3));
     }
 
-    // Minimal table/driver for this microbench.
+    // Minimal table/driver for this microbench (EOF-only toy workload).
     let table = make_minimal_table(
         vec![vec![vec![], vec![], vec![]]], // ERROR, terminal, EOF
         vec![vec![], vec![], vec![]],
@@ -46,7 +46,7 @@ pub fn bench_parse_small(c: &mut Criterion) {
     }
 
     // Time only the hot path.
-    g.bench_function("small-parse", |b| {
+    g.bench_function("micro_eof_only_parse", |b| {
         b.iter(|| {
             #[cfg(feature = "perf_counters")]
             let _ = perf::take(); // zero


### PR DESCRIPTION
### Motivation

- Remove misleading performance claims by making benchmark names and docs reflect what they actually exercise.
- Make placeholder and utility microbenchmarks impossible to confuse with end-to-end parser/GLR throughput measurements.
- Provide a concise inventory so maintainers can see which benchmark files are real parser workloads and which are scaffolding or tablegen/compression targets.

### Description

- Renamed and documented the placeholder bench in `benchmarks/benches/parse_bench.rs` to `placeholder_api_migration_smoke` / `placeholder_no_parser_work` and added a top comment stating it does not exercise parser behavior.
- Renamed non-parser helper benchmark IDs in `benchmarks/benches/glr_performance_real.rs` to `utility_fixture_loading_*` and `utility_parse_result_is_ok`, and updated comments to label them as utility microbenchmarks. 
- Clarified `glr-core/benches/perf_snapshot.rs` to mark the hot-path microbench as an EOF-only toy workload and renamed its benchmark ID to `micro_eof_only_parse`. 
- Updated `docs/status/PERFORMANCE.md` with a benchmark inventory table that classifies each bench file (real parser, tablegen, compression, GLR forest/fork, utility microbenchmark, placeholder/mock) and softened arithmetic timing language while pointing to the concrete bench command used. 

### Testing

- Ran `cargo fmt --all --check` which passed. 
- Ran `git diff --check` which reported no whitespace or index issues. 
- Built benchmark targets with `cargo bench -p adze-benchmarks --no-run`, `cargo bench -p adze-glr-core --no-run`, and `cargo bench -p adze-tablegen --no-run` to verify the bench targets compile as executables, all of which completed successfully (no-run mode).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a8c08488333884c1ca689da6e98)