### PR TITLE
runtime: harvest structured parse errors from pure-rust ParsedNode trees

### DIFF
--- a/runtime/src/__private.rs
+++ b/runtime/src/__private.rs
@@ -308,7 +308,7 @@ fn parse_with_pure_parser<T: Extract<T>>(
     let parse_result = parser.parse_string(input);
 
     if !parse_result.errors.is_empty() {
-        let errors = parse_result
+        let mut errors: Vec<crate::errors::ParseError> = parse_result
             .errors
             .into_iter()
             .map(|e| {
@@ -350,6 +350,10 @@ fn parse_with_pure_parser<T: Extract<T>>(
                 }
             })
             .collect();
+
+        if let Some(root_node) = parse_result.root.as_ref() {
+            crate::errors::collect_parsing_errors(root_node, input.as_bytes(), &mut errors);
+        }
         return Err(errors);
     }
 
@@ -365,6 +369,14 @@ fn parse_with_pure_parser<T: Extract<T>>(
             }]);
         }
     };
+
+    if root_node.has_error() {
+        let mut errors = vec![];
+        crate::errors::collect_parsing_errors(&root_node, input.as_bytes(), &mut errors);
+        if !errors.is_empty() {
+            return Err(errors);
+        }
+    }
 
     // Check if the root node is source_file wrapper
     // In the augmented grammar, we have S' -> source_file -> actual_language_root

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1171,24 +1171,43 @@ pub mod errors {
         source: &[u8],
         errors: &mut Vec<ParseError>,
     ) {
-        // TODO: Implement error collection for pure-rust parser
-        // For now, just check if this is an error node
-        if false {
-            // TODO: Check if error node
-            let contents =
-                std::str::from_utf8(&source[node.start_byte..node.end_byte]).unwrap_or("");
-            if !contents.is_empty() {
-                errors.push(ParseError {
-                    reason: ParseErrorReason::UnexpectedToken(contents.to_string()),
-                    start: node.start_byte,
-                    end: node.end_byte,
-                })
-            }
-        }
+        if node.is_error() {
+            if node.child(0).is_some() {
+                // Collect nested parse failures for this error subtree.
+                let mut inner_errors = vec![];
+                for child in node.children() {
+                    collect_parsing_errors(child, source, &mut inner_errors);
+                }
 
-        // Recursively check children
-        for child in &node.children {
-            collect_parsing_errors(child, source, errors);
+                errors.push(ParseError {
+                    reason: ParseErrorReason::FailedNode(inner_errors),
+                    start: node.start_byte(),
+                    end: node.end_byte(),
+                });
+            } else {
+                match node.utf8_text(source) {
+                    Ok(contents) if !contents.is_empty() => errors.push(ParseError {
+                        reason: ParseErrorReason::UnexpectedToken(contents.to_string()),
+                        start: node.start_byte(),
+                        end: node.end_byte(),
+                    }),
+                    Ok(_) | Err(_) => errors.push(ParseError {
+                        reason: ParseErrorReason::FailedNode(vec![]),
+                        start: node.start_byte(),
+                        end: node.end_byte(),
+                    }),
+                }
+            }
+        } else if node.is_missing() {
+            errors.push(ParseError {
+                reason: ParseErrorReason::MissingToken(node.kind().to_string()),
+                start: node.start_byte(),
+                end: node.end_byte(),
+            });
+        } else if node.has_error() {
+            for child in node.children() {
+                collect_parsing_errors(child, source, errors);
+            }
         }
     }
 }


### PR DESCRIPTION
### Motivation
- The pure-Rust parser path had a stubbed/disabled tree error collector, causing invalid input to sometimes lack actionable diagnostics.  
- The change aims to return structured `ParseError` diagnostics (with byte spans) from pure-Rust parse runs without changing the public error API.

### Description
- Implemented `errors::collect_parsing_errors` for the pure-Rust backend in `runtime/src/lib.rs`, mirroring the Tree-sitter path to emit `UnexpectedToken`, `MissingToken`, and nested `FailedNode` variants and preserving node byte spans via `start_byte()`/`end_byte()`.  
- Updated the pure-Rust parse flow in `runtime/src/__private.rs` so that when `parse_string` reports parser-level errors we augment those with harvested tree errors (if a root exists), and when there are no low-level errors but `root.has_error()` is true we now harvest and return those diagnostics instead of proceeding to typed extraction.  
- Reused existing `ParseError` / `ParseErrorReason` types and preserved byte spans; no public API redesign.  
- Example invalid input and returned diagnostic: input `"@"` now yields `Err([ParseError { reason: UnexpectedToken("@".to_string()), start: 0, end: 1 }])` produced by the pure-Rust tree-harvesting path.

### Testing
- Ran `cargo test -p adze --test error_display_tests -- --nocapture` and all tests passed.  
- Ran `cargo test -p adze --test error_recovery_comprehensive -- --nocapture` and all tests passed.  
- Ran `cargo test -p adze --features pure-rust --test error_recovery_v9 -- --nocapture` and all tests passed.  
- Ran `cargo fmt --all --check` and formatting checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a4c14648333b4f1cdf53b008848)