### PR TITLE
runtime: harvest structured pure-Rust parse diagnostics from parsed nodes

### DIFF
--- a/runtime/src/__private.rs
+++ b/runtime/src/__private.rs
@@ -295,6 +295,76 @@ fn parse_with_pure_parser<T: Extract<T>>(
     input: &str,
     language: impl Fn() -> &'static crate::pure_parser::TSLanguage,
 ) -> core::result::Result<T, Vec<crate::errors::ParseError>> {
+    fn symbol_name(lang: &crate::pure_parser::TSLanguage, symbol: u16) -> String {
+        if (symbol as usize) < lang.symbol_count as usize {
+            // SAFETY: `symbol` is bounds-checked above against `symbol_count`.
+            // `symbol_names` and `public_symbol_map` point to static language
+            // tables that live for the entire parse.
+            unsafe {
+                let public_symbol = if !lang.public_symbol_map.is_null() {
+                    *lang.public_symbol_map.add(symbol as usize)
+                } else {
+                    symbol
+                };
+
+                if (public_symbol as usize) < lang.symbol_count as usize {
+                    let symbol_ptr = *lang.symbol_names.add(public_symbol as usize);
+                    if !symbol_ptr.is_null() {
+                        std::ffi::CStr::from_ptr(symbol_ptr as *const i8)
+                            .to_string_lossy()
+                            .to_string()
+                    } else {
+                        format!("symbol {} (public {})", symbol, public_symbol)
+                    }
+                } else {
+                    format!("symbol {} (public {} out of bounds)", symbol, public_symbol)
+                }
+            }
+        } else {
+            format!("symbol {} (out of bounds)", symbol)
+        }
+    }
+
+    fn convert_lr_errors(
+        parse_errors: Vec<crate::pure_parser::ParseError>,
+        input: &str,
+        lang: &crate::pure_parser::TSLanguage,
+    ) -> Vec<crate::errors::ParseError> {
+        parse_errors
+            .into_iter()
+            .map(|error| {
+                let found_name = symbol_name(lang, error.found);
+                let expected_names: Vec<_> = error
+                    .expected
+                    .iter()
+                    .map(|symbol| symbol_name(lang, *symbol))
+                    .collect();
+
+                let message = if expected_names.is_empty() {
+                    found_name
+                } else {
+                    format!(
+                        "{} (expected one of: {})",
+                        found_name,
+                        expected_names.join(", ")
+                    )
+                };
+
+                let end = if error.position < input.len() {
+                    error.position.saturating_add(1)
+                } else {
+                    error.position
+                };
+
+                crate::errors::ParseError {
+                    reason: crate::errors::ParseErrorReason::UnexpectedToken(message),
+                    start: error.position,
+                    end,
+                }
+            })
+            .collect()
+    }
+
     let mut parser = crate::pure_parser::Parser::new();
     let lang = language();
     parser.set_language(lang).map_err(|e| {
@@ -306,52 +376,6 @@ fn parse_with_pure_parser<T: Extract<T>>(
     })?;
 
     let parse_result = parser.parse_string(input);
-
-    if !parse_result.errors.is_empty() {
-        let errors = parse_result
-            .errors
-            .into_iter()
-            .map(|e| {
-                // Get symbol name from language if available
-                let symbol_name = if (e.found as usize) < lang.symbol_count as usize {
-                    // SAFETY: `e.found` is bounds-checked above against `symbol_count`.
-                    // `symbol_names` and `public_symbol_map` point to static language
-                    // tables that live for the entire parse.
-                    unsafe {
-                        let public_symbol = if !lang.public_symbol_map.is_null() {
-                            *lang.public_symbol_map.add(e.found as usize)
-                        } else {
-                            e.found
-                        };
-
-                        if (public_symbol as usize) < lang.symbol_count as usize {
-                            let symbol_ptr = *lang.symbol_names.add(public_symbol as usize);
-                            if !symbol_ptr.is_null() {
-                                std::ffi::CStr::from_ptr(symbol_ptr as *const i8)
-                                    .to_string_lossy()
-                                    .to_string()
-                            } else {
-                                format!("symbol {} (public {})", e.found, public_symbol)
-                            }
-                        } else {
-                            format!(
-                                "symbol {} (public {} out of bounds)",
-                                e.found, public_symbol
-                            )
-                        }
-                    }
-                } else {
-                    format!("symbol {} (out of bounds)", e.found)
-                };
-                crate::errors::ParseError {
-                    reason: crate::errors::ParseErrorReason::UnexpectedToken(symbol_name),
-                    start: e.position,
-                    end: e.position,
-                }
-            })
-            .collect();
-        return Err(errors);
-    }
 
     let root_node = match parse_result.root {
         Some(root_node) => root_node,
@@ -365,6 +389,14 @@ fn parse_with_pure_parser<T: Extract<T>>(
             }]);
         }
     };
