### PR TITLE
Clarify benchmark scope, mark placeholder benches, and document benchmark inventory

### DIFF
--- a/benchmarks/benches/parse_bench.rs
+++ b/benchmarks/benches/parse_bench.rs
@@ -1,10 +1,13 @@
-// TODO: Fix benchmarks after pure_parser API stabilization
-// This file is temporarily disabled while we stabilize the parser API
+//! Placeholder benchmark while parser API stabilization is in progress.
+//!
+//! This does **not** measure parser performance. Keep this bench only so CI and
+//! local `cargo bench -p adze-benchmarks --no-run` continue to validate bench
+//! wiring until a real parser workload replaces it.
 
 use criterion::{criterion_group, criterion_main};
 
 fn dummy_bench(c: &mut criterion::Criterion) {
-    c.bench_function("dummy", |b| b.iter(|| 1 + 1));
+    c.bench_function("placeholder_no_parser_workload", |b| b.iter(|| 1 + 1));
 }
 
 criterion_group!(benches, dummy_bench);

--- a/docs/status/PERFORMANCE.md
+++ b/docs/status/PERFORMANCE.md
@@ -13,14 +13,16 @@ benchmarking, and known limitations of adze's parsing infrastructure.
 | GLR with few conflicts | O(n) amortized | ~224 µs for 200-op expressions | Fork/merge overhead is constant per conflict site |
 | GLR with pervasive ambiguity | O(n³) worst case | Varies widely | Every token triggers forking; avoid if possible |
 
-The arithmetic grammar benchmarks illustrate typical scaling:
+The arithmetic grammar benchmarks illustrate typical scaling in this repository's
+fixture-driven parser benches (not a cross-machine SLA):
 
 - **Small** (~100 LOC, ~88 expressions): 10–100 µs
 - **Medium** (~2,000 LOC, ~1,914 expressions): 200 µs – 2 ms
 - **Large** (~10,000 LOC, ~9,606 expressions): 1–10 ms
 
-These numbers come from `benchmarks/benches/glr_performance_real.rs` using valid
-arithmetic expression fixtures.
+These ranges come from `benchmarks/benches/glr_performance_real.rs` using valid
+arithmetic expression fixtures on a developer machine. Treat them as directional
+unless you reproduce them locally with the commands in this document.
 
 ### Memory Usage Patterns
 
@@ -154,6 +156,54 @@ cargo bench -p adze-benchmarks
 | `runtime` | `parser_benchmark.rs` | General parser benchmarks |
 | `runtime` | `pure_rust_bench.rs` | Pure-Rust backend performance |
 | `runtime` | `incremental_benchmark.rs` | Incremental parsing overhead |
