### PR TITLE
Enforce valid_symbols contract in external scanner dispatch

### DIFF
--- a/glr-core/src/ts_lexer.rs
+++ b/glr-core/src/ts_lexer.rs
@@ -232,4 +232,14 @@ mod tests {
         //     assert_eq!(token.unwrap().kind, 1); // { token
         // }
     }
+
+    #[test]
+    #[ignore = "external scanner plumbing missing: GrammarLexer::next currently does not dispatch external scanners with valid_symbols"]
+    fn contract_external_scanner_must_respect_valid_symbols() {
+        // Contract marker test:
+        // once GrammarLexer::next dispatches language.external_scanner.scan,
+        // this test should assert that a scanner-emitted token is rejected
+        // whenever its valid_symbols entry is false for the current state.
+        panic!("not yet implemented");
+    }
 }

--- a/runtime/src/external_scanner.rs
+++ b/runtime/src/external_scanner.rs
@@ -132,6 +132,22 @@ impl ExternalScannerRuntime {
 
         // Scan for external tokens
         if let Some(result) = scanner.scan(lexer, &valid_symbols) {
+            // Enforce Tree-sitter contract: external scanners may only emit symbols
+            // that are valid in the current parser state.
+            let emitted_index = usize::from(result.symbol);
+            let emitted_by_index =
+                emitted_index < valid_symbols.len() && valid_symbols[emitted_index];
+            let emitted_by_symbol_id = self
+                .external_tokens
+                .iter()
+                .enumerate()
+                .find_map(|(idx, token)| (*token == result.symbol).then_some(idx))
+                .is_some_and(|idx| valid_symbols.get(idx) == Some(&true));
+
+            if !emitted_by_index && !emitted_by_symbol_id {
+                return None;
+            }
+
             // Serialize updated state
             self.state.data.clear();
             scanner.serialize(&mut self.state.data);
@@ -567,5 +583,55 @@ mod tests {
 
         assert!(new_scanner.in_string);
         assert_eq!(new_scanner.quote_char, Some(b'\''));
+    }
+
+    #[test]
+    fn test_runtime_rejects_emitted_symbol_not_valid_for_state() {
+        #[derive(Default)]
+        struct InvalidScanner;
+
+        impl ExternalScanner for InvalidScanner {
+            fn scan(
+                &mut self,
+                _lexer: &mut dyn Lexer,
+                _valid_symbols: &[bool],
+            ) -> Option<ScanResult> {
+                // Emit symbol index 1, even if caller only allows index 0.
+                Some(ScanResult {
+                    symbol: 1,
+                    length: 0,
+                })
+            }
+
+            fn serialize(&self, _buffer: &mut Vec<u8>) {}
+
+            fn deserialize(&mut self, _buffer: &[u8]) {}
+        }
+
+        struct EmptyLexer;
+        impl Lexer for EmptyLexer {
+            fn lookahead(&self) -> Option<u8> {
+                None
+            }
+            fn advance(&mut self, _n: usize) {}
+            fn mark_end(&mut self) {}
+            fn column(&self) -> usize {
+                0
+            }
+            fn is_eof(&self) -> bool {
+                true
+            }
+        }
+
+        let mut runtime = ExternalScannerRuntime::new(vec![SymbolId(0), SymbolId(1)]);
+        let mut scanner = InvalidScanner;
+        let mut lexer = EmptyLexer;
+        let valid_external_tokens = std::iter::once(SymbolId(0)).collect();
+
+        let scanned = runtime.scan(&mut scanner, &mut lexer, &valid_external_tokens);
+        assert!(
+            scanned.is_none(),
+            "scanner emission must be filtered by valid_symbols",
+        );
     }
 }

--- a/runtime/src/parser.rs
+++ b/runtime/src/parser.rs
@@ -439,6 +439,11 @@ impl Parser {
             }
 
             if success && lexer.result_symbol > 0 {
+                let emitted_index = lexer.result_symbol as usize;
+                if emitted_index >= valid_symbols.len() || !valid_symbols[emitted_index] {
+                    return None;
+                }
+
                 // Map external symbol to actual symbol
                 let symbol = if !lang.external_scanner.symbol_map.is_null() {
                     *lang

--- a/runtime/src/parser_v4.rs
+++ b/runtime/src/parser_v4.rs
@@ -1209,6 +1209,10 @@ impl Parser {
         self.external_scanner = Some(scanner);
 
         if let Some(result) = scan_result {
+            if !valid_externals.contains(&SymbolId(result.symbol)) {
+                return Ok(None);
+            }
+
             // Extract token text
             let end = self.position + result.length;
             let text = if end <= self.input.len() {
@@ -1818,6 +1822,84 @@ mod tests {
         assert_eq!(scanned.end, 2);
         // Text is empty because position advanced past input during scan
         assert!(scanned.text.is_empty());
+    }
+
+    #[derive(Default)]
+    struct InvalidEmittingScanner;
+
+    impl crate::external_scanner::ExternalScanner for InvalidEmittingScanner {
+        fn scan(
+            &mut self,
+            _lexer: &mut dyn crate::external_scanner::Lexer,
+            _valid_symbols: &[bool],
+        ) -> Option<crate::external_scanner::ScanResult> {
+            // Always emits token id 1, even when parser state only allows token id 0.
+            Some(crate::external_scanner::ScanResult {
+                symbol: 1,
+                length: 0,
+            })
+        }
+
+        fn serialize(&self, _buffer: &mut Vec<u8>) {}
+
+        fn deserialize(&mut self, _buffer: &[u8]) {}
+    }
+
+    #[test]
+    fn test_external_scanner_rejects_token_not_in_valid_symbols() {
+        let language_name = "test_parser_external_scanner_valid_symbols_contract".to_string();
+        ExternalScannerBuilder::new(language_name.clone())
+            .register_rust::<InvalidEmittingScanner>();
+
+        let mut grammar = Grammar::new(language_name.clone());
+        grammar.externals.push(adze_ir::ExternalToken {
+            name: "NEWLINE".to_string(),
+            symbol_id: SymbolId(0),
+        });
+        grammar.externals.push(adze_ir::ExternalToken {
+            name: "INDENT".to_string(),
+            symbol_id: SymbolId(1),
+        });
+
+        let parse_table = ParseTable {
+            action_table: vec![],
+            goto_table: vec![],
+            symbol_metadata: vec![],
+            state_count: 0,
+            symbol_count: 0,
+            symbol_to_index: std::collections::BTreeMap::new(),
+            index_to_symbol: vec![],
+            // Only NEWLINE is valid in this state.
+            external_scanner_states: vec![vec![true, false]],
+            rules: vec![],
+            nonterminal_to_index: std::collections::BTreeMap::new(),
+            goto_indexing: adze_glr_core::GotoIndexing::NonterminalMap,
+            eof_symbol: SymbolId(0),
+            start_symbol: SymbolId(1),
+            grammar: Grammar::default(),
+            initial_state: StateId(0),
+            token_count: 0,
+            external_token_count: 0,
+            lex_modes: vec![],
+            extras: vec![],
+            dynamic_prec_by_rule: vec![],
+            rule_assoc_by_rule: vec![],
+            alias_sequences: vec![],
+            field_names: vec![],
+            field_map: std::collections::BTreeMap::new(),
+        };
+
+        let mut parser = Parser::new(grammar, parse_table, language_name);
+        parser.input = b"\n".to_vec();
+        parser.position = 0;
+
+        let scanned = parser
+            .try_external_scanner(StateId(0))
+            .expect("external scanner dispatch should be available");
+        assert!(
+            scanned.is_none(),
+            "scanner emitted token that is false in valid_symbols and must be rejected",
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- External scanners were able to emit tokens that were not allowed by the current parser state (`valid_symbols`), which can break parsing or recovery (notably for indentation-like scanners such as Python). 
- The change is scoped to scanner dispatch and tests; Python indentation algorithm improvements are intentionally out of scope.

### Description

- Reject scanner emissions at the runtime layer by validating the returned `ScanResult.symbol` against the `valid_symbols` slice in `ExternalScannerRuntime::scan` (supports both index-style and symbol-id-style external token representations). 
- Harden Tree-sitter FFI dispatch in `runtime/src/parser.rs` to drop any `lexer.result_symbol` that is not allowed by the `valid_symbols` array before mapping/acceptance. 
- Harden parser-v4 path in `runtime/src/parser_v4.rs` to reject scanner results whose `result.symbol` is not present in the computed valid externals set. 
- Add focused regression/unit tests: `test_runtime_rejects_emitted_symbol_not_valid_for_state` (runtime) and `test_external_scanner_rejects_token_not_in_valid_symbols` (parser-v4) that exercise the contract where two externals exist but only one is valid and the scanner incorrectly emits the other. 
- Add an ignored contract-marker test in `glr-core/src/ts_lexer.rs` documenting that `GrammarLexer::next` currently does not dispatch external scanners with `valid_symbols` and thus requires additional plumbing to test the FFI lexer path.

### Testing

- Ran `cargo fmt --all --check`, which succeeded. 
- Added unit tests: `runtime::test_runtime_rejects_emitted_symbol_not_valid_for_state` and `parser_v4::test_external_scanner_rejects_token_not_in_valid_symbols` (both assert that invalid scanner emissions are rejected). 
- Attempted `cargo test -p adze --features external_scanners external -- --nocapture` and `cargo test -p adze-python-simple --no-run` in this environment, but the full workspace compilation was long-running/blocked and did not complete here; the code and tests are intentionally minimal and focused so CI should run them to completion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a640f5483339efb551ce79dc705)