### PR TITLE
chore: upgrade workspace Criterion to 0.8.2 and remove bincode test dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,9 +552,9 @@ version = "0.8.0-dev"
 dependencies = [
  "adze-glr-core",
  "anyhow",
- "bincode",
  "indexmap",
  "insta",
+ "postcard",
  "proptest",
  "serde",
  "serde_json",
@@ -878,6 +878,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1051,15 +1060,6 @@ dependencies = [
  "object",
  "rustc-demangle",
  "windows-link",
-]
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -1334,25 +1334,24 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
  "itertools",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -1360,9 +1359,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools",
@@ -1750,12 +1749,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2011,17 +2004,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2029,9 +2011,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -2277,6 +2259,16 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "parking_lot"
@@ -3588,6 +3580,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3595,6 +3603,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 proptest = "1.4"
 insta = "1.39"
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "0.8.2", features = ["html_reports"] }
 thiserror = "2.0"
 syn = { version = "2", features = ["full", "extra-traits"] }
 quote = "1"
@@ -122,7 +122,7 @@ proc-macro2 = "1"
 anyhow = "1.0"
 tempfile = "3"
 indexmap = "2.0"
-bincode = "1.3"
+postcard = { version = "1.1", features = ["use-std"] }
 clap = { version = "4.6", features = ["derive"] }
 rayon = "1.10"
 rustc-hash = "2.1"

--- a/benchmarks/benches/arena_vs_box_allocation.rs
+++ b/benchmarks/benches/arena_vs_box_allocation.rs
@@ -7,7 +7,8 @@
 //! Run with: cargo bench --bench arena_vs_box_allocation
 
 use adze::arena_allocator::{TreeArena, TreeNode};
