### PR TITLE
Add non-blocking product-proof advisory CI lane

### DIFF
--- a/.github/workflows/product-proof.yml
+++ b/.github/workflows/product-proof.yml
@@ -1,0 +1,30 @@
+name: Product Proof (Advisory)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '20 4 * * 1' # weekly Monday advisory canary
+
+permissions:
+  contents: read
+
+jobs:
+  ci-product:
+    name: ci-product advisory canaries
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Show canary plan (dry-run)
+        run: scripts/ci-product.sh --dry-run
+
+      - name: Run ci-product advisory lane
+        run: scripts/ci-product.sh

--- a/docs/status/KNOWN_RED.md
+++ b/docs/status/KNOWN_RED.md
@@ -1,6 +1,6 @@
 # Known red
 
-**Last updated:** 2026-04-06
+**Last updated:** 2026-04-29
 
 This file tracks intentional exclusions from the supported lane:
 
@@ -63,6 +63,28 @@ These may run as optional signal (nightly/manual/canary), but are not required f
 - All other `.github/workflows/ci.yml` jobs are optional unless explicitly promoted in settings.
 
 ---
+
+
+## Advisory product proof lane (non-blocking)
+
+A broad-surface advisory lane now exists as `.github/workflows/product-proof.yml` and runs `scripts/ci-product.sh` on schedule/manual dispatch.
+
+This lane is **not** part of required merge gates. It provides bounded smoke proof across product surfaces that are outside `ci-supported`.
+
+Current canaries:
+
+- `adze` runtime pure-rust smoke — **compile-only** (`cargo check -p adze --features pure-rust`)
+- `adze-cli` smoke — **compile-only** (`cargo check -p adze-cli`)
+- `adze-golden-tests` smoke — **compile-only** (`cargo test -p adze-golden-tests --features python-grammar --no-run`)
+- `adze-benchmarks` canary — **compile-only** (`cargo bench -p adze-benchmarks --no-run`)
+- `wasm-demo` canary — **compile-only** (`cargo check --manifest-path wasm-demo/Cargo.toml --target wasm32-unknown-unknown`)
+- grammar smoke (`adze-python`) — **compile-only** (`cargo check -p adze-python`)
+- `runtime2` canary — **compile-only** (`cargo test --manifest-path runtime2/Cargo.toml --no-run`)
+- governance/BDD microcrate smoke (`adze-bdd-grid-core`) — **compile-only** (`cargo test -p adze-bdd-grid-core --lib --no-run`)
+
+Notes:
+- This lane intentionally does not provide full behavior proof; it is bounded canary signal only.
+- If one canary is red, the advisory job can fail while remaining non-blocking due to workflow `continue-on-error: true`.
 
 ## Known warnings (non-blocking)
 

--- a/scripts/ci-product.sh
+++ b/scripts/ci-product.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DRY_RUN=false
+if [[ "${1:-}" == "--dry-run" ]]; then
+  DRY_RUN=true
+fi
+
+# Canary definitions: "label|proof_type|command"
+CANARIES=(
+  "adze runtime pure-rust smoke|compile-only|cargo check -p adze --features pure-rust"
+  "adze-cli smoke|compile-only|cargo check -p adze-cli"
+  "golden-tests smoke|compile-only|cargo test -p adze-golden-tests --features python-grammar --no-run"
+  "benchmarks canary|compile-only|cargo bench -p adze-benchmarks --no-run"
+  "wasm-demo canary|compile-only|cargo check --manifest-path wasm-demo/Cargo.toml --target wasm32-unknown-unknown"
+  "grammar smoke (python)|compile-only|cargo check -p adze-python"
+  "runtime2 canary|compile-only|cargo test --manifest-path runtime2/Cargo.toml --no-run"
+  "governance/BDD microcrate smoke|compile-only|cargo test -p adze-bdd-grid-core --lib --no-run"
+)
+
+printf '== ci-product advisory canaries ==\n'
+printf 'Mode: %s\n\n' "$([[ "$DRY_RUN" == true ]] && echo dry-run || echo execute)"
+
+failures=0
+for entry in "${CANARIES[@]}"; do
+  IFS='|' read -r label proof_type cmd <<<"$entry"
+  printf '\n[%s] %s\n' "$proof_type" "$label"
+  printf '  $ %s\n' "$cmd"
+
+  if [[ "$DRY_RUN" == true ]]; then
+    continue
+  fi
+
+  if eval "$cmd"; then
+    printf '  -> PASS\n'
+  else
+    printf '  -> FAIL\n'
+    failures=$((failures + 1))
+  fi
+done
+
+if [[ "$DRY_RUN" == true ]]; then
+  printf '\nDry run complete.\n'
+  exit 0
+fi
+
+if [[ $failures -gt 0 ]]; then
+  printf '\nci-product completed with %d failing canary(s).\n' "$failures"
+  exit 1
+fi
+
+printf '\nci-product completed successfully.\n'


### PR DESCRIPTION
### Motivation

- Provide an advisory, non-blocking CI lane that gives bounded smoke proof across broader product surfaces that are intentionally excluded from the narrow `ci-supported` gate. 
- Surface quick compile/smoke canaries for runtime, CLI, golden tests, benchmarks, wasm demo, a grammar, runtime2, and one governance/BDD microcrate so maintainers can run a single advisory proof job. 

### Description

- Add `.github/workflows/product-proof.yml`, a manual/scheduled advisory workflow that runs `scripts/ci-product.sh`, is `workflow_dispatch`/scheduled, and is marked non-blocking via `continue-on-error: true`. 
- Add `scripts/ci-product.sh`, a small runner that supports `--dry-run` and executes a bounded list of canaries (each is a label, proof type, and command). 
- The canaries cover: `adze` runtime (pure-rust) compile-only, `adze-cli` compile-only, `adze-golden-tests` compile-only (`--no-run`), `adze-benchmarks` compile-only (`--no-run`), `wasm-demo` wasm compile-only, one grammar (`adze-python`) compile-only, `runtime2` compile-only (`--no-run`), and one governance/BDD microcrate (`adze-bdd-grid-core`) compile-only. 
- Update `docs/status/KNOWN_RED.md` with an "Advisory product proof lane" section documenting the lane intent, list of canaries and their proof levels, and refresh the last-updated date. 

### Testing

- Ran `bash -n scripts/ci-product.sh` to validate shell syntax and it succeeded. 
- Ran `cargo metadata --format-version 1` to confirm workspace metadata and it succeeded. 
- Ran `scripts/ci-product.sh --dry-run` to show the plan and it succeeded. 
- Executed `scripts/ci-product.sh` end-to-end; 7 of 8 canaries passed and the `wasm-demo` canary failed due to a missing `wasm32-unknown-unknown` target in the local environment (this workflow installs that target when run by GitHub). 
- Ran `git diff --check` and basic repository checks, and committed the new files.`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a6fccd88333829d4ea6c2470b75)