### PR TITLE
Clarify benchmark truth labels and document benchmark inventory

### DIFF
--- a/benchmarks/benches/optimization_bench.rs
+++ b/benchmarks/benches/optimization_bench.rs
@@ -88,10 +88,12 @@ fn benchmark_arena_allocator(c: &mut Criterion) {
 }
 
 fn benchmark_combined_optimizations(c: &mut Criterion) {
-    let mut group = c.benchmark_group("combined_optimizations");
+    let mut group = c.benchmark_group("combined_optimizations_synthetic");
 
-    // Simulate a parsing workload with both optimizations
-    group.bench_function("parse_simulation", |b| {
+    // Synthetic benchmark: exercises allocator/stack behavior only.
+    // This intentionally does not invoke the parser and should not be treated
+    // as parser or GLR throughput evidence.
+    group.bench_function("synthetic_parse_like_workload", |b| {
         let pool = StackPool::new(32);
 
         b.iter(|| {
@@ -139,7 +141,7 @@ fn benchmark_combined_optimizations(c: &mut Criterion) {
 }
 
 fn benchmark_memory_patterns(c: &mut Criterion) {
-    let mut group = c.benchmark_group("memory_patterns");
+    let mut group = c.benchmark_group("memory_patterns_synthetic");
 
     // Test different allocation patterns
     group.bench_function("small_frequent", |b| {

--- a/benchmarks/benches/parse_bench.rs
+++ b/benchmarks/benches/parse_bench.rs
@@ -1,11 +1,11 @@
-// TODO: Fix benchmarks after pure_parser API stabilization
-// This file is temporarily disabled while we stabilize the parser API
+// Placeholder benchmark kept to verify Criterion harness wiring while parser APIs stabilize.
+// This does NOT measure parser, GLR, or tablegen performance.
 
 use criterion::{criterion_group, criterion_main};
 
-fn dummy_bench(c: &mut criterion::Criterion) {
-    c.bench_function("dummy", |b| b.iter(|| 1 + 1));
+fn placeholder_harness_smoke(c: &mut criterion::Criterion) {
+    c.bench_function("placeholder_harness_smoke", |b| b.iter(|| 1 + 1));
 }
 
-criterion_group!(benches, dummy_bench);
+criterion_group!(benches, placeholder_harness_smoke);
 criterion_main!(benches);

--- a/benchmarks/benches/stack_optimization.rs
+++ b/benchmarks/benches/stack_optimization.rs
@@ -92,12 +92,12 @@ fn benchmark_memory_pooling(c: &mut Criterion) {
     group.finish();
 }
 
-/// Benchmark fork/merge patterns with optimizations
+/// Synthetic fork/merge allocation patterns (no parser invocation)
 fn benchmark_fork_merge_patterns(c: &mut Criterion) {
-    let mut group = c.benchmark_group("fork_merge_patterns");
+    let mut group = c.benchmark_group("fork_merge_patterns_synthetic");
 
     // Simulate a parse that forks frequently
-    group.bench_function("frequent_fork_pattern", |b| {
+    group.bench_function("frequent_fork_pattern_synthetic", |b| {
         b.iter(|| {
             let stack = StackNode::with_state(0);
             let mut active_stacks = vec![stack];
@@ -131,7 +131,7 @@ fn benchmark_fork_merge_patterns(c: &mut Criterion) {
     });
 
     // Simulate a parse with deep recursion
-    group.bench_function("deep_recursion_pattern", |b| {
+    group.bench_function("deep_recursion_pattern_synthetic", |b| {
         b.iter(|| {
             let mut stack = StackNode::new();
 

--- a/docs/status/PERFORMANCE.md
+++ b/docs/status/PERFORMANCE.md
@@ -141,19 +141,41 @@ cargo bench -p adze-tablegen
 cargo bench -p adze-benchmarks
 ```
 
-**Benchmark suites across the workspace:**
+**Benchmark inventory (scope: `benchmarks/**`, `runtime/benches/**`, `glr-core/benches/**`, `tablegen/benches/**`)**
 
-| Crate | Benchmark | What It Measures |
-|---|---|---|
-| `adze-benchmarks` | `glr_performance.rs` | End-to-end GLR parsing of arithmetic fixtures |
-| `adze-benchmarks` | `glr_performance_real.rs` | Release-gated real parsing benchmarks |
-| `adze-glr-core` | `automaton.rs` | LR(1) automaton construction time |
-| `adze-glr-core` | `perf_snapshot.rs` | GLR core performance snapshots |
-| `adze-tablegen` | `compression.rs` | Parse table compression speed |
-| `runtime` | `glr_parser_bench.rs` | GLR parser with ambiguous grammars |
-| `runtime` | `parser_benchmark.rs` | General parser benchmarks |
-| `runtime` | `pure_rust_bench.rs` | Pure-Rust backend performance |
-| `runtime` | `incremental_benchmark.rs` | Incremental parsing overhead |
+> Classification key: real parser workload, tablegen workload, compression/decode workload,
+> GLR forest/fork workload, placeholder/mock, utility microbenchmark.
+
+| Crate | Benchmark file | Classification | What it actually measures |
+|---|---|---|---|
+| `adze-benchmarks` | `glr_performance.rs` | real parser workload | Parses valid arithmetic fixtures with `adze_example::arithmetic::grammar::parse`. |
+| `adze-benchmarks` | `glr_performance_real.rs` | real parser workload + utility microbenchmark | Real parsing on valid arithmetic fixtures; also includes fixture-loading and parse-result-check microbenches. |
+| `adze-benchmarks` | `glr_hot.rs` | real parser workload | Hot-path parse loops on medium/large arithmetic fixtures. |
+| `adze-benchmarks` | `incremental_bench.rs` | GLR forest/fork workload | Incremental GLR parse behavior under synthetic edit patterns; includes full-reparse comparison. |
+| `adze-benchmarks` | `core_baselines.rs` | tablegen workload + compression/decode workload + utility microbenchmark | IR normalization, FIRST/FOLLOW, LR(1) automaton construction, and table compression on synthetic grammars. |
+| `adze-benchmarks` | `arena_vs_box_allocation.rs` | utility microbenchmark | Allocator behavior for tree-node-like allocations (arena vs `Box`). |
+| `adze-benchmarks` | `optimization_bench.rs` | placeholder/mock | Synthetic stack/arena/allocation simulations; does **not** call parser APIs. |
+| `adze-benchmarks` | `stack_optimization.rs` | placeholder/mock | Synthetic fork/merge and pooling patterns; does **not** parse source text. |
+| `adze-benchmarks` | `parse_bench.rs` | placeholder/mock | Criterion harness smoke target only (`1 + 1`). |
+| `adze` runtime | `glr_parser_bench.rs` | GLR forest/fork workload | Real GLR parser/lexer loop over intentionally ambiguous arithmetic grammar. |
+| `adze` runtime | `runtime_parse_serialize_bench.rs` | real parser workload + utility microbenchmark | GLR parse + tree serialization/traversal/construction costs. |
+| `adze` runtime | `simple_bench.rs` | utility microbenchmark | Lexer throughput on synthetic token sets and source snippets. |
+| `adze` runtime | `parser_benchmark.rs` | real parser workload | Parses expressions through `tree_sitter::Parser` with generated grammar (`unstable-benches`). |
+| `adze` runtime | `parser_bench.rs` | utility microbenchmark | Lexer/parser component costs on synthetic token streams (`unstable-benches`). |
+| `adze` runtime | `perf_benchmark.rs` | utility microbenchmark | Lexer (standard vs SIMD) and parser wrappers on synthetic corpora (`unstable-benches`). |
+| `adze` runtime | `incremental_benchmark.rs` | GLR forest/fork workload | Incremental GLR parse/reparse comparisons with explicit edits (`unstable-benches`). |
+| `adze` runtime | `incremental_parsing.rs` | placeholder/mock | Legacy incremental benchmark with TODO-marked API gaps (`unstable-benches`). |
+| `adze` runtime | `incremental_simple.rs` | placeholder/mock | Legacy/simple incremental benchmark with TODO-marked API gaps (`unstable-benches`). |
+| `adze` runtime | `pure_rust_bench.rs` | placeholder/mock | Placeholder entrypoint that prints a disabled message. |
+| `adze-glr-core` | `automaton.rs` | tablegen workload | FIRST/FOLLOW + LR(1) automaton construction from grammar builders. |
+| `adze-glr-core` | `perf_snapshot.rs` | utility microbenchmark | Minimal-driver microbench (`EOF` token path), useful for regressions, not end-to-end parsing. |
+| `adze-tablegen` | `compression.rs` | compression/decode workload + tablegen workload | Parse-table generation + compression cost across grammar sizes/shapes. |
+
+### Gaps still missing from current benchmark coverage
+
+- No checked-in **real-language GLR corpus benchmark** (Python/JavaScript fixtures parsed by their production grammars).
+- No **table decode/runtime dispatch** benchmark isolated from compression.
+- No **long-running incremental edit trace** benchmark from recorded real editor sessions.
 
 ### Interpreting Results
 

--- a/glr-core/benches/perf_snapshot.rs
+++ b/glr-core/benches/perf_snapshot.rs
@@ -8,7 +8,7 @@ use adze_ir::SymbolId;
 use glr_test_support::test_utilities::make_minimal_table;
 
 pub fn bench_parse_small(c: &mut Criterion) {
-    let mut g = c.benchmark_group("glr-perf-snapshot");
+    let mut g = c.benchmark_group("glr-perf-snapshot-micro");
 
     // Quick/stable knobs: default to "quick" for dev loops; unset for longer runs.
     if std::env::var_os("BENCH_QUICK").is_some() {
@@ -46,7 +46,7 @@ pub fn bench_parse_small(c: &mut Criterion) {
     }
 
     // Time only the hot path.
-    g.bench_function("small-parse", |b| {
+    g.bench_function("micro_eof_only_parse", |b| {
         b.iter(|| {
             #[cfg(feature = "perf_counters")]
             let _ = perf::take(); // zero

--- a/runtime/benches/pure_rust_bench.rs
+++ b/runtime/benches/pure_rust_bench.rs
@@ -1,6 +1,9 @@
-// TODO: Fix benchmarks after API stabilization
-// This file is temporarily disabled while we stabilize the pure-Rust parser API
+// Placeholder benchmark entrypoint.
+// This binary exists so `cargo bench` can enumerate the target while
+// pure-Rust benchmark APIs are stabilized. It does NOT run runtime benchmarks.
 
 fn main() {
-    println!("Pure Rust benchmarks temporarily disabled - API migration in progress");
+    println!(
+        "placeholder: pure_rust_bench is disabled while unstable benchmark APIs are stabilized"
+    );
 }


### PR DESCRIPTION
### Motivation

- Benchmarks and documentation contained claims that could be misread as end-to-end parser or GLR throughput results when some targets were synthetic, mock, or microbenchmarks, so the intent is to make benchmark names and docs honestly reflect what is measured. 
- Provide maintainers a single inventory that classifies each benchmark under `benchmarks/**`, `runtime/benches/**`, `glr-core/benches/**`, and `tablegen/benches/**` so future contributors won't mistake placeholder workloads for real parser evidence.

### Description

- Added a benchmark inventory table and a short "gaps still missing" section to `docs/status/PERFORMANCE.md` that classifies each bench by workload type (real parser, tablegen, compression/decode, GLR forest/fork, placeholder/mock, utility microbenchmark). 
- Marked synthetic/placeholder benchmarks and renamed groups and functions to make intent explicit: `benchmarks/benches/parse_bench.rs` is now a `placeholder_harness_smoke` harness, `runtime/benches/pure_rust_bench.rs` prints a disabled placeholder message, and synthetic benchmarks in `benchmarks/benches/optimization_bench.rs` and `benchmarks/benches/stack_optimization.rs` were renamed to include `_synthetic` and received comments clarifying they do not invoke parser APIs. 
- Clarified that the GLR core snapshot is a minimal EOF-path microbench by renaming the group and bench in `glr-core/benches/perf_snapshot.rs` to `glr-perf-snapshot-micro` / `micro_eof_only_parse`. 
- No dependency updates, no Cargo.toml edits, and no algorithmic/optimization changes were made; the change is purely renaming, documentation, and clarifying comments to align benchmarks with what they actually measure.

### Testing

- Ran `git diff --check` and `cargo fmt --all --check`, and both succeeded. 
- Built bench targets without executing them with `cargo bench -p adze-glr-core --no-run` and `cargo bench -p adze-tablegen --no-run`, and both produced finished bench executables successfully. 
- Attempted `cargo bench -p adze-benchmarks --no-run`; compilation started and progressed but the optimized bench build did not finish within the session window, so no-run for that package is inconclusive in this run. 
- Committed the changes with message: "Clarify benchmark scope and mark synthetic placeholders" and verified the working tree shows only the intended edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a8c08488333884c1ca689da6e98)