-use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use std::hint::black_box;
 
 /// Benchmark arena allocation for N nodes
 fn bench_arena_allocation(c: &mut Criterion) {

--- a/benchmarks/benches/core_baselines.rs
+++ b/benchmarks/benches/core_baselines.rs
@@ -10,7 +10,8 @@ use adze_glr_core::{FirstFollowSets, build_lr1_automaton};
 use adze_ir::{Grammar, ProductionId, Rule, Symbol, SymbolId, Token, TokenPattern};
 use adze_tablegen::compress::TableCompressor;
 use adze_tablegen::helpers;
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 /// Build a grammar with `n` binary-operator rules over a single expression nonterminal.
 /// This creates: expr -> expr OP_i expr  (for i in 0..n)  plus  expr -> NUMBER.

--- a/benchmarks/benches/glr_hot.rs
+++ b/benchmarks/benches/glr_hot.rs
@@ -1,5 +1,6 @@
 use adze_example::arithmetic::grammar::parse;
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 const ARITH_MEDIUM: &str = include_str!("../fixtures/arithmetic/medium.expr");
 const ARITH_LARGE: &str = include_str!("../fixtures/arithmetic/large.expr");

--- a/benchmarks/benches/glr_performance.rs
+++ b/benchmarks/benches/glr_performance.rs
@@ -1,5 +1,6 @@
 use adze_example::arithmetic::grammar::parse;
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 // Load real arithmetic fixtures to keep benchmark inputs valid
 // for the GLR parser used in perf gating.

--- a/benchmarks/benches/glr_performance_real.rs
+++ b/benchmarks/benches/glr_performance_real.rs
@@ -42,7 +42,8 @@
 //! - Fixtures: benchmarks/fixtures/arithmetic/
 
 use adze_example::arithmetic::grammar::parse;
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 // Load arithmetic fixtures at compile time (deterministic, zero I/O overhead)
 const ARITH_SMALL: &str = include_str!("../fixtures/arithmetic/small.expr");

--- a/benchmarks/benches/optimization_bench.rs
+++ b/benchmarks/benches/optimization_bench.rs
@@ -1,6 +1,7 @@
 use adze::arena_allocator::{TreeArena, TreeNode};
 use adze::stack_pool::StackPool;
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 fn benchmark_stack_pool(c: &mut Criterion) {
     let mut group = c.benchmark_group("stack_pool");

--- a/benchmarks/benches/stack_optimization.rs
+++ b/benchmarks/benches/stack_optimization.rs
@@ -1,6 +1,7 @@
 use adze::pool::NodePool;
 use adze_glr_core::stack::StackNode;
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 use std::sync::Arc;
 
 /// Benchmark comparing old Vec-based stacks vs new persistent stacks

--- a/crates/bdd-grid-core/benches/bdd_grid_bench.rs
+++ b/crates/bdd-grid-core/benches/bdd_grid_bench.rs
@@ -2,7 +2,8 @@
 //!
 //! Measures performance of scenario lookup and progress reporting used in BDD framework.
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 use adze_bdd_grid_core::{
     BddPhase, BddScenario, BddScenarioStatus, GLR_CONFLICT_PRESERVATION_GRID, bdd_progress,

--- a/crates/concurrency-caps-core/benches/caps_bench.rs
+++ b/crates/concurrency-caps-core/benches/caps_bench.rs
@@ -1,4 +1,5 @@
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 use adze_concurrency_caps_core::{
     ConcurrencyCaps, normalized_concurrency, parse_positive_usize_or_default,

--- a/crates/concurrency-map-core/benches/bench_map.rs
+++ b/crates/concurrency-map-core/benches/bench_map.rs
@@ -1,4 +1,5 @@
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 use adze_concurrency_map_core::{
     ParallelPartitionPlan, bounded_parallel_map, normalized_concurrency,

--- a/crates/feature-policy-core/benches/bench_policy.rs
+++ b/crates/feature-policy-core/benches/bench_policy.rs
@@ -1,4 +1,5 @@
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 use adze_feature_policy_core::{ParserBackend, ParserFeatureProfile};
 

--- a/crates/governance-matrix-core-impl/benches/governance_matrix_bench.rs
+++ b/crates/governance-matrix-core-impl/benches/governance_matrix_bench.rs
@@ -2,7 +2,8 @@
 //!
 //! Measures performance of matrix operations used in governance.
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 use adze_governance_matrix_core_impl::{
     BddGovernanceMatrix, BddPhase, GLR_CONFLICT_PRESERVATION_GRID, ParserFeatureProfile,

--- a/crates/governance-metadata/benches/bench_governance.rs
+++ b/crates/governance-metadata/benches/bench_governance.rs
@@ -1,4 +1,5 @@
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 use adze_feature_policy_core::ParserFeatureProfile;
 use adze_governance_metadata::{GovernanceMetadata, ParserFeatureProfileSnapshot};

--- a/crates/linecol-core/benches/linecol_bench.rs
+++ b/crates/linecol-core/benches/linecol_bench.rs
@@ -1,4 +1,5 @@
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 use adze_linecol_core::LineCol;
 

--- a/crates/parser-backend-core/benches/parser_backend_bench.rs
+++ b/crates/parser-backend-core/benches/parser_backend_bench.rs
@@ -2,7 +2,8 @@
 //!
 //! Measures performance of backend selection used in parser.
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 use adze_parser_backend_core::ParserBackend;
 

--- a/crates/parsetable-metadata/benches/metadata_bench.rs
+++ b/crates/parsetable-metadata/benches/metadata_bench.rs
@@ -1,4 +1,5 @@
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 use adze_parsetable_metadata::{
     FeatureFlags, GenerationInfo, GrammarInfo, ParsetableMetadata, TableStatistics,

--- a/crates/stack-pool-core/benches/stack_pool_bench.rs
+++ b/crates/stack-pool-core/benches/stack_pool_bench.rs
@@ -1,4 +1,5 @@
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 use adze_stack_pool_core::StackPool;
 

--- a/crates/ts-format-core/benches/ts_format_bench.rs
+++ b/crates/ts-format-core/benches/ts_format_bench.rs
@@ -4,7 +4,8 @@
 
 use std::collections::BTreeMap;
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 use adze_glr_core::{
     Action, GotoIndexing, Grammar, LexMode, ParseTable, RuleId, StateId, SymbolId, SymbolMetadata,

--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -17,7 +17,6 @@ dependencies = [
  "adze-ts-format-core",
  "ahash",
  "anyhow",
- "getrandom",
  "indexmap",
  "log",
  "once_cell",
@@ -33,12 +32,29 @@ dependencies = [
 name = "adze-bdd-governance-core"
 version = "0.1.0"
 dependencies = [
+ "adze-bdd-governance-reporting-core",
  "adze-bdd-grid-core",
  "adze-feature-policy-core",
 ]
 
 [[package]]
+name = "adze-bdd-governance-reporting-core"
+version = "0.1.0"
+dependencies = [
+ "adze-bdd-grid-core",
+ "adze-feature-policy-core",
+ "adze-governance-status-core",
+]
+
+[[package]]
 name = "adze-bdd-grid-core"
+version = "0.1.0"
+dependencies = [
+ "adze-bdd-scenario-core",
+]
+
+[[package]]
+name = "adze-bdd-scenario-core"
 version = "0.1.0"
 
 [[package]]
@@ -46,6 +62,8 @@ name = "adze-common"
 version = "0.8.0-dev"
 dependencies = [
  "adze-common-syntax-core",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -87,6 +105,7 @@ dependencies = [
 name = "adze-concurrency-env-contract-core"
 version = "0.1.0"
 dependencies = [
+ "adze-concurrency-env-vars-core",
  "adze-concurrency-parse-core",
 ]
 
@@ -96,6 +115,10 @@ version = "0.1.0"
 dependencies = [
  "adze-concurrency-env-contract-core",
 ]
+
+[[package]]
+name = "adze-concurrency-env-vars-core"
+version = "0.1.0"
 
 [[package]]
 name = "adze-concurrency-init-bootstrap-core"
@@ -162,7 +185,6 @@ name = "adze-example"
 version = "0.8.0-dev"
 dependencies = [
  "adze",
- "adze-glr-core",
  "adze-tool",
  "codemap",
  "codemap-diagnostic",
@@ -177,6 +199,7 @@ name = "adze-feature-policy-core"
 version = "0.1.0"
 dependencies = [
  "adze-parser-backend-core",
+ "adze-parser-feature-profile-core",
 ]
 
 [[package]]
@@ -186,7 +209,6 @@ dependencies = [
  "adze-ir",
  "fixedbitset",
  "indexmap",
- "postcard",
  "rustc-hash",
  "serde",
  "smallvec",
@@ -228,7 +250,15 @@ dependencies = [
 name = "adze-governance-runtime-core"
 version = "0.1.0"
 dependencies = [
+ "adze-governance-runtime-profile-core",
  "adze-governance-runtime-reporting",
+]
+
+[[package]]
+name = "adze-governance-runtime-profile-core"
+version = "0.1.0"
+dependencies = [
+ "adze-governance-matrix-contract",
 ]
 
 [[package]]
@@ -236,6 +266,14 @@ name = "adze-governance-runtime-reporting"
 version = "0.1.0"
 dependencies = [
  "adze-governance-matrix-contract",
+]
+
+[[package]]
+name = "adze-governance-status-core"
+version = "0.1.0"
+dependencies = [
+ "adze-bdd-grid-core",
+ "adze-feature-policy-core",
 ]
 
 [[package]]
@@ -266,6 +304,13 @@ dependencies = [
 [[package]]
 name = "adze-parser-backend-core"
 version = "0.1.0"
+
+[[package]]
+name = "adze-parser-feature-profile-core"
+version = "0.1.0"
+dependencies = [
+ "adze-parser-backend-core",
+]
 
 [[package]]
 name = "adze-parsetable-metadata"
@@ -365,7 +410,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -446,15 +490,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
-name = "atomic-polyfill"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
-dependencies = [
- "critical-section",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,12 +515,6 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "c2rust-bitfields"
@@ -529,7 +558,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "wasm-bindgen",
  "windows-link 0.2.1",
 ]
 
@@ -572,15 +603,6 @@ name = "clap_lex"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
-
-[[package]]
-name = "cobs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
-dependencies = [
- "thiserror",
-]
 
 [[package]]
 name = "codemap"
@@ -630,12 +652,6 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
@@ -700,18 +716,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "embedded-io"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
-
-[[package]]
-name = "embedded-io"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
-
-[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -771,11 +775,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -785,33 +787,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
-name = "hash32"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-
-[[package]]
-name = "heapless"
-version = "0.7.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
-dependencies = [
- "atomic-polyfill",
- "hash32",
- "rustc_version",
- "serde",
- "spin",
- "stable_deref_trait",
-]
 
 [[package]]
 name = "heck"
@@ -1019,15 +998,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1075,19 +1045,6 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
-
-[[package]]
-name = "postcard"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
-dependencies = [
- "cobs",
- "embedded-io 0.4.0",
- "embedded-io 0.6.1",
- "heapless",
- "serde",
-]
 
 [[package]]
 name = "potential_utf"
@@ -1189,21 +1146,21 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
 ]
 
 [[package]]
 name = "rustc_version_runtime"
-version = "0.3.0"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
+checksum = "6de8ecd7fad7731f306f69b6e10ec5a3178c61e464dcc06979427aa4cc891145"
 dependencies = [
  "rustc_version",
- "semver",
+ "semver 0.9.0",
 ]
 
 [[package]]
@@ -1241,10 +1198,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
+name = "semver"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
 
 [[package]]
 name = "semver"
@@ -1254,6 +1214,12 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -1331,15 +1297,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "stable_deref_trait"
@@ -1543,7 +1500,7 @@ dependencies = [
  "regex",
  "regex-syntax",
  "rustc-hash",
- "semver",
+ "semver 1.0.26",
  "serde",
  "serde_json",
  "smallbitvec",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -17,7 +17,6 @@ dependencies = [
  "adze-ts-format-core",
  "ahash",
  "anyhow",
- "getrandom",
  "indexmap",
  "log",
  "once_cell",
@@ -31,8 +30,18 @@ dependencies = [
 name = "adze-bdd-governance-core"
 version = "0.1.0"
 dependencies = [
+ "adze-bdd-governance-reporting-core",
  "adze-bdd-grid-core",
  "adze-feature-policy-core",
+]
+
+[[package]]
+name = "adze-bdd-governance-reporting-core"
+version = "0.1.0"
+dependencies = [
+ "adze-bdd-grid-core",
+ "adze-feature-policy-core",
+ "adze-governance-status-core",
 ]
 
 [[package]]
@@ -45,12 +54,21 @@ dependencies = [
 [[package]]
 name = "adze-bdd-grid-core"
 version = "0.1.0"
+dependencies = [
+ "adze-bdd-scenario-core",
+]
+
+[[package]]
+name = "adze-bdd-scenario-core"
+version = "0.1.0"
 
 [[package]]
 name = "adze-common"
 version = "0.8.0-dev"
 dependencies = [
  "adze-common-syntax-core",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -92,6 +110,7 @@ dependencies = [
 name = "adze-concurrency-env-contract-core"
 version = "0.1.0"
 dependencies = [
+ "adze-concurrency-env-vars-core",
  "adze-concurrency-parse-core",
 ]
 
@@ -101,6 +120,10 @@ version = "0.1.0"
 dependencies = [
  "adze-concurrency-env-contract-core",
 ]
+
+[[package]]
+name = "adze-concurrency-env-vars-core"
+version = "0.1.0"
 
 [[package]]
 name = "adze-concurrency-init-bootstrap-core"
@@ -167,6 +190,7 @@ name = "adze-feature-policy-core"
 version = "0.1.0"
 dependencies = [
  "adze-parser-backend-core",
+ "adze-parser-feature-profile-core",
 ]
 
 [[package]]
@@ -207,7 +231,6 @@ dependencies = [
  "adze-ir",
  "fixedbitset",
  "indexmap",
- "postcard",
  "rustc-hash",
  "serde",
  "smallvec",
@@ -249,7 +272,15 @@ dependencies = [
 name = "adze-governance-runtime-core"
 version = "0.1.0"
 dependencies = [
+ "adze-governance-runtime-profile-core",
  "adze-governance-runtime-reporting",
+]
+
+[[package]]
+name = "adze-governance-runtime-profile-core"
+version = "0.1.0"
+dependencies = [
+ "adze-governance-matrix-contract",
 ]
 
 [[package]]
@@ -257,6 +288,14 @@ name = "adze-governance-runtime-reporting"
 version = "0.1.0"
 dependencies = [
  "adze-governance-matrix-contract",
+]
+
+[[package]]
+name = "adze-governance-status-core"
+version = "0.1.0"
+dependencies = [
+ "adze-bdd-grid-core",
+ "adze-feature-policy-core",
 ]
 
 [[package]]
@@ -287,6 +326,13 @@ dependencies = [
 [[package]]
 name = "adze-parser-backend-core"
 version = "0.1.0"
+
+[[package]]
+name = "adze-parser-feature-profile-core"
+version = "0.1.0"
+dependencies = [
+ "adze-parser-backend-core",
+]
 
 [[package]]
 name = "adze-parsetable-metadata"
@@ -359,7 +405,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -396,15 +441,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
-name = "atomic-polyfill"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
-dependencies = [
- "critical-section",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,12 +460,6 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "c2rust-bitfields"
@@ -476,17 +506,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "wasm-bindgen",
  "windows-link",
-]
-
-[[package]]
-name = "cobs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
-dependencies = [
- "thiserror",
 ]
 
 [[package]]
@@ -503,12 +526,6 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
@@ -562,18 +579,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "embedded-io"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
-
-[[package]]
-name = "embedded-io"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,20 +613,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi",
  "wasip2",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "hash32"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
@@ -629,20 +623,6 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
-name = "heapless"
-version = "0.7.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
-dependencies = [
- "atomic-polyfill",
- "hash32",
- "rustc_version",
- "serde",
- "spin",
- "stable_deref_trait",
-]
 
 [[package]]
 name = "iana-time-zone"
@@ -723,15 +703,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,19 +728,6 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "postcard"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
-dependencies = [
- "cobs",
- "embedded-io 0.4.0",
- "embedded-io 0.6.1",
- "heapless",
- "serde",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -852,18 +810,18 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver",
 ]
 
 [[package]]
 name = "rustc_version_runtime"
-version = "0.3.0"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
+checksum = "6de8ecd7fad7731f306f69b6e10ec5a3178c61e464dcc06979427aa4cc891145"
 dependencies = [
  "rustc_version",
  "semver",
@@ -876,16 +834,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
+name = "semver"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
 
 [[package]]
-name = "semver"
-version = "1.0.27"
+name = "semver-parser"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -953,21 +914,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "streaming-iterator"

--- a/glr-core/Cargo.toml
+++ b/glr-core/Cargo.toml
@@ -52,7 +52,7 @@ glr_telemetry = [] # Enable GLR telemetry (used by benchmarks)
 
 [dev-dependencies]
 insta = "1.0"
-criterion = "0.5"
+criterion.workspace = true
 dhat = "0.3"
 serde_json = "1.0"
 proptest = "1.4"

--- a/glr-core/benches/perf_snapshot.rs
+++ b/glr-core/benches/perf_snapshot.rs
@@ -1,4 +1,5 @@
-use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use std::hint::black_box;
 use std::time::Duration;
 
 use adze_glr_core::Driver;

--- a/ir/Cargo.toml
+++ b/ir/Cargo.toml
@@ -31,6 +31,6 @@ strict_docs = []
 insta = "1.0"
 proptest = "1.4"
 serde_json = "1.0"
-bincode = "1.3"
+postcard = { workspace = true }
 adze-glr-core = { version = "0.8.0-dev", path = "../glr-core" }
 indexmap = { version = "2.0", features = ["serde"] }

--- a/ir/tests/alias_sequence_proptest.rs
+++ b/ir/tests/alias_sequence_proptest.rs
@@ -84,8 +84,8 @@ proptest! {
     #[test]
     fn test_serde_bincode_roundtrip(aliases in alias_vec_strategy(15)) {
         let seq = AliasSequence { aliases };
-        let bytes = bincode::serialize(&seq).unwrap();
-        let deserialized: AliasSequence = bincode::deserialize(&bytes).unwrap();
+        let bytes = postcard::to_allocvec(&seq).unwrap();
+        let deserialized: AliasSequence = postcard::from_bytes(&bytes).unwrap();
         prop_assert_eq!(seq, deserialized);
     }
 

--- a/ir/tests/external_token_proptest.rs
+++ b/ir/tests/external_token_proptest.rs
@@ -741,8 +741,8 @@ proptest! {
 
     #[test]
     fn ext_bincode_roundtrip(et in arb_external_token()) {
-        let bytes = bincode::serialize(&et).unwrap();
-        let back: ExternalToken = bincode::deserialize(&bytes).unwrap();
+        let bytes = postcard::to_allocvec(&et).unwrap();
+        let back: ExternalToken = postcard::from_bytes(&bytes).unwrap();
         prop_assert_eq!(&back, &et);
     }
 

--- a/ir/tests/grammar_clone_serde_comprehensive.rs
+++ b/ir/tests/grammar_clone_serde_comprehensive.rs
@@ -93,8 +93,8 @@ fn grammar_serde_bincode_roundtrip() {
         .rule("s", vec!["x"])
         .start("s")
         .build();
-    let bytes = bincode::serialize(&g).unwrap();
-    let g2: adze_ir::Grammar = bincode::deserialize(&bytes).unwrap();
+    let bytes = postcard::to_allocvec(&g).unwrap();
+    let g2: adze_ir::Grammar = postcard::from_bytes(&bytes).unwrap();
     assert_eq!(g.name, g2.name);
 }
 

--- a/ir/tests/grammar_serde_proptest.rs
+++ b/ir/tests/grammar_serde_proptest.rs
@@ -221,8 +221,8 @@ fn bincode_roundtrip<
 >(
     val: &T,
 ) -> T {
-    let bytes = bincode::serialize(val).expect("bincode serialize");
-    let back: T = bincode::deserialize(&bytes).expect("bincode deserialize");
+    let bytes = postcard::to_allocvec(val).expect("bincode serialize");
+    let back: T = postcard::from_bytes(&bytes).expect("bincode deserialize");
     assert_eq!(val, &back, "bincode roundtrip mismatch");
     back
 }
@@ -367,8 +367,8 @@ proptest! {
     // -----------------------------------------------------------------------
     #[test]
     fn serialization_preserves_all_fields_bincode(g in arb_full_grammar()) {
-        let bytes = bincode::serialize(&g).unwrap();
-        let back: Grammar = bincode::deserialize(&bytes).unwrap();
+        let bytes = postcard::to_allocvec(&g).unwrap();
+        let back: Grammar = postcard::from_bytes(&bytes).unwrap();
         prop_assert_eq!(&g.name, &back.name);
         prop_assert_eq!(&g.rules, &back.rules);
         prop_assert_eq!(&g.tokens, &back.tokens);
@@ -408,7 +408,7 @@ proptest! {
     fn deserialization_error_corrupt_bincode(
         garbage in prop::collection::vec(any::<u8>(), 1..32),
     ) {
-        let result = bincode::deserialize::<Grammar>(&garbage);
+        let result = postcard::from_bytes::<Grammar>(&garbage);
         if result.is_ok() {
             let g = result.unwrap();
             let back = bincode_roundtrip(&g);
@@ -587,8 +587,8 @@ proptest! {
     // -----------------------------------------------------------------------
     #[test]
     fn bincode_deterministic_grammar(g in arb_full_grammar()) {
-        let bytes1 = bincode::serialize(&g).unwrap();
-        let bytes2 = bincode::serialize(&g).unwrap();
+        let bytes1 = postcard::to_allocvec(&g).unwrap();
+        let bytes2 = postcard::to_allocvec(&g).unwrap();
         prop_assert_eq!(bytes1, bytes2);
     }
 
@@ -600,8 +600,8 @@ proptest! {
         let from_json: Grammar = serde_json::from_str(
             &serde_json::to_string(&g).unwrap()
         ).unwrap();
-        let from_bincode: Grammar = bincode::deserialize(
-            &bincode::serialize(&g).unwrap()
+        let from_bincode: Grammar = postcard::from_bytes(
+            &postcard::to_allocvec(&g).unwrap()
         ).unwrap();
         prop_assert_eq!(&from_json, &from_bincode);
     }
@@ -640,10 +640,10 @@ proptest! {
     // -----------------------------------------------------------------------
     #[test]
     fn double_roundtrip_bincode(g in arb_full_grammar()) {
-        let bytes1 = bincode::serialize(&g).unwrap();
-        let back1: Grammar = bincode::deserialize(&bytes1).unwrap();
-        let bytes2 = bincode::serialize(&back1).unwrap();
-        let back2: Grammar = bincode::deserialize(&bytes2).unwrap();
+        let bytes1 = postcard::to_allocvec(&g).unwrap();
+        let back1: Grammar = postcard::from_bytes(&bytes1).unwrap();
+        let bytes2 = postcard::to_allocvec(&back1).unwrap();
+        let back2: Grammar = postcard::from_bytes(&bytes2).unwrap();
         prop_assert_eq!(&g, &back2);
         prop_assert_eq!(bytes1, bytes2);
     }
@@ -680,10 +680,10 @@ proptest! {
     // -----------------------------------------------------------------------
     #[test]
     fn truncated_bincode_fails(g in arb_full_grammar()) {
-        let bytes = bincode::serialize(&g).unwrap();
+        let bytes = postcard::to_allocvec(&g).unwrap();
         if bytes.len() > 1 {
             let truncated = &bytes[..bytes.len() / 2];
-            let result = bincode::deserialize::<Grammar>(truncated);
+            let result = postcard::from_bytes::<Grammar>(truncated);
             prop_assert!(result.is_err());
         }
     }
@@ -781,8 +781,8 @@ fn complex_builder_grammar_roundtrip() {
     let from_json: Grammar = serde_json::from_str(&json).unwrap();
     assert_eq!(g, from_json);
 
-    let bytes = bincode::serialize(&g).unwrap();
-    let from_bincode: Grammar = bincode::deserialize(&bytes).unwrap();
+    let bytes = postcard::to_allocvec(&g).unwrap();
+    let from_bincode: Grammar = postcard::from_bytes(&bytes).unwrap();
     assert_eq!(g, from_bincode);
     assert_eq!(from_json, from_bincode);
 }

--- a/ir/tests/precedence_assoc_proptest.rs
+++ b/ir/tests/precedence_assoc_proptest.rs
@@ -482,24 +482,24 @@ proptest! {
     // 41. Precedence bincode serde roundtrip
     #[test]
     fn precedence_bincode_roundtrip(p in arb_precedence()) {
-        let bytes = bincode::serialize(&p).unwrap();
-        let back: Precedence = bincode::deserialize(&bytes).unwrap();
+        let bytes = postcard::to_allocvec(&p).unwrap();
+        let back: Precedence = postcard::from_bytes(&bytes).unwrap();
         prop_assert_eq!(&p, &back);
     }
 
     // 42. Associativity bincode serde roundtrip
     #[test]
     fn associativity_bincode_roundtrip(a in arb_associativity()) {
-        let bytes = bincode::serialize(&a).unwrap();
-        let back: Associativity = bincode::deserialize(&bytes).unwrap();
+        let bytes = postcard::to_allocvec(&a).unwrap();
+        let back: Associativity = postcard::from_bytes(&bytes).unwrap();
         prop_assert_eq!(a, back);
     }
 
     // 43. PrecedenceKind bincode roundtrip
     #[test]
     fn prec_kind_bincode_roundtrip(pk in arb_precedence_kind()) {
-        let bytes = bincode::serialize(&pk).unwrap();
-        let back: PrecedenceKind = bincode::deserialize(&bytes).unwrap();
+        let bytes = postcard::to_allocvec(&pk).unwrap();
+        let back: PrecedenceKind = postcard::from_bytes(&bytes).unwrap();
         prop_assert_eq!(pk, back);
     }
 

--- a/ir/tests/production_ids_v2_comprehensive.rs
+++ b/ir/tests/production_ids_v2_comprehensive.rs
@@ -383,8 +383,8 @@ fn test_grammar_with_alias_data_serde_roundtrip() {
 #[test]
 fn test_production_id_bincode_roundtrip() {
     let id = ProductionId(255);
-    let encoded = bincode::serialize(&id).unwrap();
-    let decoded: ProductionId = bincode::deserialize(&encoded).unwrap();
+    let encoded = postcard::to_allocvec(&id).unwrap();
+    let decoded: ProductionId = postcard::from_bytes(&encoded).unwrap();
     assert_eq!(id, decoded);
 }
 

--- a/ir/tests/rule_proptest.rs
+++ b/ir/tests/rule_proptest.rs
@@ -167,8 +167,8 @@ proptest! {
 
     #[test]
     fn rule_bincode_roundtrip(rule in rule_strategy()) {
-        let bytes = bincode::serialize(&rule).unwrap();
-        let decoded: Rule = bincode::deserialize(&bytes).unwrap();
+        let bytes = postcard::to_allocvec(&rule).unwrap();
+        let decoded: Rule = postcard::from_bytes(&bytes).unwrap();
         prop_assert_eq!(&rule, &decoded);
     }
 

--- a/ir/tests/rule_structure_proptest.rs
+++ b/ir/tests/rule_structure_proptest.rs
@@ -296,8 +296,8 @@ proptest! {
 
     #[test]
     fn rule_bincode_roundtrip(rule in rule_strategy()) {
-        let bytes = bincode::serialize(&rule).unwrap();
-        let decoded: Rule = bincode::deserialize(&bytes).unwrap();
+        let bytes = postcard::to_allocvec(&rule).unwrap();
+        let decoded: Rule = postcard::from_bytes(&bytes).unwrap();
         prop_assert_eq!(&rule, &decoded);
     }
 

--- a/ir/tests/serde_roundtrip_comprehensive.rs
+++ b/ir/tests/serde_roundtrip_comprehensive.rs
@@ -39,11 +39,11 @@ fn assert_json_roundtrip(grammar: &Grammar, test_name: &str) {
 
 // Helper function to perform bincode roundtrip test
 fn assert_bincode_roundtrip(grammar: &Grammar, test_name: &str) {
-    let bytes = bincode::serialize(grammar)
+    let bytes = postcard::to_allocvec(grammar)
         .unwrap_or_else(|_| panic!("{}: failed to serialize with bincode", test_name));
-    let deserialized: Grammar = bincode::deserialize(&bytes)
+    let deserialized: Grammar = postcard::from_bytes(&bytes)
         .unwrap_or_else(|_| panic!("{}: failed to deserialize from bincode", test_name));
-    let roundtrip_bytes = bincode::serialize(&deserialized)
+    let roundtrip_bytes = postcard::to_allocvec(&deserialized)
         .unwrap_or_else(|_| panic!("{}: failed to re-serialize with bincode", test_name));
 
     assert_eq!(
@@ -537,8 +537,8 @@ fn test_symbol_epsilon_json_roundtrip() {
 #[test]
 fn test_symbol_epsilon_bincode_roundtrip() {
     let symbol = Symbol::Epsilon;
-    let bytes = bincode::serialize(&symbol).expect("serialize");
-    let deserialized: Symbol = bincode::deserialize(&bytes).expect("deserialize");
+    let bytes = postcard::to_allocvec(&symbol).expect("serialize");
+    let deserialized: Symbol = postcard::from_bytes(&bytes).expect("deserialize");
     assert_eq!(symbol, deserialized);
 }
 
@@ -566,8 +566,8 @@ fn test_external_token_bincode_roundtrip() {
         name: "DEDENT".to_string(),
         symbol_id: SymbolId(101),
     };
-    let bytes = bincode::serialize(&external).expect("serialize");
-    let deserialized: ExternalToken = bincode::deserialize(&bytes).expect("deserialize");
+    let bytes = postcard::to_allocvec(&external).expect("serialize");
+    let deserialized: ExternalToken = postcard::from_bytes(&bytes).expect("deserialize");
     assert_eq!(external, deserialized);
 }
 
@@ -675,8 +675,8 @@ fn test_symbol_id_json_roundtrip() {
 #[test]
 fn test_symbol_id_bincode_roundtrip() {
     let id = SymbolId(54321);
-    let bytes = bincode::serialize(&id).expect("serialize");
-    let deserialized: SymbolId = bincode::deserialize(&bytes).expect("deserialize");
+    let bytes = postcard::to_allocvec(&id).expect("serialize");
+    let deserialized: SymbolId = postcard::from_bytes(&bytes).expect("deserialize");
     assert_eq!(id, deserialized);
 }
 
@@ -951,16 +951,16 @@ fn test_precedence_kind_dynamic_json_roundtrip() {
 #[test]
 fn test_precedence_kind_static_bincode_roundtrip() {
     let kind = PrecedenceKind::Static(0);
-    let bytes = bincode::serialize(&kind).expect("serialize");
-    let deserialized: PrecedenceKind = bincode::deserialize(&bytes).expect("deserialize");
+    let bytes = postcard::to_allocvec(&kind).expect("serialize");
+    let deserialized: PrecedenceKind = postcard::from_bytes(&bytes).expect("deserialize");
     assert_eq!(kind, deserialized);
 }
 
 #[test]
 fn test_precedence_kind_dynamic_bincode_roundtrip() {
     let kind = PrecedenceKind::Dynamic(100);
-    let bytes = bincode::serialize(&kind).expect("serialize");
-    let deserialized: PrecedenceKind = bincode::deserialize(&bytes).expect("deserialize");
+    let bytes = postcard::to_allocvec(&kind).expect("serialize");
+    let deserialized: PrecedenceKind = postcard::from_bytes(&bytes).expect("deserialize");
     assert_eq!(kind, deserialized);
 }
 
@@ -997,8 +997,8 @@ fn test_associativity_all_variants_bincode_roundtrip() {
     ];
 
     for assoc in variants {
-        let bytes = bincode::serialize(&assoc).expect("serialize");
-        let deserialized: Associativity = bincode::deserialize(&bytes).expect("deserialize");
+        let bytes = postcard::to_allocvec(&assoc).expect("serialize");
+        let deserialized: Associativity = postcard::from_bytes(&bytes).expect("deserialize");
         assert_eq!(assoc, deserialized);
     }
 }
@@ -1014,9 +1014,9 @@ fn test_empty_grammar_comprehensive_roundtrip() {
     assert_eq!(json, json_roundtrip);
 
     // Bincode roundtrip
-    let bytes = bincode::serialize(&grammar).expect("serialize");
-    let from_bytes: Grammar = bincode::deserialize(&bytes).expect("deserialize");
-    let bytes_roundtrip = bincode::serialize(&from_bytes).expect("re-serialize");
+    let bytes = postcard::to_allocvec(&grammar).expect("serialize");
+    let from_bytes: Grammar = postcard::from_bytes(&bytes).expect("deserialize");
+    let bytes_roundtrip = postcard::to_allocvec(&from_bytes).expect("re-serialize");
     assert_eq!(bytes, bytes_roundtrip);
 }
 
@@ -1309,9 +1309,9 @@ fn test_all_symbol_types_bincode_roundtrip() {
     ];
 
     for (idx, symbol) in symbols.into_iter().enumerate() {
-        let bytes = bincode::serialize(&symbol).unwrap_or_else(|_| panic!("serialize {}", idx));
+        let bytes = postcard::to_allocvec(&symbol).unwrap_or_else(|_| panic!("serialize {}", idx));
         let deserialized: Symbol =
-            bincode::deserialize(&bytes).unwrap_or_else(|_| panic!("deserialize {}", idx));
+            postcard::from_bytes(&bytes).unwrap_or_else(|_| panic!("deserialize {}", idx));
         assert_eq!(symbol, deserialized, "Symbol roundtrip failed for {}", idx);
     }
 }
@@ -1432,8 +1432,8 @@ fn test_state_id_max_json_roundtrip() {
 #[test]
 fn test_state_id_bincode_roundtrip() {
     let id = StateId(1024);
-    let bytes = bincode::serialize(&id).expect("serialize");
-    let deserialized: StateId = bincode::deserialize(&bytes).expect("deserialize");
+    let bytes = postcard::to_allocvec(&id).expect("serialize");
+    let deserialized: StateId = postcard::from_bytes(&bytes).expect("deserialize");
     assert_eq!(id, deserialized);
 }
 

--- a/ir/tests/serde_roundtrip_proptest.rs
+++ b/ir/tests/serde_roundtrip_proptest.rs
@@ -181,8 +181,8 @@ fn assert_bincode_roundtrip<
 >(
     val: &T,
 ) -> T {
-    let bytes = bincode::serialize(val).expect("bincode serialize");
-    let back: T = bincode::deserialize(&bytes).expect("bincode deserialize");
+    let bytes = postcard::to_allocvec(val).expect("bincode serialize");
+    let back: T = postcard::from_bytes(&bytes).expect("bincode deserialize");
     assert_eq!(val, &back, "bincode roundtrip mismatch");
     back
 }
@@ -549,8 +549,8 @@ proptest! {
     // ---- Bincode determinism: same input produces same bytes ----
     #[test]
     fn bincode_deterministic_symbol(sym in arb_symbol()) {
-        let bytes1 = bincode::serialize(&sym).unwrap();
-        let bytes2 = bincode::serialize(&sym).unwrap();
+        let bytes1 = postcard::to_allocvec(&sym).unwrap();
+        let bytes2 = postcard::to_allocvec(&sym).unwrap();
         prop_assert_eq!(bytes1, bytes2);
     }
 
@@ -564,8 +564,8 @@ proptest! {
         for rule in rules {
             grammar.add_rule(rule);
         }
-        let bytes1 = bincode::serialize(&grammar).unwrap();
-        let bytes2 = bincode::serialize(&grammar).unwrap();
+        let bytes1 = postcard::to_allocvec(&grammar).unwrap();
+        let bytes2 = postcard::to_allocvec(&grammar).unwrap();
         prop_assert_eq!(bytes1, bytes2);
     }
 
@@ -575,8 +575,8 @@ proptest! {
         let from_json: Rule = serde_json::from_str(
             &serde_json::to_string(&rule).unwrap()
         ).unwrap();
-        let from_bincode: Rule = bincode::deserialize(
-            &bincode::serialize(&rule).unwrap()
+        let from_bincode: Rule = postcard::from_bytes(
+            &postcard::to_allocvec(&rule).unwrap()
         ).unwrap();
         prop_assert_eq!(&from_json, &from_bincode);
     }

--- a/ir/tests/serde_roundtrip_v2_comprehensive.rs
+++ b/ir/tests/serde_roundtrip_v2_comprehensive.rs
@@ -28,8 +28,8 @@ fn bincode_roundtrip<
 >(
     val: &T,
 ) {
-    let bytes = bincode::serialize(val).expect("bincode serialize");
-    let back: T = bincode::deserialize(&bytes).expect("bincode deserialize");
+    let bytes = postcard::to_allocvec(val).expect("bincode serialize");
+    let back: T = postcard::from_bytes(&bytes).expect("bincode deserialize");
     assert_eq!(*val, back);
 }
 
@@ -623,7 +623,7 @@ fn test_bincode_smaller_than_json() {
         .start("expr")
         .build();
     let json_len = serde_json::to_string(&g).unwrap().len();
-    let bin_len = bincode::serialize(&g).unwrap().len();
+    let bin_len = postcard::to_allocvec(&g).unwrap().len();
     assert!(
         bin_len < json_len,
         "bincode ({bin_len}) should be smaller than json ({json_len})"

--- a/ir/tests/serde_shapes_comprehensive.rs
+++ b/ir/tests/serde_shapes_comprehensive.rs
@@ -9,8 +9,8 @@ fn roundtrip_json(g: &Grammar) -> Grammar {
 }
 
 fn roundtrip_bincode(g: &Grammar) -> Grammar {
-    let bytes = bincode::serialize(g).unwrap();
-    bincode::deserialize(&bytes).unwrap()
+    let bytes = postcard::to_allocvec(g).unwrap();
+    postcard::from_bytes(&bytes).unwrap()
 }
 
 #[test]

--- a/ir/tests/symbol_metadata_proptest.rs
+++ b/ir/tests/symbol_metadata_proptest.rs
@@ -110,8 +110,8 @@ proptest! {
 proptest! {
     #[test]
     fn serde_bincode_roundtrip(meta in symbol_metadata_strategy()) {
-        let bytes = bincode::serialize(&meta).unwrap();
-        let restored: SymbolMetadata = bincode::deserialize(&bytes).unwrap();
+        let bytes = postcard::to_allocvec(&meta).unwrap();
+        let restored: SymbolMetadata = postcard::from_bytes(&bytes).unwrap();
         prop_assert_eq!(meta, restored);
     }
 }
@@ -559,8 +559,8 @@ proptest! {
         a in symbol_metadata_strategy(),
         b in symbol_metadata_strategy(),
     ) {
-        let bytes_a = bincode::serialize(&a).unwrap();
-        let bytes_b = bincode::serialize(&b).unwrap();
+        let bytes_a = postcard::to_allocvec(&a).unwrap();
+        let bytes_b = postcard::to_allocvec(&b).unwrap();
         prop_assert_eq!(bytes_a.len(), bytes_b.len());
     }
 }

--- a/repro-issue-74/Cargo.lock
+++ b/repro-issue-74/Cargo.lock
@@ -30,12 +30,29 @@ dependencies = [
 name = "adze-bdd-governance-core"
 version = "0.1.0"
 dependencies = [
+ "adze-bdd-governance-reporting-core",
  "adze-bdd-grid-core",
  "adze-feature-policy-core",
 ]
 
 [[package]]
+name = "adze-bdd-governance-reporting-core"
+version = "0.1.0"
+dependencies = [
+ "adze-bdd-grid-core",
+ "adze-feature-policy-core",
+ "adze-governance-status-core",
+]
+
+[[package]]
 name = "adze-bdd-grid-core"
+version = "0.1.0"
+dependencies = [
+ "adze-bdd-scenario-core",
+]
+
+[[package]]
+name = "adze-bdd-scenario-core"
 version = "0.1.0"
 
 [[package]]
@@ -86,6 +103,7 @@ dependencies = [
 name = "adze-concurrency-env-contract-core"
 version = "0.1.0"
 dependencies = [
+ "adze-concurrency-env-vars-core",
  "adze-concurrency-parse-core",
 ]
 
@@ -95,6 +113,10 @@ version = "0.1.0"
 dependencies = [
  "adze-concurrency-env-contract-core",
 ]
+
+[[package]]
+name = "adze-concurrency-env-vars-core"
+version = "0.1.0"
 
 [[package]]
 name = "adze-concurrency-init-bootstrap-core"
@@ -161,6 +183,7 @@ name = "adze-feature-policy-core"
 version = "0.1.0"
 dependencies = [
  "adze-parser-backend-core",
+ "adze-parser-feature-profile-core",
 ]
 
 [[package]]
@@ -211,7 +234,15 @@ dependencies = [
 name = "adze-governance-runtime-core"
 version = "0.1.0"
 dependencies = [
+ "adze-governance-runtime-profile-core",
  "adze-governance-runtime-reporting",
+]
+
+[[package]]
+name = "adze-governance-runtime-profile-core"
+version = "0.1.0"
+dependencies = [
+ "adze-governance-matrix-contract",
 ]
 
 [[package]]
@@ -219,6 +250,14 @@ name = "adze-governance-runtime-reporting"
 version = "0.1.0"
 dependencies = [
  "adze-governance-matrix-contract",
+]
+
+[[package]]
+name = "adze-governance-status-core"
+version = "0.1.0"
+dependencies = [
+ "adze-bdd-grid-core",
+ "adze-feature-policy-core",
 ]
 
 [[package]]
@@ -249,6 +288,13 @@ dependencies = [
 [[package]]
 name = "adze-parser-backend-core"
 version = "0.1.0"
+
+[[package]]
+name = "adze-parser-feature-profile-core"
+version = "0.1.0"
+dependencies = [
+ "adze-parser-backend-core",
+]
 
 [[package]]
 name = "adze-parsetable-metadata"
@@ -348,7 +394,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -684,18 +729,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasip2",
 ]
 
 [[package]]
@@ -1286,7 +1319,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -77,7 +77,7 @@ adze-stack-pool-core = { version = "0.1.0", path = "../crates/stack-pool-core" }
 [dev-dependencies]
 insta = "1.43.1"
 tempfile = "3.20.0"
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion.workspace = true
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.142"
 proptest = "1.4"

--- a/runtime/benches/glr_parser_bench.rs
+++ b/runtime/benches/glr_parser_bench.rs
@@ -2,7 +2,8 @@ use adze::glr_lexer::GLRLexer;
 use adze::glr_parser::GLRParser;
 use adze_glr_core::{FirstFollowSets, build_lr1_automaton};
 use adze_ir::{Grammar, ProductionId, Rule, Symbol, SymbolId, Token, TokenPattern};
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 /// Create a highly ambiguous arithmetic expression grammar
 fn create_ambiguous_grammar() -> Grammar {

--- a/runtime/benches/incremental_benchmark.rs
+++ b/runtime/benches/incremental_benchmark.rs
@@ -7,7 +7,8 @@ use adze::{
 };
 use adze_glr_core::{FirstFollowSets, build_lr1_automaton};
 use adze_ir::{Grammar, ProductionId, Rule, Symbol, SymbolId, Token, TokenPattern};
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 use std::sync::Arc;
 
 /// Create arithmetic expression grammar

--- a/runtime/benches/incremental_parsing.rs
+++ b/runtime/benches/incremental_parsing.rs
@@ -7,7 +7,8 @@ use adze::{
 };
 use adze_glr_core::{FirstFollowSets, build_lr1_automaton};
 use adze_ir::{Grammar, ProductionId, Rule, Symbol, SymbolId};
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 use std::sync::Arc;
 
 /// Create a simple repetition grammar for benchmarking

--- a/runtime/benches/incremental_simple.rs
+++ b/runtime/benches/incremental_simple.rs
@@ -7,7 +7,8 @@ use adze::{
 };
 use adze_glr_core::{FirstFollowSets, build_lr1_automaton};
 use adze_ir::{Grammar, ProductionId, Rule, Symbol, SymbolId};
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 use std::sync::Arc;
 
 /// Create a simple left-recursive repetition grammar

--- a/runtime/benches/parser_bench.rs
+++ b/runtime/benches/parser_bench.rs
@@ -5,7 +5,8 @@
 
 use adze::lexer::{ErrorRecoveringLexer, ErrorRecoveryMode, GrammarLexer};
 use adze::parser_v4::{ParserV4 as ParserV2, Token};
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 // use adze::incremental::{IncrementalParser, Edit, IncrementalTree};
 use adze_glr_core::{Action, ParseTable, SymbolMetadata};
 use adze_ir::{

--- a/runtime/benches/parser_benchmark.rs
+++ b/runtime/benches/parser_benchmark.rs
@@ -1,7 +1,8 @@
 #![cfg(feature = "unstable-benches")]
 
 use adze::tree_sitter::Parser;
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 // Simple arithmetic grammar for benchmarking
 #[adze::grammar("benchmark")]

--- a/runtime/benches/perf_benchmark.rs
+++ b/runtime/benches/perf_benchmark.rs
@@ -4,7 +4,7 @@
 #![cfg(feature = "unstable-benches")]
 
 /*
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use adze::lexer::GrammarLexer;
 use adze::parallel_parser::{ParallelConfig, ParallelParser};
 use adze::parser_v3::Parser;
@@ -14,7 +14,8 @@ use adze::simd_lexer::SimdLexer;
 use adze::lexer::GrammarLexer;
 use adze_glr_core::{Action, ParseTable};
 use adze_ir::{Grammar, Rule, SymbolId, TokenPattern};
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 use std::time::Duration;
 
 /// Create a test grammar for benchmarking

--- a/runtime/benches/runtime_parse_serialize_bench.rs
+++ b/runtime/benches/runtime_parse_serialize_bench.rs
@@ -17,7 +17,8 @@ use adze::glr_tree_bridge::{GLRTree, subtree_to_tree};
 use adze::subtree::Subtree;
 use adze_glr_core::{FirstFollowSets, build_lr1_automaton};
 use adze_ir::{Grammar, ProductionId, Rule, Symbol, SymbolId, Token, TokenPattern};
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 // ---------------------------------------------------------------------------
 // Grammar helpers

--- a/runtime/benches/simple_bench.rs
+++ b/runtime/benches/simple_bench.rs
@@ -3,7 +3,8 @@
 
 use adze::lexer::{self, GrammarLexer};
 use adze_ir::{SymbolId, TokenPattern};
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 fn configured_lexer(
     token_patterns: &[(SymbolId, TokenPattern, i32)],

--- a/runtime/fuzz/Cargo.lock
+++ b/runtime/fuzz/Cargo.lock
@@ -17,7 +17,6 @@ dependencies = [
  "adze-ts-format-core",
  "ahash",
  "anyhow",
- "getrandom",
  "indexmap",
  "log",
  "once_cell",
@@ -31,12 +30,29 @@ dependencies = [
 name = "adze-bdd-governance-core"
 version = "0.1.0"
 dependencies = [
+ "adze-bdd-governance-reporting-core",
  "adze-bdd-grid-core",
  "adze-feature-policy-core",
 ]
 
 [[package]]
+name = "adze-bdd-governance-reporting-core"
+version = "0.1.0"
+dependencies = [
+ "adze-bdd-grid-core",
+ "adze-feature-policy-core",
+ "adze-governance-status-core",
+]
+
+[[package]]
 name = "adze-bdd-grid-core"
+version = "0.1.0"
+dependencies = [
+ "adze-bdd-scenario-core",
+]
+
+[[package]]
+name = "adze-bdd-scenario-core"
 version = "0.1.0"
 
 [[package]]
@@ -44,6 +60,8 @@ name = "adze-common"
 version = "0.8.0-dev"
 dependencies = [
  "adze-common-syntax-core",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -85,6 +103,7 @@ dependencies = [
 name = "adze-concurrency-env-contract-core"
 version = "0.1.0"
 dependencies = [
+ "adze-concurrency-env-vars-core",
  "adze-concurrency-parse-core",
 ]
 
@@ -94,6 +113,10 @@ version = "0.1.0"
 dependencies = [
  "adze-concurrency-env-contract-core",
 ]
+
+[[package]]
+name = "adze-concurrency-env-vars-core"
+version = "0.1.0"
 
 [[package]]
 name = "adze-concurrency-init-bootstrap-core"
@@ -160,6 +183,7 @@ name = "adze-feature-policy-core"
 version = "0.1.0"
 dependencies = [
  "adze-parser-backend-core",
+ "adze-parser-feature-profile-core",
 ]
 
 [[package]]
@@ -181,7 +205,6 @@ dependencies = [
  "adze-ir",
  "fixedbitset",
  "indexmap",
- "postcard",
  "rustc-hash",
  "serde",
  "smallvec",
@@ -223,7 +246,15 @@ dependencies = [
 name = "adze-governance-runtime-core"
 version = "0.1.0"
 dependencies = [
+ "adze-governance-runtime-profile-core",
  "adze-governance-runtime-reporting",
+]
+
+[[package]]
+name = "adze-governance-runtime-profile-core"
+version = "0.1.0"
+dependencies = [
+ "adze-governance-matrix-contract",
 ]
 
 [[package]]
@@ -231,6 +262,14 @@ name = "adze-governance-runtime-reporting"
 version = "0.1.0"
 dependencies = [
  "adze-governance-matrix-contract",
+]
+
+[[package]]
+name = "adze-governance-status-core"
+version = "0.1.0"
+dependencies = [
+ "adze-bdd-grid-core",
+ "adze-feature-policy-core",
 ]
 
 [[package]]
@@ -261,6 +300,13 @@ dependencies = [
 [[package]]
 name = "adze-parser-backend-core"
 version = "0.1.0"
+
+[[package]]
+name = "adze-parser-feature-profile-core"
+version = "0.1.0"
+dependencies = [
+ "adze-parser-backend-core",
+]
 
 [[package]]
 name = "adze-parsetable-metadata"
@@ -333,7 +379,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -373,15 +418,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-polyfill"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
-dependencies = [
- "critical-section",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,12 +437,6 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "c2rust-bitfields"
@@ -452,17 +482,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "wasm-bindgen",
  "windows-link",
-]
-
-[[package]]
-name = "cobs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
-dependencies = [
- "thiserror",
 ]
 
 [[package]]
@@ -479,12 +502,6 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
@@ -549,18 +566,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "embedded-io"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
-
-[[package]]
-name = "embedded-io"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,20 +594,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi",
  "wasip2",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "hash32"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
@@ -610,20 +604,6 @@ name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
-
-[[package]]
-name = "heapless"
-version = "0.7.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
-dependencies = [
- "atomic-polyfill",
- "hash32",
- "rustc_version",
- "serde",
- "spin",
- "stable_deref_trait",
-]
 
 [[package]]
 name = "iana-time-zone"
@@ -709,15 +689,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -743,19 +714,6 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "postcard"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
-dependencies = [
- "cobs",
- "embedded-io 0.4.0",
- "embedded-io 0.6.1",
- "heapless",
- "serde",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -838,18 +796,18 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver",
 ]
 
 [[package]]
 name = "rustc_version_runtime"
-version = "0.3.0"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
+checksum = "6de8ecd7fad7731f306f69b6e10ec5a3178c61e464dcc06979427aa4cc891145"
 dependencies = [
  "rustc_version",
  "semver",
@@ -868,16 +826,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
+name = "semver"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
 
 [[package]]
-name = "semver"
-version = "1.0.27"
+name = "semver-parser"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -934,21 +895,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "streaming-iterator"

--- a/tablegen/Cargo.toml
+++ b/tablegen/Cargo.toml
@@ -41,7 +41,7 @@ tree-sitter-c2rust = { version = "0.25.2", optional = true }
 proptest = "1.5"
 insta = "1.40"
 rustc-hash = "2.1"
-criterion = "0.5"
+criterion.workspace = true
 syn = { version = "2", features = ["full", "parsing"] }
 adze-bdd-grid-core = { version = "0.1.0", path = "../crates/bdd-grid-core" }
 adze-glr-core = { version = "0.8.0-dev", path = "../glr-core" }

--- a/test-example/Cargo.lock
+++ b/test-example/Cargo.lock
@@ -31,12 +31,29 @@ dependencies = [
 name = "adze-bdd-governance-core"
 version = "0.1.0"
 dependencies = [
+ "adze-bdd-governance-reporting-core",
  "adze-bdd-grid-core",
  "adze-feature-policy-core",
 ]
 
 [[package]]
+name = "adze-bdd-governance-reporting-core"
+version = "0.1.0"
+dependencies = [
+ "adze-bdd-grid-core",
+ "adze-feature-policy-core",
+ "adze-governance-status-core",
+]
+
+[[package]]
 name = "adze-bdd-grid-core"
+version = "0.1.0"
+dependencies = [
+ "adze-bdd-scenario-core",
+]
+
+[[package]]
+name = "adze-bdd-scenario-core"
 version = "0.1.0"
 
 [[package]]
@@ -87,6 +104,7 @@ dependencies = [
 name = "adze-concurrency-env-contract-core"
 version = "0.1.0"
 dependencies = [
+ "adze-concurrency-env-vars-core",
  "adze-concurrency-parse-core",
 ]
 
@@ -96,6 +114,10 @@ version = "0.1.0"
 dependencies = [
  "adze-concurrency-env-contract-core",
 ]
+
+[[package]]
+name = "adze-concurrency-env-vars-core"
+version = "0.1.0"
 
 [[package]]
 name = "adze-concurrency-init-bootstrap-core"
@@ -162,6 +184,7 @@ name = "adze-feature-policy-core"
 version = "0.1.0"
 dependencies = [
  "adze-parser-backend-core",
+ "adze-parser-feature-profile-core",
 ]
 
 [[package]]
@@ -212,7 +235,15 @@ dependencies = [
 name = "adze-governance-runtime-core"
 version = "0.1.0"
 dependencies = [
+ "adze-governance-runtime-profile-core",
  "adze-governance-runtime-reporting",
+]
+
+[[package]]
+name = "adze-governance-runtime-profile-core"
+version = "0.1.0"
+dependencies = [
+ "adze-governance-matrix-contract",
 ]
 
 [[package]]
@@ -220,6 +251,14 @@ name = "adze-governance-runtime-reporting"
 version = "0.1.0"
 dependencies = [
  "adze-governance-matrix-contract",
+]
+
+[[package]]
+name = "adze-governance-status-core"
+version = "0.1.0"
+dependencies = [
+ "adze-bdd-grid-core",
+ "adze-feature-policy-core",
 ]
 
 [[package]]
@@ -250,6 +289,13 @@ dependencies = [
 [[package]]
 name = "adze-parser-backend-core"
 version = "0.1.0"
+
+[[package]]
+name = "adze-parser-feature-profile-core"
+version = "0.1.0"
+dependencies = [
+ "adze-parser-backend-core",
+]
 
 [[package]]
 name = "adze-parsetable-metadata"
@@ -349,7 +395,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",


### PR DESCRIPTION
### Motivation
- Modernize stale benchmark tooling by consolidating the workspace `criterion` pin and removing an old `bincode` test dependency used only for dev/tests. 
- Replace `criterion::black_box` usage with the stable `std::hint::black_box` to avoid depending on Criterion for a language primitive. 
- Keep changes conservative and limited to dependency/ test hygiene without changing runtime binary formats or benchmark semantics. 

### Description
- Upgraded the workspace `criterion` to `0.8.2` and retained the `html_reports` feature by changing the single resolved workspace line to `criterion = { version = "0.8.2", features = ["html_reports"] }` in `Cargo.toml`.
- Normalized crate-local Criterion dev-dependencies that targeted `0.5` to use the workspace reference (e.g. `criterion.workspace = true`) in `runtime`, `glr-core`, and `tablegen` manifests.
- Replaced imports/usages of `criterion::black_box` with `use std::hint::black_box;` across benchmark files so benches no longer pull `black_box` from Criterion.
- Removed `bincode = "1.3"` from workspace and `adze-ir` dev-dependencies and migrated `adze-ir` test code to use `postcard` (`to_allocvec` / `from_bytes`) for binary roundtrip tests, and added `postcard` as a workspace dev dependency for shared test tooling.

### Testing
- Ran `cargo metadata --format-version 1` to refresh the resolver and verify dependency updates, which resolved `criterion` to `0.8.2` successfully. (Succeeded)
- Ran `cargo tree -i criterion` and confirmed workspace now resolves to `criterion v0.8.2`. (Succeeded)
- Ran `cargo tree -i bincode` and observed no matching package in the resolved workspace graph (i.e. `bincode` no longer appears as an active dependency). (Succeeded)
- Built bench artifacts (`cargo bench --no-run`) for the core benches to validate Criterion upgrade and benchmark code edits: `adze-benchmarks`, `adze-glr-core`, and `adze-tablegen` were built as expected. (Succeeded)
- Executed `cargo test -p adze-ir serde -- --nocapture` to validate the migrated serialization tests in `adze-ir` and observed the test suite run and pass. (Succeeded)
- Ran `cargo fmt --all --check` to verify formatting; no formatting issues. (Succeeded)

Notes: this PR is dependency/API hygiene only — it does not change parse-table on-disk formats or benchmark semantics beyond importing `std::hint::black_box` and switching test-only serialization from `bincode` to `postcard`. The final workspace Criterion version is `0.8.2` and `bincode` no longer appears in the resolved dependency graph; test binary-serialization needs are now served by `postcard` (documented in the manifests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a8854c48333b4f7dce159238259)