### PR TITLE
glr-core: unify conflict detection predicate for Fork and multi-action cells

### DIFF
--- a/glr-core/src/conflict_inspection.rs
+++ b/glr-core/src/conflict_inspection.rs
@@ -39,11 +39,14 @@
 //!
 //! ### What Counts as a Conflict?
 //!
-//! A conflict exists when an action cell contains **multiple actions** (`cell.len() > 1`).
+//! A conflict exists when an action cell can lead to **more than one valid parse action**
+//! for the same state/lookahead pair.
 //!
-//! - **Single action** (`cell.len() == 1`): Not a conflict, deterministic behavior
-//! - **Multiple actions** (`cell.len() > 1`): Conflict, GLR fork required
-//! - **Empty cell** (`cell.len() == 0`): Error state, not a conflict
+//! - **0 or 1 valid actions**: Not a conflict, deterministic behavior
+//! - **2+ valid actions**: Conflict, GLR branching required
+//! - **Empty cell** (`cell.len() == 0`): No action, not a conflict
+//!
+//! This treats `Action::Fork(_)` as an encoded set of alternatives rather than a single action.
 //!
 //! ### Conflict Classification
 //!
@@ -226,8 +229,8 @@ pub fn count_conflicts(table: &ParseTable) -> ConflictSummary {
                 continue;
             }
 
