### PR TITLE
Preserve field IDs during runtime node conversion and pure-rust reductions

### DIFF
--- a/runtime/src/__private.rs
+++ b/runtime/src/__private.rs
@@ -460,6 +460,25 @@ fn convert_parse_node_v4_to_pure(
     lang: &crate::pure_parser::TSLanguage,
     source: &[u8],
 ) -> crate::pure_parser::ParsedNode {
+    let resolve_field_id = |field_name: &str| -> Option<u16> {
+        if lang.field_count == 0 || lang.field_names.is_null() {
+            return None;
+        }
+        // SAFETY: `field_names` points to a static array of `field_count` pointers.
+        let field_names =
+            unsafe { std::slice::from_raw_parts(lang.field_names, lang.field_count as usize) };
+        field_names.iter().enumerate().find_map(|(idx, name_ptr)| {
+            if name_ptr.is_null() {
+                return None;
+            }
+            // SAFETY: name_ptr is validated non-null and points to NUL-terminated static bytes.
+            let raw = unsafe { std::ffi::CStr::from_ptr(*name_ptr as *const i8) };
+            let Ok(name) = raw.to_str() else {
+                return None;
+            };
+            (name == field_name).then_some(idx as u16)
+        })
+    };
     let is_error_symbol = |symbol: u16| {
         if symbol as u32 >= lang.symbol_count || lang.symbol_names.is_null() {
             return false;
@@ -520,7 +539,7 @@ fn convert_parse_node_v4_to_pure(
         is_error: is_error_symbol(node.symbol.0) || is_empty_error_node,
         is_missing: false,
         is_named,
-        field_id: None, // TODO: Convert field_name to field_id using language field_names
+        field_id: node.field_name.as_deref().and_then(resolve_field_id),
         language: Some(lang as *const _),
     }
 }
@@ -853,5 +872,79 @@ mod tests {
         assert_eq!(byte_to_point(source, 4), Point { row: 1, column: 1 });
         assert_eq!(byte_to_point(source, 7), Point { row: 2, column: 0 });
         assert_eq!(byte_to_point(source, 99), Point { row: 2, column: 1 });
+    }
+
+    #[test]
+    #[cfg(feature = "glr")]
+    fn given_parse_node_with_known_field_name_when_converting_then_field_id_is_preserved() {
+        let parse_node = crate::parser_v4::ParseNode {
+            symbol: adze_ir::SymbolId(1),
+            symbol_id: adze_ir::SymbolId(1),
+            start_byte: 0,
+            end_byte: 1,
+            field_name: Some("name".to_string()),
+            children: vec![],
+        };
+
+        let converted = convert_parse_node_v4_to_pure(&parse_node, &FIELD_LANGUAGE, b"x");
+        assert_eq!(converted.field_id, Some(1));
+    }
+
+    #[test]
+    #[cfg(feature = "glr")]
+    fn given_nested_parse_nodes_with_field_names_when_converting_then_nested_field_ids_are_preserved()
+     {
+        let parse_node = crate::parser_v4::ParseNode {
+            symbol: adze_ir::SymbolId(1),
+            symbol_id: adze_ir::SymbolId(1),
+            start_byte: 0,
+            end_byte: 2,
+            field_name: None,
+            children: vec![crate::parser_v4::ParseNode {
+                symbol: adze_ir::SymbolId(2),
+                symbol_id: adze_ir::SymbolId(2),
+                start_byte: 0,
+                end_byte: 2,
+                field_name: Some("value".to_string()),
+                children: vec![crate::parser_v4::ParseNode {
+                    symbol: adze_ir::SymbolId(3),
+                    symbol_id: adze_ir::SymbolId(3),
+                    start_byte: 0,
+                    end_byte: 1,
+                    field_name: Some("name".to_string()),
+                    children: vec![],
+                }],
+            }],
+        };
+
+        let converted = convert_parse_node_v4_to_pure(&parse_node, &FIELD_LANGUAGE, b"xy");
+        assert_eq!(converted.children[0].field_id, Some(0));
+        assert_eq!(converted.children[0].children[0].field_id, Some(1));
+    }
+
+    #[test]
+    #[cfg(feature = "glr")]
+    fn given_parse_node_with_missing_or_unknown_field_when_converting_then_field_id_is_none() {
+        let absent = crate::parser_v4::ParseNode {
+            symbol: adze_ir::SymbolId(1),
+            symbol_id: adze_ir::SymbolId(1),
+            start_byte: 0,
+            end_byte: 1,
+            field_name: None,
+            children: vec![],
+        };
+        let unknown = crate::parser_v4::ParseNode {
+            symbol: adze_ir::SymbolId(1),
+            symbol_id: adze_ir::SymbolId(1),
+            start_byte: 0,
+            end_byte: 1,
+            field_name: Some("does_not_exist".to_string()),
+            children: vec![],
+        };
+
+        let converted_absent = convert_parse_node_v4_to_pure(&absent, &FIELD_LANGUAGE, b"x");
+        let converted_unknown = convert_parse_node_v4_to_pure(&unknown, &FIELD_LANGUAGE, b"x");
+        assert_eq!(converted_absent.field_id, None);
+        assert_eq!(converted_unknown.field_id, None);
     }
 }

--- a/runtime/src/pure_parser.rs
+++ b/runtime/src/pure_parser.rs
@@ -1449,6 +1449,7 @@ impl Parser {
 
             // Reverse children to correct order
             children.reverse();
+            self.assign_field_ids_for_production(language, production_id, &mut children);
 
             // Handle empty reduction
             if children.is_empty() && child_count == 0 {
@@ -1559,6 +1560,57 @@ impl Parser {
                 // symbol >= language.token_count as u16
                 // );
                 false
+            }
+        }
+    }
+
+    fn assign_field_ids_for_production(
+        &self,
+        language: &TSLanguage,
+        production_id: u16,
+        children: &mut [Subtree],
+    ) {
+        if children.is_empty()
+            || language.field_count == 0
+            || language.field_map_slices.is_null()
+            || language.field_map_entries.is_null()
+        {
+            return;
+        }
+
+        let slices_len = language.production_id_count as usize * 2;
+        // SAFETY: `field_map_slices` is non-null and points to static language data.
+        let field_map_slices =
+            unsafe { std::slice::from_raw_parts(language.field_map_slices, slices_len) };
+        let slice_offset = production_id as usize * 2;
+        if slice_offset + 1 >= field_map_slices.len() {
+            return;
+        }
+
+        let slice_start = field_map_slices[slice_offset] as usize;
+        let slice_length = field_map_slices[slice_offset + 1] as usize;
+        if slice_length == 0 {
+            return;
+        }
+
+        let entries_len = (slice_start + slice_length) * 2;
+        // SAFETY: `field_map_entries` is non-null and points to static language data.
+        let field_map_entries =
+            unsafe { std::slice::from_raw_parts(language.field_map_entries, entries_len) };
+
+        for idx in 0..slice_length {
+            let entry_offset = (slice_start + idx) * 2;
+            if entry_offset + 1 >= field_map_entries.len() {
+                break;
+            }
+
+            let packed_entry = ((field_map_entries[entry_offset + 1] as u32) << 16)
+                | (field_map_entries[entry_offset] as u32);
+            let field_id = (packed_entry & 0xFFFF) as u16;
+            let child_index = ((packed_entry >> 16) & 0xFF) as usize;
+
+            if child_index < children.len() && field_id < language.field_count as u16 {
+                children[child_index].field_id = Some(field_id);
             }
         }
     }
@@ -2069,6 +2121,11 @@ fn create_ts_lexer(ext_lexer: &mut ExternalLexer) -> crate::lex::TsLexer {
 mod tests {
     use super::*;
 
+    fn pack_field_map_entry(field_id: u16, child_index: u8, inherited: u8) -> [u16; 2] {
+        let packed = (field_id as u32) | ((child_index as u32) << 16) | ((inherited as u32) << 24);
+        [packed as u16, (packed >> 16) as u16]
+    }
+
     #[test]
     fn test_parser_creation() {
         let parser = Parser::new();
@@ -2244,5 +2301,87 @@ mod tests {
         assert!(!unsafe { ExternalLexer::eof(&mut ts) });
         unsafe { ExternalLexer::advance(&mut ts, true) };
         assert!(unsafe { ExternalLexer::eof(&mut ts) });
+    }
+
+    #[test]
+    fn test_assign_field_ids_for_production_preserves_named_fields() {
+        let entry_first = pack_field_map_entry(1, 0, 0);
+        let entry_second = pack_field_map_entry(2, 1, 0);
+        let field_map_entries = [
+            entry_first[0],
+            entry_first[1],
+            entry_second[0],
+            entry_second[1],
+        ];
+        // production 0 -> empty; production 1 -> two entries from offset 0
+        let field_map_slices = [0u16, 0u16, 0u16, 2u16];
+        let language = TSLanguage {
+            version: TREE_SITTER_LANGUAGE_VERSION,
+            symbol_count: 2,
+            alias_count: 0,
+            token_count: 1,
+            external_token_count: 0,
+            state_count: 1,
+            large_state_count: 1,
+            production_id_count: 2,
+            field_count: 3,
+            max_alias_sequence_length: 0,
+            production_id_map: std::ptr::null(),
+            parse_table: std::ptr::null(),
+            small_parse_table: std::ptr::null(),
+            small_parse_table_map: std::ptr::null(),
+            parse_actions: std::ptr::null(),
+            symbol_names: std::ptr::null(),
+            field_names: std::ptr::null(),
+            field_map_slices: field_map_slices.as_ptr(),
+            field_map_entries: field_map_entries.as_ptr(),
+            symbol_metadata: std::ptr::null(),
+            public_symbol_map: std::ptr::null(),
+            alias_map: std::ptr::null(),
+            alias_sequences: std::ptr::null(),
+            lex_modes: std::ptr::null(),
+            lex_fn: None,
+            keyword_lex_fn: None,
+            keyword_capture_token: 0,
+            external_scanner: ExternalScanner::default(),
+            primary_state_ids: std::ptr::null(),
+            production_lhs_index: std::ptr::null(),
+            production_count: 0,
+            eof_symbol: 0,
+            rules: std::ptr::null(),
+            rule_count: 0,
+        };
+        let mut children = vec![
+            Subtree {
+                symbol: 1,
+                children: vec![],
+                start_byte: 0,
+                end_byte: 1,
+                start_point: Point { row: 0, column: 0 },
+                end_point: Point { row: 0, column: 1 },
+                is_extra: false,
+                is_error: false,
+                is_missing: false,
+                production_id: 0,
+                field_id: None,
+            },
+            Subtree {
+                symbol: 1,
+                children: vec![],
+                start_byte: 1,
+                end_byte: 2,
+                start_point: Point { row: 0, column: 1 },
+                end_point: Point { row: 0, column: 2 },
+                is_extra: false,
+                is_error: false,
+                is_missing: false,
+                production_id: 0,
+                field_id: None,
+            },
+        ];
+
+        Parser::new().assign_field_ids_for_production(&language, 1, &mut children);
+        assert_eq!(children[0].field_id, Some(1));
+        assert_eq!(children[1].field_id, Some(2));
     }
 }


### PR DESCRIPTION
### Motivation
- Typed extraction requires child `field_id` metadata to match Rust struct/enum field positions, but runtime conversion paths were dropping or never populating those IDs, breaking extraction for named fields, nested variants, skipped fields and GLR-produced trees. 
- The change surfaces existing language table data (`field_names`, `field_map_slices`, `field_map_entries`) at runtime so `ParsedNode`/`Subtree` carry field IDs when the language provides them.

### Description
- Add `assign_field_ids_for_production` to `Parser` (in `runtime/src/pure_parser.rs`) and call it just after children are reversed in `reduce` so reduced child `Subtree` entries receive `field_id` values derived from `TSLanguage.field_map_slices`/`field_map_entries` when present. 
- Implement resolution of `ParseNode.field_name -> ParsedNode.field_id` in `convert_parse_node_v4_to_pure` (in `runtime/src/__private.rs`) by scanning `TSLanguage.field_names` and setting `ParsedNode.field_id` when the name maps to a valid index. 
- Add focused unit tests: a pure-parser test that `assign_field_ids_for_production` sets child `field_id`s from packed field map entries, and GLR-to-pure conversion tests that verify known named fields, nested field preservation, and absent/unknown-field behaviors.
- Keep behavior unchanged when table data is missing or incomplete by early-returning; no GLR algorithm, tablegen, or macro expansion changes were made.

### Testing
- Ran `cargo fmt --all --check` (formatting applied where needed) and it passed after formatting. 
- Ran `cargo test -p adze --test extract_trait_v9 field -- --nocapture` and the targeted tests passed. 
- Ran `cargo test -p adze field -- --nocapture` which executed the runtime unit test suite including the new tests and they passed. 
- Built the tool tests via `cargo test -p adze-tool --test field_extraction_proptest --no-run` to verify the tool crate test binary compiles and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a4800548333a12ffac943e73ff6)