### PR TITLE
runtime: stop parser_v4 from silently degrading GLR fork conflicts

### DIFF
--- a/runtime/src/parser_v4.rs
+++ b/runtime/src/parser_v4.rs
@@ -17,6 +17,9 @@ use std::rc::Rc;
 
 const PARSE_WITH_CUSTOM_LEXER_UNSUPPORTED: &str = "Custom lexer functions are not yet supported by parser_v4 runtime. \
      Provide a grammar/tokenization path without a custom transform lexer.";
+const GLR_CONFLICT_REQUIRES_TRUE_GLR: &str = "Encountered parse-table conflict (Action::Fork) in parser_v4. \
+     parser_v4 no longer degrades conflicts into first-success fallback; route conflicted grammars to \
+     the GLR parser engine (runtime/src/glr_parser.rs).";
 
 // Define types directly in parser_v4 (no longer dependent on parser_v3)
 
@@ -795,113 +798,13 @@ impl Parser {
                 }
 
                 Action::Fork(actions) => {
-                    // GLR fork point - multiple valid parse paths
-                    // Quick implementation: try each action in sequence, use first successful one
-                    // #[cfg(feature = "debug")]
-                    // eprintln!(
-                    // "Fork with {} actions at state {}",
-                    // actions.len(),
-                    // current_state.0
-                    // );
-
-                    let mut fork_succeeded = false;
-                    for fork_action in actions.iter() {
-                        // #[cfg(feature = "debug")]
-                        // eprintln!("  Trying fork action {}: {:?}", _i, fork_action);
-
-                        // Clone the current parser state for this fork
-                        let saved_state_stack = state_stack.clone();
-                        let saved_symbol_stack = symbol_stack.clone();
-                        let saved_node_stack = node_stack.clone();
-
-                        // Try to apply the action
-                        match fork_action {
-                            Action::Shift(next_state) => {
-                                // Apply shift as normal
-                                let node = ParseNode {
-                                    symbol: token.symbol,
-                                    symbol_id: token.symbol,
-                                    start_byte: token.start,
-                                    end_byte: token.end,
-                                    children: vec![],
-                                    field_name: None,
-                                };
-
-                                state_stack.push(*next_state);
-                                symbol_stack.push(token.symbol);
-                                node_stack.push(node);
-
-                                // Advance position
-                                current_position = token.end;
-                                fork_succeeded = true;
-                                break;
-                            }
-                            Action::Reduce(rule_id) => {
-                                // Apply reduce as normal
-                                let rule = self.find_rule_by_production_id(*rule_id)?;
-                                let child_count = rule.rhs_len;
-
-                                // Pop items from stacks
-                                let mut children = Vec::new();
-                                for _ in 0..child_count {
-                                    state_stack.pop();
-                                    symbol_stack.pop();
-                                    if let Some(child) = node_stack.pop() {
-                                        children.push(child);
-                                    }
-                                }
-                                children.reverse();
-
-                                // Create a parent node
-                                let start_byte = children
-                                    .first()
-                                    .map(|n| n.start_byte)
-                                    .unwrap_or(current_position);
-                                let end_byte = children
-                                    .last()
-                                    .map(|n| n.end_byte)
-                                    .unwrap_or(current_position);
-                                let parent_node = ParseNode {
-                                    symbol: rule.lhs,
-                                    symbol_id: rule.lhs,
-                                    start_byte,
-                                    end_byte,
-                                    children,
-                                    field_name: None,
-                                };
-
-                                // Get the goto state
-                                let goto_from_state = *state_stack.last().ok_or_else(|| {
-                                    anyhow!(
-                                        "State stack is empty after fork-path reduce of rule {:?}",
-                                        rule_id
-                                    )
-                                })?;
-                                let goto_state = self.get_goto_state(goto_from_state, rule.lhs)?;
-
-                                // Push the new state and symbol
-                                state_stack.push(goto_state);
-                                symbol_stack.push(rule.lhs);
-                                node_stack.push(parent_node);
-
-                                fork_succeeded = true;
-                                break;
-                            }
-                            _ => {
-                                // Try next fork action
-                                state_stack = saved_state_stack.clone();
-                                symbol_stack = saved_symbol_stack.clone();
-                                node_stack = saved_node_stack.clone();
-                            }
-                        }
-                    }
-
-                    if !fork_succeeded {
-                        // #[cfg(feature = "debug")]
-                        // eprintln!("All fork actions failed");
-                        error_count += 1;
-                        current_position += 1;
-                    }
+                    bail!(
+                        "{} state={} lookahead={} actions={:?}",
+                        GLR_CONFLICT_REQUIRES_TRUE_GLR,
+                        current_state.0,
+                        lookahead.0,
+                        actions
+                    );
                 }
 
                 _ => {

--- a/runtime/tests/test_parser_routing.rs
+++ b/runtime/tests/test_parser_routing.rs
@@ -196,3 +196,59 @@ mod test_helpers {
         false
     }
 }