-            // Conflict exists if cell has multiple actions
-            if action_cell.len() > 1 {
+            // Conflict exists if this cell can take >1 valid parse actions.
+            if action_cell_has_conflict(action_cell) {
                 state_has_conflict = true;
 
                 // Get symbol info using index_to_symbol
@@ -324,7 +327,30 @@ pub fn state_has_conflicts(table: &ParseTable, state: StateId) -> bool {
     }
 
     let state_actions = &table.action_table[state.0 as usize];
-    state_actions.iter().any(|cell| cell.len() > 1)
+    state_actions
+        .iter()
+        .any(|cell| action_cell_has_conflict(cell))
+}
+
+/// Returns true when an action cell contains more than one valid parse action.
+///
+/// This unifies conflict detection for both representations:
+/// - multi-entry cells (e.g. `[Shift(..), Reduce(..)]`)
+/// - single-entry fork cells (e.g. `[Fork([Shift(..), Reduce(..)])]`)
+pub fn action_cell_has_conflict(cell: &[Action]) -> bool {
+    count_valid_parse_actions(cell) > 1
+}
+
+fn count_valid_parse_actions(cell: &[Action]) -> usize {
+    cell.iter().map(count_valid_actions_in_action).sum()
+}
+
+fn count_valid_actions_in_action(action: &Action) -> usize {
+    match action {
+        Action::Shift(_) | Action::Reduce(_) | Action::Accept => 1,
+        Action::Fork(inner) => count_valid_parse_actions(inner),
+        Action::Error | Action::Recover => 0,
+    }
 }
 
 /// Get all conflicts for a specific state

--- a/glr-core/tests/action_cell_prop_v9.rs
+++ b/glr-core/tests/action_cell_prop_v9.rs
@@ -15,7 +15,10 @@
 //! cargo test -p adze-glr-core --test action_cell_prop_v9 --features test-api -- --test-threads=2
 //! ```
 
-use adze_glr_core::{Action, ActionCell, FirstFollowSets, ParseTable, build_lr1_automaton};
+use adze_glr_core::{
+    Action, ActionCell, FirstFollowSets, ParseTable, build_lr1_automaton,
+    conflict_inspection::action_cell_has_conflict,
+};
 use adze_ir::builder::GrammarBuilder;
 use adze_ir::{Associativity, Grammar, RuleId, StateId, SymbolId};
 use proptest::prelude::*;
@@ -131,7 +134,7 @@ fn build_table_normalized(g: &Grammar) -> ParseTable {
 }
 
 fn has_conflict(cell: &[Action]) -> bool {
-    cell.len() > 1
+    action_cell_has_conflict(cell)
 }
 
 fn find_accept_in_table(pt: &ParseTable) -> bool {

--- a/glr-core/tests/action_cell_v8.rs
+++ b/glr-core/tests/action_cell_v8.rs
@@ -20,7 +20,8 @@
 //!  15.  Multiple grammars with varying complexities (6)
 
 use adze_glr_core::{
-    Action, ActionCell, FirstFollowSets, ParseTable, RuleId, StateId, SymbolId, build_lr1_automaton,
+    Action, ActionCell, FirstFollowSets, ParseTable, RuleId, StateId, SymbolId,
+    build_lr1_automaton, conflict_inspection::action_cell_has_conflict,
 };
 use adze_ir::builder::GrammarBuilder;
 use adze_ir::{Associativity, Grammar};
@@ -110,9 +111,9 @@ fn expr_grammar() -> Grammar {
         .build()
 }
 
-/// Returns true if the ActionCell has more than one action (conflict).
+/// Returns true if the ActionCell has more than one valid parse action.
 fn has_conflict(cell: &ActionCell) -> bool {
-    cell.len() > 1
+    action_cell_has_conflict(cell)
 }
 
 /// Finds any Accept action across all states for a given symbol.

--- a/glr-core/tests/ambiguity_detection_comprehensive.rs
+++ b/glr-core/tests/ambiguity_detection_comprehensive.rs
@@ -7,8 +7,8 @@
 //! grammars remain conflict-free.
 
 use adze_glr_core::conflict_inspection::{
-    ConflictType, count_conflicts, find_conflicts_for_symbol, get_state_conflicts,
-    state_has_conflicts,
+    ConflictType, action_cell_has_conflict, count_conflicts, find_conflicts_for_symbol,
+    get_state_conflicts, state_has_conflicts,
 };
 use adze_glr_core::{Action, FirstFollowSets, build_lr1_automaton};
 use adze_ir::builder::GrammarBuilder;
@@ -30,12 +30,12 @@ fn build_table_normalized(grammar: &mut Grammar) -> adze_glr_core::ParseTable {
     build_lr1_automaton(grammar, &ff).expect("LR(1) automaton failed")
 }
 
-/// Count the total number of multi-action cells in a parse table.
-fn count_multi_action_cells(table: &adze_glr_core::ParseTable) -> usize {
+/// Count action cells with more than one valid parse action.
+fn count_conflicted_action_cells(table: &adze_glr_core::ParseTable) -> usize {
     let mut count = 0;
     for state in 0..table.state_count {
         for sym in 0..table.action_table[state].len() {
-            if table.action_table[state][sym].len() > 1 {
+            if action_cell_has_conflict(&table.action_table[state][sym]) {
                 count += 1;
             }
         }
@@ -45,15 +45,15 @@ fn count_multi_action_cells(table: &adze_glr_core::ParseTable) -> usize {
 
 /// Return true if any cell in the table has more than one action.
 fn has_any_conflict(table: &adze_glr_core::ParseTable) -> bool {
-    count_multi_action_cells(table) > 0
+    count_conflicted_action_cells(table) > 0
 }
 
-/// Count how many cells contain a Shift among the multi-action cells.
+/// Count how many conflicted cells contain both Shift and Reduce possibilities.
 fn count_cells_with_shift_reduce(table: &adze_glr_core::ParseTable) -> usize {
     let mut count = 0;
     for state in &table.action_table {
         for cell in state {
-            if cell.len() > 1 {
+            if action_cell_has_conflict(cell) {
                 let has_shift = cell.iter().any(|a| matches!(a, Action::Shift(_)));
                 let has_reduce = cell.iter().any(|a| matches!(a, Action::Reduce(_)));
                 if has_shift && has_reduce {
@@ -335,8 +335,8 @@ fn test_concat_ambiguity_conflict_count() {
         .build();
 
     let table = build_table(&grammar);
-    let n = count_multi_action_cells(&table);
-    assert!(n >= 1, "Expected ≥1 multi-action cells, got {}", n);
+    let n = count_conflicted_action_cells(&table);
+    assert!(n >= 1, "Expected ≥1 conflicted action cells, got {}", n);
 }
 
 // ---------------------------------------------------------------------------
@@ -409,8 +409,8 @@ fn test_get_state_conflicts_returns_details() {
     assert!(!conflicts.is_empty(), "Should return conflict details");
     for c in &conflicts {
         assert!(
-            c.actions.len() > 1,
-            "Each conflict must have multiple actions"
+            action_cell_has_conflict(&c.actions),
+            "Each conflict must have more than one valid parse action"
         );
     }
 }
@@ -1153,8 +1153,8 @@ fn test_more_operators_at_least_as_many_conflicts() {
     let t2 = build_table(&g2);
     let t3 = build_table(&g3);
 
-    let c2 = count_multi_action_cells(&t2);
-    let c3 = count_multi_action_cells(&t3);
+    let c2 = count_conflicted_action_cells(&t2);
+    let c3 = count_conflicted_action_cells(&t3);
     assert!(
         c3 >= c2,
         "Adding an operator should not reduce conflicts ({} vs {})",

--- a/glr-core/tests/conflict_detection_comprehensive.rs
+++ b/glr-core/tests/conflict_detection_comprehensive.rs
@@ -10,8 +10,8 @@
 
 use adze_glr_core::advanced_conflict::{ConflictAnalyzer, PrecedenceDecision, PrecedenceResolver};
 use adze_glr_core::conflict_inspection::{
-    ConflictType, classify_conflict, count_conflicts, find_conflicts_for_symbol,
-    get_state_conflicts, state_has_conflicts,
+    ConflictType, action_cell_has_conflict, classify_conflict, count_conflicts,
+    find_conflicts_for_symbol, get_state_conflicts, state_has_conflicts,
 };
 use adze_glr_core::precedence_compare::{
     PrecedenceComparison, PrecedenceInfo, StaticPrecedenceResolver, compare_precedences,
@@ -643,7 +643,7 @@ fn test_21_grammarbuilder_ambiguous_has_multi_action_cells() {
     let has_multi = table
         .action_table
         .iter()
-        .any(|row| row.iter().any(|cell| cell.len() > 1));
+        .any(|row| row.iter().any(|cell| action_cell_has_conflict(cell)));
     assert!(
         has_multi,
         "Ambiguous grammar must have at least one multi-action cell (GLR fork)"
@@ -667,7 +667,7 @@ fn test_22_grammarbuilder_unambiguous_no_multi_action() {
     let has_multi = table
         .action_table
         .iter()
-        .any(|row| row.iter().any(|cell| cell.len() > 1));
+        .any(|row| row.iter().any(|cell| action_cell_has_conflict(cell)));
     assert!(
         !has_multi,
         "Unambiguous grammar must have no multi-action cells"


### PR DESCRIPTION
### Motivation

- Tests and tooling interpreted parse-table conflicts differently depending on whether the table used multi-entry action cells or a single `Action::Fork(...)` entry, causing inconsistent conflict counts and flaky ambiguity/resolve tests.
- Define a single, crate-local conflict predicate so all `glr-core` components (inspection, counting and tests) agree on what a conflict is.

### Description

- Introduced `conflict_inspection::action_cell_has_conflict(cell: &[Action]) -> bool` which returns true iff the state/lookahead can produce more than one valid parse action, counting `Shift`, `Reduce`, and `Accept` as valid, recursively expanding `Fork`, and ignoring `Error`/`Recover`.
- Replaced ad-hoc `cell.len() > 1` checks with `action_cell_has_conflict` in `count_conflicts` and `state_has_conflicts` so conflict summaries are representation-independent.
- Updated comprehensive tests that inspected action cells (`ambiguity_detection_comprehensive.rs`, `conflict_detection_comprehensive.rs`, `action_cell_v8.rs`, `action_cell_prop_v9.rs`, and related helpers) to use the unified predicate, and adjusted helper counters to count `conflicted` cells by the new predicate.
- Kept all changes confined to `glr-core` and did not modify runtime, tablegen, macro, or downstream crates.
- Left the LR item-set level conflict collector (`ConflictResolver::detect_conflicts`) intact (it still builds per-symbol `Vec<Action>` from items and checks `actions.len() > 1` at that layer), since that code operates on a different representation; noted as a follow-up consideration for alignment if needed.

### Testing

- Ran `cargo test -p adze-glr-core conflict -- --nocapture` and the conflict-focused unit/test suites completed with all tests passing.
- Ran `cargo test -p adze-glr-core ambiguity -- --nocapture` and the ambiguity-focused suites completed with all tests passing.
- Ran `cargo test -p adze-glr-core --all-features --no-run` to exercise build with all features (no-run) and it built successfully.
- Ran `cargo fmt --all --check` to verify formatting and it passed.

Follow-up: some callers/tests outside `glr-core` may still infer conflicts via `cell.len() > 1`; migrate them to `action_cell_has_conflict` or use `count_conflicts` / `state_has_conflicts` if they require representation-invariant conflict semantics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a559d8c8333842cbd049009d895)