### PR TITLE
Harden lexer callbacks and block zero-length token no-progress loops

### DIFF
--- a/glr-core/src/ts_lexer.rs
+++ b/glr-core/src/ts_lexer.rs
@@ -4,6 +4,7 @@
 use crate::LexMode;
 use std::ffi::c_void;
 use std::os::raw::c_char;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Tree-sitter lexer struct passed to lex function
 #[repr(C)]
@@ -129,12 +130,32 @@ impl<'a> TsLexerHost<'a> {
         host.end_mark = host.pos;
     }
 
-    extern "C" fn get_column(_payload: *mut c_void) -> u32 {
-        0 // TODO: Track column for proper error reporting
+    extern "C" fn get_column(payload: *mut c_void) -> u32 {
+        // SAFETY: see shared invariant above.
+        let host = unsafe { &mut *(payload as *mut Self) };
+        let pos = host.pos.min(host.input.len());
+
+        let mut line_start = 0usize;
+        for (idx, b) in host.input[..pos].iter().enumerate() {
+            if *b == b'\n' {
+                line_start = idx + 1;
+            }
+        }
+
+        (pos - line_start) as u32
     }
 
-    extern "C" fn is_included(_payload: *mut c_void) -> bool {
-        false // TODO: Support included ranges for injections
+    extern "C" fn is_included(payload: *mut c_void) -> bool {
+        // SAFETY: see shared invariant above.
+        let _host = unsafe { &mut *(payload as *mut Self) };
+        static WARNED_INCLUDED_UNSUPPORTED: AtomicBool = AtomicBool::new(false);
+        if !WARNED_INCLUDED_UNSUPPORTED.swap(true, Ordering::Relaxed) {
+            eprintln!(
+                "adze_glr_core::ts_lexer: included ranges are not implemented; \
+                 `is_included` always returns false"
+            );
+        }
+        false
     }
 }
 
@@ -217,6 +238,8 @@ unsafe extern "C" {
 
 #[cfg(test)]
 mod tests {
+    use super::TsLexerHost;
+    use std::ffi::c_void;
 
     #[test]
     #[ignore = "requires actual Tree-sitter library to be linked"]
@@ -231,5 +254,38 @@ mod tests {
         //     assert!(token.is_some());
         //     assert_eq!(token.unwrap().kind, 1); // { token
         // }
+    }
+
+    #[test]
+    fn host_reports_column_from_last_newline() {
+        let mut host = TsLexerHost {
+            input: b"first\nsecond",
+            pos: 9,
+            end_mark: 9,
+        };
+        let col = TsLexerHost::get_column(&mut host as *mut _ as *mut c_void);
+        assert_eq!(col, 3);
+    }
+
+    #[test]
+    fn host_reports_column_at_input_start() {
+        let mut host = TsLexerHost {
+            input: b"abc",
+            pos: 0,
+            end_mark: 0,
+        };
+        let col = TsLexerHost::get_column(&mut host as *mut _ as *mut c_void);
+        assert_eq!(col, 0);
+    }
+
+    #[test]
+    fn included_ranges_are_explicitly_unsupported() {
+        let mut host = TsLexerHost {
+            input: b"abc",
+            pos: 1,
+            end_mark: 1,
+        };
+        let included = TsLexerHost::is_included(&mut host as *mut _ as *mut c_void);
+        assert!(!included);
     }
 }

--- a/runtime/src/external_scanner.rs
+++ b/runtime/src/external_scanner.rs
@@ -132,6 +132,9 @@ impl ExternalScannerRuntime {
 
         // Scan for external tokens
         if let Some(result) = scanner.scan(lexer, &valid_symbols) {
+            if result.length == 0 {
+                return None;
+            }
             // Serialize updated state
             self.state.data.clear();
             scanner.serialize(&mut self.state.data);
@@ -567,5 +570,54 @@ mod tests {
 
         assert!(new_scanner.in_string);
         assert_eq!(new_scanner.quote_char, Some(b'\''));
+    }
+
+    #[test]
+    fn test_runtime_rejects_zero_length_scan_result() {
+        use std::collections::HashSet;
+
+        #[derive(Default)]
+        struct ZeroLengthScanner;
+
+        impl ExternalScanner for ZeroLengthScanner {
+            fn scan(
+                &mut self,
+                _lexer: &mut dyn Lexer,
+                _valid_symbols: &[bool],
+            ) -> Option<ScanResult> {
+                Some(ScanResult {
+                    symbol: 0,
+                    length: 0,
+                })
+            }
+
+            fn serialize(&self, _buffer: &mut Vec<u8>) {}
+
+            fn deserialize(&mut self, _buffer: &[u8]) {}
+        }
+
+        struct TestLexer;
+
+        impl Lexer for TestLexer {
+            fn lookahead(&self) -> Option<u8> {
+                Some(b'x')
+            }
+            fn advance(&mut self, _n: usize) {}
+            fn mark_end(&mut self) {}
+            fn column(&self) -> usize {
+                0
+            }
+            fn is_eof(&self) -> bool {
+                false
+            }
+        }
+
+        let mut runtime = ExternalScannerRuntime::new(vec![1]);
+        let mut scanner = ZeroLengthScanner;
+        let mut lexer = TestLexer;
+        let mut valid = HashSet::new();
+        valid.insert(1);
+
+        assert_eq!(runtime.scan(&mut scanner, &mut lexer, &valid), None);
     }
 }

--- a/runtime/src/glr_lexer.rs
+++ b/runtime/src/glr_lexer.rs
@@ -68,7 +68,15 @@ impl GLRLexer {
         // Compile token patterns
         for (symbol_id, token) in &grammar.tokens {
             let matcher = match &token.pattern {
-                TokenPattern::String(s) => TokenMatcher::Literal(s.clone()),
+                TokenPattern::String(s) => {
+                    if s.is_empty() {
+                        return Err(format!(
+                            "Token '{}' has an empty literal pattern, which would cause lexer no-progress loops",
+                            token.name
+                        ));
+                    }
+                    TokenMatcher::Literal(s.clone())
+                }
                 TokenPattern::Regex(pattern) => {
                     // Add ^ anchor if not present to ensure matching at position
                     let anchored_pattern = if pattern.starts_with('^') {
@@ -78,7 +86,15 @@ impl GLRLexer {
                     };
 
                     match Regex::new(&anchored_pattern) {
-                        Ok(re) => TokenMatcher::Regex(re),
+                        Ok(re) => {
+                            if re.find("").is_some_and(|m| m.start() == 0 && m.end() == 0) {
+                                return Err(format!(
+                                    "Token '{}' has a zero-length regex pattern ('{}'), which is unsupported to prevent lexer no-progress loops",
+                                    token.name, pattern
+                                ));
+                            }
+                            TokenMatcher::Regex(re)
+                        }
                         Err(e) => {
                             let name = grammar
                                 .rule_names

--- a/runtime/tests/boundary_tests.rs
+++ b/runtime/tests/boundary_tests.rs
@@ -416,7 +416,6 @@ fn alternating_single_digits_produces_many_tokens() {
 // ===========================================================================
 
 #[test]
-#[ignore = "known: GLRLexer infinite loops on zero-length regex matches"]
 fn zero_length_regex_token_does_not_infinite_loop() {
     // A regex that can match the empty string (e.g. "\d*")
     let mut g = Grammar::new("zero_len".into());
@@ -441,15 +440,14 @@ fn zero_length_regex_token_does_not_infinite_loop() {
     });
     g.rule_names.insert(s, "start".into());
 
-    // The lexer must not spin forever on empty-match patterns.
-    let mut lexer = GLRLexer::new(&g, "abc".into()).unwrap();
-    let tokens = lexer.tokenize_all();
-    // We just care that it terminates; the token count is implementation-defined.
-    let _ = tokens;
+    // The lexer must reject zero-length patterns to avoid no-progress loops.
+    let err = GLRLexer::new(&g, "abc".into())
+        .err()
+        .expect("zero-length regex should be rejected");
+    assert!(err.contains("zero-length regex pattern"));
 }
 
 #[test]
-#[ignore = "known: GLRLexer infinite loops on empty literal tokens"]
 fn empty_literal_token_does_not_infinite_loop() {
     let mut g = Grammar::new("empty_lit".into());
     let empty = SymbolId(1);
@@ -473,10 +471,11 @@ fn empty_literal_token_does_not_infinite_loop() {
     });
     g.rule_names.insert(s, "start".into());
 
-    // Must terminate.
-    let mut lexer = GLRLexer::new(&g, "hello".into()).unwrap();
-    let tokens = lexer.tokenize_all();
-    let _ = tokens;
+    // Empty literal patterns are rejected to avoid no-progress loops.
+    let err = GLRLexer::new(&g, "hello".into())
+        .err()
+        .expect("empty literal should be rejected");
+    assert!(err.contains("empty literal pattern"));
 }
 
 // ===========================================================================


### PR DESCRIPTION
### Motivation

- Make Tree-sitter lexer callback behavior safer and more accurate for downstream tooling and diagnostics.  
- Prevent no-progress infinite loops caused by zero-length token patterns and make included-range handling explicit instead of silently unimplemented.

### Description

- Implemented `get_column` in `glr-core/src/ts_lexer.rs` to compute the byte column as the distance from the last newline (uses available input bytes) and added unit tests covering start-of-input and post-newline behavior.  
- Made included ranges explicit: `is_included` now emits a one-time diagnostic and returns `false` (still unsupported) so callers observe deterministic behavior instead of a silent TODO.  
- Prevent no-progress lexer loops in `runtime/src/glr_lexer.rs` by rejecting empty literal token patterns at construction and rejecting regex token patterns that can match the empty string.  
- Harden external scanner runtime in `runtime/src/external_scanner.rs` to drop scanner results with `length == 0` and added a unit test that verifies zero-length scan results are ignored.  
- Updated `runtime/tests/boundary_tests.rs` to assert that zero-length literal/regex token definitions are rejected (replacing prior ignored infinite-loop regression tests).

### Testing

- Ran `cargo test -p adze-glr-core lexer -- --nocapture`, which completed successfully (lexer unit tests passed; included-range warning printed once).  
- Ran `cargo test -p adze --test boundary_tests -- --nocapture`, which completed successfully (boundary tests passed, including the updated zero-length pattern checks).  
- Built tests with external scanners via `cargo test -p adze --features external_scanners --no-run`, which succeeded (test binaries produced).  
- Ran `cargo fmt --all --check`, which passed.

Implemented callbacks: `get_column`, `eof`, `advance`, and `mark_end` (existing behavior preserved).  
Explicitly unsupported: `is_included` (now returns `false` and emits a one-time diagnostic).  
No-progress loops prevented by rejecting empty/zero-length token patterns at lexer construction and by dropping zero-length `ScanResult` values from external scanners at runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a6b2a5c8333b91d68a752be0965)