+
+#[cfg(all(feature = "pure-rust", feature = "glr"))]
+mod conflicted_table_behavior {
+    use adze::parser_v4::Parser;
+    use adze_glr_core::{Action, FirstFollowSets, build_lr1_automaton};
+    use adze_ir::builder::GrammarBuilder;
+
+    fn make_conflicted_parser() -> Parser {
+        // Ambiguous expression grammar: expr -> expr - expr | num
+        let mut grammar = GrammarBuilder::new("ambiguous_for_routing")
+            .token("num", "[0-9]+")
+            .token("minus", "-")
+            .rule("expr", vec!["num"])
+            .rule("expr", vec!["expr", "minus", "expr"])
+            .start("expr")
+            .build();
+        grammar.normalize();
+        let ff = FirstFollowSets::compute_normalized(&mut grammar).expect("first/follow");
+        let table = build_lr1_automaton(&grammar, &ff).expect("lr1 table");
+        Parser::new(grammar, table, "ambiguous_for_routing".to_string())
+    }
+
+    #[test]
+    fn parser_routing_conflicted_table_is_not_first_success_fallback() {
+        let mut parser = make_conflicted_parser();
+
+        // Sanity-check that this table is genuinely conflicted.
+        let has_conflict = parser
+            .parse_table()
+            .action_table
+            .iter()
+            .flat_map(|row| row.iter())
+            .any(|cell| {
+                cell.len() > 1 || cell.iter().any(|action| matches!(action, Action::Fork(_)))
+            });
+        assert!(
+            has_conflict,
+            "test fixture should produce a conflicted table"
+        );
+
+        // Prior behavior silently picked a branch from Action::Fork.
+        // New behavior must fail explicitly instead of ordered fallback.
+        let err = parser
+            .parse_tree_with_error_count("1-2-3")
+            .expect_err("conflicted parser_v4 path should reject fallback parsing");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Action::Fork"),
+            "error should explain conflict handling, got: {msg}"
+        );
+        assert!(
+            msg.contains("route conflicted grammars to the GLR parser engine"),
+            "error should direct users to GLR parser, got: {msg}"
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- Prevent `parser_v4` from masking parse-table conflicts by sequentially trying `Action::Fork` branches and accepting the first successful branch, which silently discards ambiguity. 
- Make the runtime honest about GLR-required parsing and direct conflicted grammars to the full GLR engine rather than continuing with an incorrect ordered-fallback strategy. 
- Add a focused test to prevent regressions where conflicted tables would be treated as first-success fallbacks.

### Description
- Replaced the previous first-success fallback implementation inside the `Action::Fork` handler in `runtime/src/parser_v4.rs` with an explicit fail-fast diagnostic (`bail!`) and a new constant `GLR_CONFLICT_REQUIRES_TRUE_GLR` that tells callers to route conflicted grammars to the GLR engine (`runtime/src/glr_parser.rs`).
- Added a targeted integration test (`parser_routing_conflicted_table_is_not_first_success_fallback`) in `runtime/tests/test_parser_routing.rs` which builds a small ambiguous grammar (`expr -> expr - expr | num`), verifies the parse table has conflicts, invokes `parse_tree_with_error_count`, and asserts that `parser_v4` fails with an explicit `Action::Fork`/GLR-required diagnostic instead of silently succeeding.
- No changes were made to CLI, docs, dependency manifests, benchmarks, or grammar crates; this is a minimal runtime safety change.

### Testing
- Ran `cargo fmt --all --check`, which succeeded. 
- Executed the new focused test: `cargo test -p adze --features glr --test test_parser_routing parser_routing_conflicted_table_is_not_first_success_fallback -- --nocapture`, which passed. 
- Built `adze-glr-core` test artifacts via `cargo test -p adze-glr-core --all-features --no-run`, which completed successfully (no-run build). 
- Larger filtered test runs (`--features glr ambiguous` / full `parser_routing` suites) were attempted but compile-time workload for this workspace was large and those runs were not used as the final verification signal in this narrow patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a3dbb1c833398a94dbd22bb4fd1)