+
+### Benchmark Inventory and Credibility
+
+The table below classifies every benchmark file under:
+
+- `benchmarks/**`
+- `runtime/benches/**`
+- `glr-core/benches/**`
+- `tablegen/benches/**`
+
+Use this inventory to distinguish **real parser/GLR evidence** from
+**placeholder** and **utility** microbenchmarks.
+
+| Benchmark file | Classification | Notes |
+|---|---|---|
+| `benchmarks/benches/glr_performance.rs` | real parser workload | Parses real arithmetic fixtures with `adze_example::arithmetic::grammar::parse`. |
+| `benchmarks/benches/glr_hot.rs` | real parser workload | Hot-path fixture parsing only (medium/large). |
+| `benchmarks/benches/glr_performance_real.rs` | real parser workload | Primary fixture-driven GLR parser benchmark. |
+| `benchmarks/benches/incremental_bench.rs` | GLR forest/fork workload | Measures incremental parser behavior using grammar/token/edit helpers. |
+| `benchmarks/benches/core_baselines.rs` | tablegen workload | IR normalize, FIRST/FOLLOW, LR(1) automaton, and table compression generation steps. |
+| `benchmarks/benches/arena_vs_box_allocation.rs` | utility microbenchmark | Allocation strategy benchmark; not an end-to-end parser benchmark. |
+| `benchmarks/benches/optimization_bench.rs` | placeholder/mock | Simulated parse/fork loops (`parse_simulation`), not a parser run. |
+| `benchmarks/benches/stack_optimization.rs` | utility microbenchmark | Stack/pool/fork-pattern data-structure costs, synthetic workload. |
+| `benchmarks/benches/parse_bench.rs` | placeholder/mock | Explicit placeholder target (`placeholder_no_parser_workload`). |
+| `runtime/benches/glr_parser_bench.rs` | GLR forest/fork workload | GLR parsing stress cases, including ambiguous grammars. |
+| `runtime/benches/runtime_parse_serialize_bench.rs` | compression/decode workload | Runtime parse + JSON/S-expression serialization traversal costs. |
+| `runtime/benches/parser_benchmark.rs` | real parser workload | Pure-Rust parser over expression inputs. |
+| `runtime/benches/parser_bench.rs` | utility microbenchmark | Lexer/parser/incremental microbench routines on synthetic grammar setup. |
+| `runtime/benches/simple_bench.rs` | utility microbenchmark | Lexer-focused microbenchmarks. |
+| `runtime/benches/perf_benchmark.rs` | utility microbenchmark | Lexer SIMD vs standard and single vs parallel parser utility comparisons. |
+| `runtime/benches/incremental_benchmark.rs` | GLR forest/fork workload | Incremental parsing with edits against tokenized inputs. |
+| `runtime/benches/incremental_parsing.rs` | placeholder/mock | Contains TODO-disabled edit API paths (`parse_incremental(..., &[])`). |
+| `runtime/benches/incremental_simple.rs` | placeholder/mock | Similar TODO-disabled incremental-edit paths. |
+| `runtime/benches/pure_rust_bench.rs` | placeholder/mock | Explicit non-Criterion placeholder binary target. |
+| `glr-core/benches/automaton.rs` | tablegen workload | FIRST/FOLLOW and LR(1) automaton construction only. |
+| `glr-core/benches/perf_snapshot.rs` | placeholder/mock | Minimal synthetic table (`make_minimal_table`) for fast perf snapshots. |
+| `tablegen/benches/compression.rs` | compression/decode workload | Parse table compression plus parse table generation path. |
+
+### Still-Missing Real Benchmark Categories
+
+Current gaps (as of April 26, 2026):
+
+1. **Real language grammar parser benchmarks** (Python/JavaScript fixtures parsed
+   end-to-end in a stable, maintained suite).
+2. **Real incremental editing benchmarks** that exercise edit-aware APIs without
+   TODO-disabled edit vectors.
+3. **Forest-to-tree materialization benchmarks** on large ambiguous inputs with
+   stable, reproducible fixtures.
 
 ### Interpreting Results
 

--- a/runtime/benches/pure_rust_bench.rs
+++ b/runtime/benches/pure_rust_bench.rs
@@ -1,6 +1,8 @@
-// TODO: Fix benchmarks after API stabilization
-// This file is temporarily disabled while we stabilize the pure-Rust parser API
+//! Placeholder binary for a future pure-Rust parser benchmark suite.
+//!
+//! This target intentionally does not run Criterion today, and should not be
+//! interpreted as evidence of runtime performance.
 
 fn main() {
-    println!("Pure Rust benchmarks temporarily disabled - API migration in progress");
+    println!("placeholder-only bench target: pure-Rust runtime benchmarks are not implemented yet");
 }


### PR DESCRIPTION
### Motivation

- Benchmarks in the workspace included several placeholder or simulated tests and strong performance language that could be mistaken for end-to-end parser evidence, so benchmarks and docs need to reflect what is actually measured. 
- The intent is to make the benchmark surface truthful and discoverable without changing dependencies, tuning code, or adding large fixtures. 

### Description

- Marked `benchmarks/benches/parse_bench.rs` as an explicit placeholder and renamed its Criterion entry to `placeholder_no_parser_workload` so it cannot be mistaken for real parser proof. 
- Converted `runtime/benches/pure_rust_bench.rs` into an explicit placeholder binary with a clear comment that it does not run Criterion or provide runtime performance evidence. 
- Expanded `docs/status/PERFORMANCE.md` to soften directional latency language (call out developer-machine context), add a benchmark inventory table that classifies each bench file (real parser workload, tablegen, compression/decode, GLR forest/fork, placeholder/mock, utility microbenchmark), and list still-missing real benchmark categories. 
- No Cargo.toml, dependency upgrades, or performance-tuning changes were made; this PR focuses on clarity and classification only. 

### Testing

- Ran formatting check with `cargo fmt --all --check` which succeeded. 
- Compiled bench targets (dry-run) with `cargo bench -p adze-benchmarks --no-run`, `cargo bench -p adze-glr-core --no-run`, and `cargo bench -p adze-tablegen --no-run`, and the bench executables were produced successfully (no-run dry compile passed). 
- Ran `git diff --check` to validate whitespace/formatting issues and it reported no problems. 
- All automated checks run as part of this change completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a8c08488333884c1ca689da6e98)