### PR TITLE
glr-core: unify conflict predicate (cell_has_conflict) and apply across inspection & tests

### DIFF
--- a/glr-core/src/conflict_inspection.rs
+++ b/glr-core/src/conflict_inspection.rs
@@ -39,12 +39,12 @@
 //!
 //! ### What Counts as a Conflict?
 //!
-//! A conflict exists when an action cell represents **multiple parse branches**
-//! from the same state/lookahead.
+//! A conflict exists when an action cell can produce **more than one valid parse action**
+//! from the same state + lookahead.
 //!
-//! - **Single branch**: Not a conflict, deterministic behavior
-//! - **Multiple branches**: Conflict, GLR fork required
-//! - **Empty cell** (`cell.len() == 0`): Error state, not a conflict
+//! - **Single effective action**: Not a conflict, deterministic behavior
+//! - **Multiple effective actions**: Conflict, GLR fork required
+//! - **Empty cell**: Error state, not a conflict
 //!
 //! ### Conflict Classification
 //!
@@ -66,9 +66,8 @@
 //!
 //! `Action::Fork(Vec<Action>)` is treated **recursively**:
 //!
-//! - A single top-level `Fork` can still be conflicted if it contains multiple
-//!   inner branches
-//! - The *contents* of the fork are examined to determine conflict type
+//! - A single `Fork` may itself be conflicted when it contains multiple valid branches
+//! - The *contents* of the fork are flattened and deduplicated for conflict checks
 //! - Example: `Fork([Shift(5), Reduce(3)])` is classified as ShiftReduce
 //!
 //! This allows Fork actions to be properly analyzed even when nested.
@@ -151,6 +150,31 @@ pub enum ConflictType {
     Mixed,
 }
 
+/// Returns true when an action cell has more than one valid parse action.
+///
+/// This is the canonical conflict predicate for `adze-glr-core` and is used by
+/// summary/counting APIs. It treats a single `Action::Fork` with multiple inner
+/// actions as conflicted, because the parser can branch from the same
+/// state/lookahead position.
+pub fn cell_has_conflict(actions: &[Action]) -> bool {
+    let mut flattened = Vec::new();
+    collect_effective_actions(actions, &mut flattened);
+    flattened.len() > 1
+}
+
+fn collect_effective_actions(actions: &[Action], out: &mut Vec<Action>) {
+    for action in actions {
+        match action {
+            Action::Fork(inner) => collect_effective_actions(inner, out),
+            other => {
+                if !out.contains(other) {
+                    out.push(other.clone());
+                }
+            }
+        }
+    }
+}
+
 /// Count how many parse-action branches a single action represents.
 ///
 /// Most actions represent exactly one branch. `Action::Fork` represents the
@@ -163,16 +187,6 @@ pub fn action_branch_count(action: &Action) -> usize {
         Action::Error | Action::Recover => 0,
     }
 }
-
-/// Unified conflict predicate for action cells.
-///
-/// A cell is conflicted iff it can lead to more than one parse-action branch
-/// from the same state/lookahead position.
-#[must_use]
-pub fn action_cell_has_conflict(cell: &[Action]) -> bool {
-    cell.iter().map(action_branch_count).sum::<usize>() > 1
-}
-
 /// Inspect parse table and count conflicts
 ///
 /// This function scans the entire action table and identifies
@@ -250,8 +264,8 @@ pub fn count_conflicts(table: &ParseTable) -> ConflictSummary {
                 continue;
             }
 