+
+    let mut errors = convert_lr_errors(parse_result.errors, input, lang);
+    if root_node.has_error() {
+        crate::errors::collect_parsing_errors(&root_node, input.as_bytes(), &mut errors);
+    }
+    if !errors.is_empty() {
+        return Err(errors);
+    }
 
     // Check if the root node is source_file wrapper
     // In the augmented grammar, we have S' -> source_file -> actual_language_root

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1171,24 +1171,49 @@ pub mod errors {
         source: &[u8],
         errors: &mut Vec<ParseError>,
     ) {
-        // TODO: Implement error collection for pure-rust parser
-        // For now, just check if this is an error node
-        if false {
-            // TODO: Check if error node
-            let contents =
-                std::str::from_utf8(&source[node.start_byte..node.end_byte]).unwrap_or("");
-            if !contents.is_empty() {
-                errors.push(ParseError {
-                    reason: ParseErrorReason::UnexpectedToken(contents.to_string()),
-                    start: node.start_byte,
-                    end: node.end_byte,
-                })
-            }
-        }
+        if node.is_error() {
+            if !node.children().is_empty() {
+                // We managed to parse some children, so collect underlying errors for this node.
+                let mut inner_errors = vec![];
+                for child in node.children() {
+                    collect_parsing_errors(child, source, &mut inner_errors);
+                }
 
-        // Recursively check children
-        for child in &node.children {
-            collect_parsing_errors(child, source, errors);
+                errors.push(ParseError {
+                    reason: ParseErrorReason::FailedNode(inner_errors),
+                    start: node.start_byte(),
+                    end: node.end_byte(),
+                });
+            } else {
+                let contents = source
+                    .get(node.start_byte()..node.end_byte())
+                    .and_then(|bytes| std::str::from_utf8(bytes).ok())
+                    .unwrap_or("");
+
+                if !contents.is_empty() {
+                    errors.push(ParseError {
+                        reason: ParseErrorReason::UnexpectedToken(contents.to_string()),
+                        start: node.start_byte(),
+                        end: node.end_byte(),
+                    });
+                } else {
+                    errors.push(ParseError {
+                        reason: ParseErrorReason::FailedNode(vec![]),
+                        start: node.start_byte(),
+                        end: node.end_byte(),
+                    });
+                }
+            }
+        } else if node.is_missing() {
+            errors.push(ParseError {
+                reason: ParseErrorReason::MissingToken(node.kind().to_string()),
+                start: node.start_byte(),
+                end: node.end_byte(),
+            });
+        } else {
+            for child in node.children() {
+                collect_parsing_errors(child, source, errors);
+            }
         }
     }
 }

--- a/runtime/tests/extract_trait_v2.rs
+++ b/runtime/tests/extract_trait_v2.rs
@@ -742,6 +742,62 @@ fn test_collect_parsing_errors_no_errors() {
 }
 
 #[test]
+fn test_collect_parsing_errors_unexpected_token_from_error_leaf() {
+    let error_leaf = make_node(
+        1,
+        vec![],
+        1,
+        2,
+        pt(0, 1),
+        pt(0, 2),
+        false,
+        true,
+        false,
+        true,
+        None,
+    );
+    let root = parent_node(0, vec![error_leaf]);
+    let mut errors = vec![];
+    adze::errors::collect_parsing_errors(&root, b"a@c", &mut errors);
+
+    assert_eq!(errors.len(), 1);
+    match &errors[0].reason {
+        ParseErrorReason::UnexpectedToken(token) => assert_eq!(token, "@"),
+        other => panic!("Expected UnexpectedToken, got {other:?}"),
+    }
+    assert_eq!(errors[0].start, 1);
+    assert_eq!(errors[0].end, 2);
+}
+
+#[test]
+fn test_collect_parsing_errors_missing_token_is_reported() {
+    let missing_node = make_node(
+        9,
+        vec![],
+        4,
+        4,
+        pt(0, 4),
+        pt(0, 4),
+        false,
+        false,
+        true,
+        true,
+        None,
+    );
+    let root = parent_node(0, vec![missing_node]);
+    let mut errors = vec![];
+    adze::errors::collect_parsing_errors(&root, b"test", &mut errors);
+
+    assert_eq!(errors.len(), 1);
+    assert!(matches!(
+        errors[0].reason,
+        ParseErrorReason::MissingToken(_)
+    ));
+    assert_eq!(errors[0].start, 4);
+    assert_eq!(errors[0].end, 4);
+}
+
+#[test]
 fn test_symbol_id_is_u16() {
     assert_eq!(
         std::mem::size_of::<adze::SymbolId>(),


### PR DESCRIPTION
### Motivation

- The pure-Rust parsing path previously stubbed error collection which caused invalid input to lose structured diagnostics; the change makes parse failures return actionable, structured `ParseError` values instead of panics or silent failures.  
- Reuse existing public error types and preserve byte spans so downstream extraction and reporting continue to work without API changes.

### Description

- Implement `errors::collect_parsing_errors` for `pure-rust` `ParsedNode` trees to emit `ParseError` variants for error leaves (`UnexpectedToken`), composite error nodes (`FailedNode` with nested errors), and missing nodes (`MissingToken`).  
- Convert low-level LR `ParseError` produced by the `pure_parser::Parser` into the public `crate::errors::ParseError` using `symbol_name` and `convert_lr_errors`, including expected token names when available and preserving byte ranges.  
- Merge LR-level errors with harvested tree errors before typed extraction in `parse_with_pure_parser`, ensuring invalid input yields `Err(Vec<ParseError>)`.  
- Add regression tests in `runtime/tests/extract_trait_v2.rs` that verify an error leaf spanning `@` yields `ParseError { reason: UnexpectedToken("@"), start: 1, end: 2 }` and that `MissingToken` is reported with a zero-width span.

### Testing

- Ran formatting check with `cargo fmt --all --check`, which succeeded.  
- Ran targeted and integration tests: `cargo test -p adze --test error_display_tests -- --nocapture`, `cargo test -p adze --test error_recovery_comprehensive -- --nocapture`, `cargo test -p adze --test error_recovery_v9 -- --nocapture`, and `cargo test -p adze --features pure-rust error -- --nocapture`, all of which completed successfully in the test runs.  
- Ran the new/modified unit tests `runtime/tests/extract_trait_v2.rs::test_collect_parsing_errors_unexpected_token_from_error_leaf` and `::test_collect_parsing_errors_missing_token_is_reported`, both of which passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a4c14648333b4f1cdf53b008848)