### PR TITLE
runtime: harvest structured pure-rust parse errors

### DIFF
--- a/runtime/src/__private.rs
+++ b/runtime/src/__private.rs
@@ -307,9 +307,23 @@ fn parse_with_pure_parser<T: Extract<T>>(
 
     let parse_result = parser.parse_string(input);
 
-    if !parse_result.errors.is_empty() {
-        let errors = parse_result
-            .errors
+    let crate::pure_parser::ParseResult {
+        root,
+        errors: parser_errors,
+    } = parse_result;
+
+    if let Some(ref root_node) = root
+        && root_node.has_error()
+    {
+        let mut errors = vec![];
+        crate::errors::collect_parsing_errors(root_node, input.as_bytes(), &mut errors);
+        if !errors.is_empty() {
+            return Err(errors);
+        }
+    }
+
+    if !parser_errors.is_empty() {
+        let errors = parser_errors
             .into_iter()
             .map(|e| {
                 // Get symbol name from language if available
@@ -346,14 +360,18 @@ fn parse_with_pure_parser<T: Extract<T>>(
                 crate::errors::ParseError {
                     reason: crate::errors::ParseErrorReason::UnexpectedToken(symbol_name),
                     start: e.position,
-                    end: e.position,
+                    end: if e.position < input.len() {
+                        e.position + 1
+                    } else {
+                        e.position
+                    },
                 }
             })
             .collect();
         return Err(errors);
     }
 
-    let root_node = match parse_result.root {
+    let root_node = match root {
         Some(root_node) => root_node,
         None => {
             return Err(vec![crate::errors::ParseError {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -630,6 +630,67 @@ mod tests {
         let s = source.as_mut_str();
         let _ = &mut s[span];
     }
+
+    #[cfg(feature = "pure-rust")]
+    #[test]
+    fn collect_parsing_errors_pure_rust_unexpected_token_preserves_span() {
+        let source = b"abc";
+        let node = crate::pure_parser::ParsedNode {
+            symbol: 1,
+            children: vec![],
+            start_byte: 1,
+            end_byte: 2,
+            start_point: crate::pure_parser::Point { row: 0, column: 1 },
+            end_point: crate::pure_parser::Point { row: 0, column: 2 },
+            is_extra: false,
+            is_error: true,
+            is_missing: false,
+            is_named: false,
+            field_id: None,
+            language: None,
+        };
+
+        let mut errors = vec![];
+        crate::errors::collect_parsing_errors(&node, source, &mut errors);
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].start, 1);
+        assert_eq!(errors[0].end, 2);
+        assert!(matches!(
+            errors[0].reason,
+            crate::errors::ParseErrorReason::UnexpectedToken(_)
+        ));
+    }
+
+    #[cfg(feature = "pure-rust")]
+    #[test]
+    fn collect_parsing_errors_pure_rust_missing_token_uses_kind() {
+        let node = crate::pure_parser::ParsedNode {
+            symbol: 999,
+            children: vec![],
+            start_byte: 3,
+            end_byte: 3,
+            start_point: crate::pure_parser::Point { row: 0, column: 3 },
+            end_point: crate::pure_parser::Point { row: 0, column: 3 },
+            is_extra: false,
+            is_error: false,
+            is_missing: true,
+            is_named: false,
+            field_id: None,
+            language: None,
+        };
+
+        let mut errors = vec![];
+        crate::errors::collect_parsing_errors(&node, b"", &mut errors);
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].start, 3);
+        assert_eq!(errors[0].end, 3);
+        assert!(matches!(
+            &errors[0].reason,
+            crate::errors::ParseErrorReason::MissingToken(kind) if kind == "unknown"
+        ));
+    }
 }
 
 impl Extract<()> for () {
@@ -1171,24 +1232,43 @@ pub mod errors {
         source: &[u8],
         errors: &mut Vec<ParseError>,
     ) {
-        // TODO: Implement error collection for pure-rust parser
-        // For now, just check if this is an error node
-        if false {
-            // TODO: Check if error node
-            let contents =
-                std::str::from_utf8(&source[node.start_byte..node.end_byte]).unwrap_or("");
-            if !contents.is_empty() {
-                errors.push(ParseError {
-                    reason: ParseErrorReason::UnexpectedToken(contents.to_string()),
-                    start: node.start_byte,
-                    end: node.end_byte,
-                })
-            }
-        }
+        if node.is_error() {
+            if node.child(0).is_some() {
+                // We managed to parse some children, so collect nested failures.
+                let mut inner_errors = vec![];
+                for child in node.children() {
+                    collect_parsing_errors(child, source, &mut inner_errors);
+                }
 
-        // Recursively check children
-        for child in &node.children {
-            collect_parsing_errors(child, source, errors);
+                errors.push(ParseError {
+                    reason: ParseErrorReason::FailedNode(inner_errors),
+                    start: node.start_byte(),
+                    end: node.end_byte(),
+                });
+            } else {
+                match node.utf8_text(source) {
+                    Ok(contents) if !contents.is_empty() => errors.push(ParseError {
+                        reason: ParseErrorReason::UnexpectedToken(contents.to_string()),
+                        start: node.start_byte(),
+                        end: node.end_byte(),
+                    }),
+                    Ok(_) | Err(_) => errors.push(ParseError {
+                        reason: ParseErrorReason::FailedNode(vec![]),
+                        start: node.start_byte(),
+                        end: node.end_byte(),
+                    }),
+                }
+            }
+        } else if node.is_missing() {
+            errors.push(ParseError {
+                reason: ParseErrorReason::MissingToken(node.kind().to_string()),
+                start: node.start_byte(),
+                end: node.end_byte(),
+            });
+        } else if node.has_error() {
+            for child in node.children() {
+                collect_parsing_errors(child, source, errors);
+            }
         }
     }
 }

--- a/runtime/src/pure_parser.rs
+++ b/runtime/src/pure_parser.rs
@@ -452,6 +452,8 @@ impl Parser {
         let start_time = Instant::now();
         // Collect extra tokens so they can be attached to the final tree after parsing
         let mut extra_nodes: Vec<Subtree> = Vec::new();
+        // Collect error nodes so callers can harvest structured diagnostics from ParsedNode.
+        let mut error_nodes: Vec<Subtree> = Vec::new();
 
         // Main parsing loop
         let mut iteration_count = 0;
@@ -681,6 +683,15 @@ impl Parser {
                             root.end_byte = max_end_byte;
                             root.end_point = max_end_point;
                         }
+                        if !error_nodes.is_empty() {
+                            for error in error_nodes.drain(..) {
+                                if error.end_byte > root.end_byte {
+                                    root.end_byte = error.end_byte;
+                                    root.end_point = error.end_point;
+                                }
+                                root.children.push(error);
+                            }
+                        }
                         return ParseResult {
                             root: Some(subtree_to_node(root, Some(language as *const _))),
                             errors,
@@ -702,6 +713,41 @@ impl Parser {
                         expected: expected_symbols,
                         found: token.symbol,
                     });
+
+                    let end_byte = position.saturating_add(token.length).min(source.len());
+                    let end_point = if end_byte > position {
+                        advance_point(point, &source[position..end_byte])
+                    } else {
+                        point
+                    };
+                    let error_node = Subtree {
+                        symbol: token.symbol,
+                        children: Vec::new(),
+                        start_byte: position,
+                        end_byte,
+                        start_point: point,
+                        end_point,
+                        is_extra: false,
+                        is_error: true,
+                        is_missing: token.length == 0,
+                        production_id: 0,
+                        field_id: None,
+                    };
+
+                    if let Some(top) = self.stack.last_mut() {
+                        if let Some(ref mut node) = top.subtree {
+                            let prev_end_byte = node.end_byte;
+                            node.end_byte = node.end_byte.max(error_node.end_byte);
+                            if error_node.end_byte >= prev_end_byte {
+                                node.end_point = error_node.end_point;
+                            }
+                            node.children.push(error_node);
+                        } else {
+                            error_nodes.push(error_node);
+                        }
+                    } else {
+                        error_nodes.push(error_node);
+                    }
 
                     // Simple error recovery: skip token
                     if position < source.len() {


### PR DESCRIPTION
### Motivation

- The pure-Rust parser path previously did not harvest structured parse diagnostics from the concrete parse tree, causing invalid input to produce unhelpful or fallback errors instead of actionable byte-span diagnostics.
- The change aims to return the existing `errors::ParseError` shape (with `ParseErrorReason`) for pure-Rust parsing, preserving byte spans and reusing the public error types.

### Description

- Implemented `collect_parsing_errors` for the pure-Rust `ParsedNode` by mirroring the Tree-sitter behavior and producing `ParseErrorReason::UnexpectedToken`, `FailedNode`, or `MissingToken` with preserved `start`/`end` byte spans (`runtime/src/lib.rs`).
- Updated the pure-parser integration to prefer harvested tree diagnostics from a returned `ParsedNode` (`root.has_error()` + `collect_parsing_errors`) before falling back to parser-loop errors and adjusted fallback spans to produce an actionable `start..start+1` range when possible (`runtime/src/__private.rs`).
- Taught the pure-Rust parser loop to create and retain concrete `Subtree` error nodes during `Action::Error` recovery (setting `is_error`/`is_missing` and byte spans) and attach them to the final returned root so diagnostics can be harvested from the tree (`runtime/src/pure_parser.rs`).
- Added focused unit tests that exercise pure-Rust error harvesting for unexpected tokens and missing tokens, preserving spans and reason variants (`runtime/src/lib.rs` tests added).

### Testing

- Ran formatter check with `cargo fmt --all --check` and it succeeded.
- Ran targeted tests: `cargo test -p adze --test error_display_tests -- --nocapture` and `cargo test -p adze --test error_recovery_comprehensive -- --nocapture`, both completed with all tests passing.
- Exercised the pure-rust path with `cargo test -p adze --features pure-rust error -- --nocapture` (core test suites executed) and the test runs completed successfully.

Example invalid input and resulting diagnostic:

- Input example: `"foo @ bar"` where `@` is not valid in the grammar.
- Example returned value: `Err(vec![ParseError { reason: ParseErrorReason::UnexpectedToken("@".to_string()), start: 4, end: 5 }])` which is produced by harvesting the parse-tree error node when available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a4c14648333b4f1cdf53b008848)