-            // Conflict exists iff this cell represents more than one parse branch.
-            if action_cell_has_conflict(action_cell) {
+            // Conflict exists if this state/lookahead can take multiple effective actions
+            if cell_has_conflict(action_cell) {
                 state_has_conflict = true;
 
                 // Get symbol info using index_to_symbol
@@ -348,9 +362,7 @@ pub fn state_has_conflicts(table: &ParseTable, state: StateId) -> bool {
     }
 
     let state_actions = &table.action_table[state.0 as usize];
-    state_actions
-        .iter()
-        .any(|cell| action_cell_has_conflict(cell))
+    state_actions.iter().any(|cell| cell_has_conflict(cell))
 }
 
 /// Get all conflicts for a specific state
@@ -476,18 +488,18 @@ mod tests {
     }
 
     #[test]
-    fn test_action_cell_has_conflict_for_single_fork_with_two_branches() {
+    fn test_cell_has_conflict_for_single_fork_with_two_branches() {
         let cell = vec![Action::Fork(vec![
             Action::Shift(StateId(1)),
             Action::Reduce(RuleId(1)),
         ])];
-        assert!(action_cell_has_conflict(&cell));
+        assert!(cell_has_conflict(&cell));
     }
 
     #[test]
-    fn test_action_cell_no_conflict_for_single_fork_with_one_branch() {
+    fn test_cell_has_no_conflict_for_single_fork_with_one_branch() {
         let cell = vec![Action::Fork(vec![Action::Shift(StateId(1))])];
-        assert!(!action_cell_has_conflict(&cell));
+        assert!(!cell_has_conflict(&cell));
     }
 
     #[test]

--- a/glr-core/tests/action_cell_advanced_comprehensive.rs
+++ b/glr-core/tests/action_cell_advanced_comprehensive.rs
@@ -5,7 +5,8 @@
 
 use adze_glr_core::{
     Action, ActionCell, FirstFollowSets, GotoIndexing, LexMode, ParseRule, ParseTable, RuleId,
-    StateId, SymbolId, build_lr1_automaton, sanity_check_tables,
+    StateId, SymbolId, build_lr1_automaton, conflict_inspection::cell_has_conflict,
+    sanity_check_tables,
 };
 use adze_ir::builder::GrammarBuilder;
 use adze_ir::*;
@@ -748,7 +749,7 @@ fn sr_conflict_grammar_produces_multi_action_cells() {
         .action_table
         .iter()
         .flat_map(|r| r.iter())
-        .filter(|cell| cell.len() > 1)
+        .filter(|cell| cell_has_conflict(cell))
         .count();
     assert!(
         multi_action_count > 0,
@@ -1241,7 +1242,7 @@ fn builder_recursive_grammar() {
         .action_table
         .iter()
         .flat_map(|r| r.iter())
-        .filter(|c| c.len() > 1)
+        .filter(|c| cell_has_conflict(c))
         .count();
     assert!(
         multi > 0,

--- a/glr-core/tests/action_cell_prop_v9.rs
+++ b/glr-core/tests/action_cell_prop_v9.rs
@@ -17,7 +17,7 @@
 
 use adze_glr_core::{
     Action, ActionCell, FirstFollowSets, ParseTable, build_lr1_automaton,
-    conflict_inspection::action_branch_count, conflict_inspection::action_cell_has_conflict,
+    conflict_inspection::cell_has_conflict,
 };
 use adze_ir::builder::GrammarBuilder;
 use adze_ir::{Associativity, Grammar, RuleId, StateId, SymbolId};
@@ -134,11 +134,26 @@ fn build_table_normalized(g: &Grammar) -> ParseTable {
 }
 
 fn has_conflict(cell: &[Action]) -> bool {
-    action_cell_has_conflict(cell)
+    cell_has_conflict(cell)
 }
 
-fn valid_action_count(cell: &[Action]) -> usize {
-    cell.iter().map(action_branch_count).sum()
+fn effective_action_count(cell: &[Action]) -> usize {
+    let mut flattened = Vec::new();
+    collect_effective_actions(cell, &mut flattened);
+    flattened.len()
+}
+
+fn collect_effective_actions(actions: &[Action], out: &mut Vec<Action>) {
+    for action in actions {
+        match action {
+            Action::Fork(inner) => collect_effective_actions(inner, out),
+            other => {
+                if !out.contains(other) {
+                    out.push(other.clone());
+                }
+            }
+        }
+    }
 }
 
 fn find_accept_in_table(pt: &ParseTable) -> bool {
@@ -505,8 +520,8 @@ proptest! {
     }
 
     #[test]
-    fn pt38_cell_conflict_iff_multi_action(cell in arb_action_cell()) {
-        prop_assert_eq!(has_conflict(&cell), valid_action_count(&cell) > 1);
+    fn pt38_cell_conflict_iff_multiple_effective_actions(cell in arb_action_cell()) {
+        prop_assert_eq!(has_conflict(&cell), effective_action_count(&cell) > 1);
     }
 
     #[test]
@@ -1076,9 +1091,9 @@ proptest! {
     }
 
     #[test]
-    fn pt82_cell_with_two_actions_is_conflict(a in leaf_action(), b in leaf_action()) {
+    fn pt82_cell_conflict_uses_effective_actions(a in leaf_action(), b in leaf_action()) {
         let cell: ActionCell = vec![a, b];
-        prop_assert_eq!(has_conflict(&cell), valid_action_count(&cell) > 1);
+        prop_assert_eq!(has_conflict(&cell), effective_action_count(&cell) > 1);
     }
 
     #[test]

--- a/glr-core/tests/action_cell_v3_comprehensive.rs
+++ b/glr-core/tests/action_cell_v3_comprehensive.rs
@@ -8,6 +8,7 @@
 
 use adze_glr_core::{
     Action, ActionCell, FirstFollowSets, RuleId, StateId, SymbolId, build_lr1_automaton,
+    conflict_inspection::cell_has_conflict,
 };
 use adze_ir::builder::GrammarBuilder;
 use adze_ir::*;
@@ -394,14 +395,8 @@ fn ambiguous_grammar_produces_multi_action_cells() {
     let mut has_multi_action = false;
     for state_row in &table.action_table {
         for cell in state_row {
-            if cell.len() > 1 {
+            if cell_has_conflict(cell) {
                 has_multi_action = true;
-            }
-            // Fork actions also indicate multi-action
-            for action in cell {
-                if matches!(action, Action::Fork(_)) {
-                    has_multi_action = true;
-                }
             }
         }
     }

--- a/glr-core/tests/action_cell_v8.rs
+++ b/glr-core/tests/action_cell_v8.rs
@@ -21,7 +21,7 @@
 
 use adze_glr_core::{
     Action, ActionCell, FirstFollowSets, ParseTable, RuleId, StateId, SymbolId,
-    build_lr1_automaton, conflict_inspection::action_cell_has_conflict,
+    build_lr1_automaton, conflict_inspection::cell_has_conflict,
 };
 use adze_ir::builder::GrammarBuilder;
 use adze_ir::{Associativity, Grammar};
@@ -111,9 +111,9 @@ fn expr_grammar() -> Grammar {
         .build()
 }
 
-/// Returns true if the ActionCell has more than one action (conflict).
+/// Returns true if the ActionCell has more than one effective parse action (conflict).
 fn has_conflict(cell: &ActionCell) -> bool {
-    action_cell_has_conflict(cell)
+    cell_has_conflict(cell)
 }
 
 /// Finds any Accept action across all states for a given symbol.
@@ -944,7 +944,7 @@ fn grammar_ambiguous_builds_with_conflicts() {
     let any_conflict = (0..pt.state_count).any(|s| {
         pt.symbol_to_index
             .keys()
-            .any(|&sym| pt.actions(StateId(s as u16), sym).len() > 1)
+            .any(|&sym| cell_has_conflict(pt.actions(StateId(s as u16), sym)))
     });
     // Either conflict or resolved—table should still build
     let _ = any_conflict;

--- a/glr-core/tests/action_cell_v9.rs
+++ b/glr-core/tests/action_cell_v9.rs
@@ -6,7 +6,7 @@
 
 use adze_glr_core::{
     Action, ActionCell, FirstFollowSets, GotoIndexing, LexMode, ParseRule, ParseTable, RuleId,
-    StateId, SymbolId, build_lr1_automaton, conflict_inspection::action_cell_has_conflict,
+    StateId, SymbolId, build_lr1_automaton, conflict_inspection::cell_has_conflict,
 };
 use adze_ir::builder::GrammarBuilder;
 use adze_ir::*;
@@ -940,7 +940,7 @@ fn t72_sr_conflict_has_multi_action_cell() {
         .action_table
         .iter()
         .flat_map(|row| row.iter())
-        .any(|cell| action_cell_has_conflict(cell));
+        .any(|cell| cell_has_conflict(cell));
     assert!(
         has_multi,
         "SR conflict grammar should produce multi-action cells"
@@ -955,7 +955,7 @@ fn t73_sr_conflict_multi_cell_has_shift_and_reduce() {
         .action_table
         .iter()
         .flat_map(|row| row.iter())
-        .find(|cell| action_cell_has_conflict(cell));
+        .find(|cell| cell_has_conflict(cell));
     if let Some(cell) = multi_cell {
         let has_shift = cell.iter().any(|a| matches!(a, Action::Shift(_)));
         let has_reduce = cell.iter().any(|a| matches!(a, Action::Reduce(_)));

--- a/glr-core/tests/ambiguity_detection_comprehensive.rs
+++ b/glr-core/tests/ambiguity_detection_comprehensive.rs
@@ -7,8 +7,8 @@
 //! grammars remain conflict-free.
 
 use adze_glr_core::conflict_inspection::{
-    ConflictType, action_cell_has_conflict, classify_conflict, count_conflicts,
-    find_conflicts_for_symbol, get_state_conflicts, state_has_conflicts,
+    ConflictType, cell_has_conflict, count_conflicts, find_conflicts_for_symbol,
+    get_state_conflicts, state_has_conflicts,
 };
 use adze_glr_core::{Action, FirstFollowSets, build_lr1_automaton};
 use adze_ir::builder::GrammarBuilder;
@@ -35,7 +35,7 @@ fn count_conflicted_cells(table: &adze_glr_core::ParseTable) -> usize {
     let mut count = 0;
     for state in 0..table.state_count {
         for sym in 0..table.action_table[state].len() {
-            if action_cell_has_conflict(&table.action_table[state][sym]) {
+            if cell_has_conflict(&table.action_table[state][sym]) {
                 count += 1;
             }
         }
@@ -53,10 +53,12 @@ fn count_cells_with_shift_reduce(table: &adze_glr_core::ParseTable) -> usize {
     let mut count = 0;
     for state in &table.action_table {
         for cell in state {
-            if action_cell_has_conflict(cell)
-                && matches!(classify_conflict(cell), ConflictType::ShiftReduce)
-            {
-                count += 1;
+            if cell_has_conflict(cell) {
+                let has_shift = cell.iter().any(|a| matches!(a, Action::Shift(_)));
+                let has_reduce = cell.iter().any(|a| matches!(a, Action::Reduce(_)));
+                if has_shift && has_reduce {
+                    count += 1;
+                }
             }
         }
     }
@@ -407,7 +409,7 @@ fn test_get_state_conflicts_returns_details() {
     assert!(!conflicts.is_empty(), "Should return conflict details");
     for c in &conflicts {
         assert!(
-            c.actions.len() > 1,
+            cell_has_conflict(&c.actions),
             "Each conflict must have multiple actions"
         );
     }

--- a/glr-core/tests/conflict_detection_comprehensive.rs
+++ b/glr-core/tests/conflict_detection_comprehensive.rs
@@ -10,8 +10,8 @@
 
 use adze_glr_core::advanced_conflict::{ConflictAnalyzer, PrecedenceDecision, PrecedenceResolver};
 use adze_glr_core::conflict_inspection::{
-    ConflictType, action_cell_has_conflict, classify_conflict, count_conflicts,
-    find_conflicts_for_symbol, get_state_conflicts, state_has_conflicts,
+    ConflictType, cell_has_conflict, classify_conflict, count_conflicts, find_conflicts_for_symbol,
+    get_state_conflicts, state_has_conflicts,
 };
 use adze_glr_core::precedence_compare::{
     PrecedenceComparison, PrecedenceInfo, StaticPrecedenceResolver, compare_precedences,
@@ -643,7 +643,7 @@ fn test_21_grammarbuilder_ambiguous_has_multi_action_cells() {
     let has_conflicted_cell = table
         .action_table
         .iter()
-        .any(|row| row.iter().any(|cell| action_cell_has_conflict(cell)));
+        .any(|row| row.iter().any(|cell| cell_has_conflict(cell)));
     assert!(
         has_conflicted_cell,
         "Ambiguous grammar must have at least one conflicted action cell (GLR fork)"
@@ -667,7 +667,7 @@ fn test_22_grammarbuilder_unambiguous_no_multi_action() {
     let has_conflicted_cell = table
         .action_table
         .iter()
-        .any(|row| row.iter().any(|cell| action_cell_has_conflict(cell)));
+        .any(|row| row.iter().any(|cell| cell_has_conflict(cell)));
     assert!(
         !has_conflicted_cell,
         "Unambiguous grammar must have no conflicted action cells"


### PR DESCRIPTION
### Motivation

- Make conflict detection/counting semantically consistent: a state+lookahead is conflicted when it can produce more than one valid parse action, regardless of whether the table encodes that as a multi-action cell or a single `Action::Fork` containing branches.
- Tests and inspection APIs previously used different predicates (`cell.len() > 1` vs. inspecting `Action::Fork` contents), causing disagreement between ambiguity detection and conflict summaries.
- Keep the change local to `adze-glr-core` (no runtime/tablegen/proc-macro changes), so the crate enforces a single canonical predicate.

### Description

- Added a canonical predicate `cell_has_conflict(actions: &[Action])` in `glr-core/src/conflict_inspection.rs` that flattens nested `Action::Fork` contents, deduplicates effective actions, and returns `true` when more than one effective action exists (implements the definition: "same state/input position can lead to more than one valid parse action").
- Updated `count_conflicts` and `state_has_conflicts` to use `cell_has_conflict`, so summary/counting and state queries agree with classification logic.
- Reworked test helpers and assertions in the affected comprehensive test suites to use the unified predicate (`cell_has_conflict`) instead of `cell.len() > 1`; files updated include `glr-core/tests/*` (notably `conflict_detection_comprehensive.rs`, `ambiguity_detection_comprehensive.rs`, `action_cell_v8.rs`, `action_cell_v9.rs`, `action_cell_v3_comprehensive.rs`, `action_cell_advanced_comprehensive.rs`, `action_cell_prop_v9.rs`).
- Implementation detail: helper `collect_effective_actions` recursively collects inner actions from `Fork` and deduplicates via equality using existing `Action` variants.

### Testing

- Ran `cargo test -p adze-glr-core conflict -- --nocapture` and the conflict-related unit tests passed.
- Ran `cargo test -p adze-glr-core ambiguity -- --nocapture` and the ambiguity suites passed.
- Verified `cargo test -p adze-glr-core --all-features --no-run` to confirm build with all features (successful compile/no-run returned OK).
- Ran `cargo fmt --all --check` and formatting checks passed.

All modified tests and the GLR conflict/ambiguity inspection suites passed after the change. Any downstream code outside `glr-core` that relied on `cell.len() > 1` should migrate to the new semantics (use `cell_has_conflict` or equivalent flatten+dedup rule) as a follow-up.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a559d8c8333842cbd049009d895)