### PR TITLE
chore: modernize Criterion to 0.8.2 and quarantine bincode to test-only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,6 +878,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1334,25 +1343,24 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
  "itertools",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -1360,9 +1368,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools",
@@ -1750,12 +1758,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2011,17 +2013,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2029,9 +2020,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -2277,6 +2268,16 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "parking_lot"
@@ -3598,6 +3599,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3605,6 +3622,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 proptest = "1.4"
 insta = "1.39"
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "0.8.2", features = ["html_reports"] }
 thiserror = "2.0"
 syn = { version = "2", features = ["full", "extra-traits"] }
 quote = "1"
@@ -122,7 +122,6 @@ proc-macro2 = "1"
 anyhow = "1.0"
 tempfile = "3"
 indexmap = "2.0"
-bincode = "1.3"
 clap = { version = "4.6", features = ["derive"] }
 rayon = "1.10"
 rustc-hash = "2.1"

--- a/benchmarks/benches/arena_vs_box_allocation.rs
+++ b/benchmarks/benches/arena_vs_box_allocation.rs
@@ -7,7 +7,8 @@
 //! Run with: cargo bench --bench arena_vs_box_allocation
 
 use adze::arena_allocator::{TreeArena, TreeNode};
-use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use std::hint::black_box;
 
 /// Benchmark arena allocation for N nodes
 fn bench_arena_allocation(c: &mut Criterion) {

--- a/benchmarks/benches/core_baselines.rs
+++ b/benchmarks/benches/core_baselines.rs
@@ -10,7 +10,8 @@ use adze_glr_core::{FirstFollowSets, build_lr1_automaton};
 use adze_ir::{Grammar, ProductionId, Rule, Symbol, SymbolId, Token, TokenPattern};
 use adze_tablegen::compress::TableCompressor;
 use adze_tablegen::helpers;
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 /// Build a grammar with `n` binary-operator rules over a single expression nonterminal.
 /// This creates: expr -> expr OP_i expr  (for i in 0..n)  plus  expr -> NUMBER.

--- a/benchmarks/benches/glr_hot.rs
+++ b/benchmarks/benches/glr_hot.rs
@@ -1,5 +1,6 @@
 use adze_example::arithmetic::grammar::parse;
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 const ARITH_MEDIUM: &str = include_str!("../fixtures/arithmetic/medium.expr");
 const ARITH_LARGE: &str = include_str!("../fixtures/arithmetic/large.expr");

--- a/benchmarks/benches/glr_performance.rs
+++ b/benchmarks/benches/glr_performance.rs
@@ -1,5 +1,6 @@
 use adze_example::arithmetic::grammar::parse;
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 // Load real arithmetic fixtures to keep benchmark inputs valid
 // for the GLR parser used in perf gating.

--- a/benchmarks/benches/glr_performance_real.rs
+++ b/benchmarks/benches/glr_performance_real.rs
@@ -42,7 +42,8 @@
 //! - Fixtures: benchmarks/fixtures/arithmetic/
 
 use adze_example::arithmetic::grammar::parse;
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 // Load arithmetic fixtures at compile time (deterministic, zero I/O overhead)
 const ARITH_SMALL: &str = include_str!("../fixtures/arithmetic/small.expr");

--- a/benchmarks/benches/optimization_bench.rs
+++ b/benchmarks/benches/optimization_bench.rs
@@ -1,6 +1,7 @@
 use adze::arena_allocator::{TreeArena, TreeNode};
 use adze::stack_pool::StackPool;
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 fn benchmark_stack_pool(c: &mut Criterion) {
     let mut group = c.benchmark_group("stack_pool");

--- a/benchmarks/benches/stack_optimization.rs
+++ b/benchmarks/benches/stack_optimization.rs
@@ -1,6 +1,7 @@
 use adze::pool::NodePool;
 use adze_glr_core::stack::StackNode;
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 use std::sync::Arc;
 
 /// Benchmark comparing old Vec-based stacks vs new persistent stacks

--- a/crates/bdd-grid-core/benches/bdd_grid_bench.rs
+++ b/crates/bdd-grid-core/benches/bdd_grid_bench.rs
@@ -2,12 +2,13 @@
 //!
 //! Measures performance of scenario lookup and progress reporting used in BDD framework.
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use adze_bdd_grid_core::{
     BddPhase, BddScenario, BddScenarioStatus, GLR_CONFLICT_PRESERVATION_GRID, bdd_progress,
     bdd_progress_report,
 };
+use std::hint::black_box;
 
 fn bench_bdd_progress_core(c: &mut Criterion) {
     c.bench_function("bdd_progress_core_phase", |b| {

--- a/crates/concurrency-caps-core/benches/caps_bench.rs
+++ b/crates/concurrency-caps-core/benches/caps_bench.rs
@@ -1,8 +1,9 @@
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use adze_concurrency_caps_core::{
     ConcurrencyCaps, normalized_concurrency, parse_positive_usize_or_default,
 };
+use std::hint::black_box;
 
 fn bench_caps_from_lookup(c: &mut Criterion) {
     c.bench_function("caps_from_lookup_defaults", |b| {

--- a/crates/concurrency-map-core/benches/bench_map.rs
+++ b/crates/concurrency-map-core/benches/bench_map.rs
@@ -1,8 +1,9 @@
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use adze_concurrency_map_core::{
     ParallelPartitionPlan, bounded_parallel_map, normalized_concurrency,
 };
+use std::hint::black_box;
 
 fn bench_normalized_concurrency(c: &mut Criterion) {
     c.bench_function("normalized_concurrency_zero", |b| {

--- a/crates/feature-policy-core/benches/bench_policy.rs
+++ b/crates/feature-policy-core/benches/bench_policy.rs
@@ -1,6 +1,7 @@
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use adze_feature_policy_core::{ParserBackend, ParserFeatureProfile};
+use std::hint::black_box;
 
 fn sample_profile() -> ParserFeatureProfile {
     ParserFeatureProfile {

--- a/crates/governance-matrix-core-impl/benches/governance_matrix_bench.rs
+++ b/crates/governance-matrix-core-impl/benches/governance_matrix_bench.rs
@@ -2,13 +2,14 @@
 //!
 //! Measures performance of matrix operations used in governance.
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use adze_governance_matrix_core_impl::{
     BddGovernanceMatrix, BddPhase, GLR_CONFLICT_PRESERVATION_GRID, ParserFeatureProfile,
     bdd_governance_snapshot, bdd_progress_report, bdd_progress_report_with_profile,
     bdd_progress_status_line, describe_backend_for_conflicts,
 };
+use std::hint::black_box;
 
 fn bench_bdd_governance_snapshot(c: &mut Criterion) {
     c.bench_function("bdd_governance_snapshot", |b| {

--- a/crates/governance-metadata/benches/bench_governance.rs
+++ b/crates/governance-metadata/benches/bench_governance.rs
@@ -1,7 +1,8 @@
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use adze_feature_policy_core::ParserFeatureProfile;
 use adze_governance_metadata::{GovernanceMetadata, ParserFeatureProfileSnapshot};
+use std::hint::black_box;
 
 fn sample_profile_snapshot() -> ParserFeatureProfileSnapshot {
     ParserFeatureProfileSnapshot::new(true, false, true, false)

--- a/crates/linecol-core/benches/linecol_bench.rs
+++ b/crates/linecol-core/benches/linecol_bench.rs
@@ -1,6 +1,7 @@
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use adze_linecol_core::LineCol;
+use std::hint::black_box;
 
 fn make_ascii_input(size: usize) -> Vec<u8> {
     let line = b"hello world\n";

--- a/crates/parser-backend-core/benches/parser_backend_bench.rs
+++ b/crates/parser-backend-core/benches/parser_backend_bench.rs
@@ -2,9 +2,10 @@
 //!
 //! Measures performance of backend selection used in parser.
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use adze_parser_backend_core::ParserBackend;
+use std::hint::black_box;
 
 fn bench_backend_is_glr(c: &mut Criterion) {
     c.bench_function("backend_is_glr", |b| {

--- a/crates/parsetable-metadata/benches/metadata_bench.rs
+++ b/crates/parsetable-metadata/benches/metadata_bench.rs
@@ -1,8 +1,9 @@
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use adze_parsetable_metadata::{
     FeatureFlags, GenerationInfo, GrammarInfo, ParsetableMetadata, TableStatistics,
 };
+use std::hint::black_box;
 
 fn sample_metadata() -> ParsetableMetadata {
     ParsetableMetadata {

--- a/crates/stack-pool-core/benches/stack_pool_bench.rs
+++ b/crates/stack-pool-core/benches/stack_pool_bench.rs
@@ -1,6 +1,7 @@
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use adze_stack_pool_core::StackPool;
+use std::hint::black_box;
 
 fn bench_sequential_push_pop(c: &mut Criterion) {
     c.bench_function("acquire_release_cycle_100", |b| {

--- a/crates/ts-format-core/benches/ts_format_bench.rs
+++ b/crates/ts-format-core/benches/ts_format_bench.rs
@@ -4,12 +4,13 @@
 
 use std::collections::BTreeMap;
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use adze_glr_core::{
     Action, GotoIndexing, Grammar, LexMode, ParseTable, RuleId, StateId, SymbolId, SymbolMetadata,
 };
 use adze_ts_format_core::{choose_action, choose_action_with_precedence};
+use std::hint::black_box;
 
 /// Create a symbol metadata instance for testing.
 fn make_symbol_metadata(id: u16) -> SymbolMetadata {

--- a/glr-core/Cargo.toml
+++ b/glr-core/Cargo.toml
@@ -52,7 +52,7 @@ glr_telemetry = [] # Enable GLR telemetry (used by benchmarks)
 
 [dev-dependencies]
 insta = "1.0"
-criterion = "0.5"
+criterion.workspace = true
 dhat = "0.3"
 serde_json = "1.0"
 proptest = "1.4"

--- a/glr-core/benches/perf_snapshot.rs
+++ b/glr-core/benches/perf_snapshot.rs
@@ -1,4 +1,4 @@
-use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use std::time::Duration;
 
 use adze_glr_core::Driver;
@@ -6,6 +6,7 @@ use adze_glr_core::Driver;
 use adze_glr_core::perf;
 use adze_ir::SymbolId;
 use glr_test_support::test_utilities::make_minimal_table;
+use std::hint::black_box;
 
 pub fn bench_parse_small(c: &mut Criterion) {
     let mut g = c.benchmark_group("glr-perf-snapshot");

--- a/ir/Cargo.toml
+++ b/ir/Cargo.toml
@@ -31,6 +31,7 @@ strict_docs = []
 insta = "1.0"
 proptest = "1.4"
 serde_json = "1.0"
+# Test-only legacy serde-compat checks; intentionally not used in library/runtime serialization APIs.
 bincode = "1.3"
 adze-glr-core = { version = "0.8.0-dev", path = "../glr-core" }
 indexmap = { version = "2.0", features = ["serde"] }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -77,7 +77,7 @@ adze-stack-pool-core = { version = "0.1.0", path = "../crates/stack-pool-core" }
 [dev-dependencies]
 insta = "1.43.1"
 tempfile = "3.20.0"
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion.workspace = true
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.142"
 proptest = "1.4"

--- a/runtime/benches/glr_parser_bench.rs
+++ b/runtime/benches/glr_parser_bench.rs
@@ -2,7 +2,8 @@ use adze::glr_lexer::GLRLexer;
 use adze::glr_parser::GLRParser;
 use adze_glr_core::{FirstFollowSets, build_lr1_automaton};
 use adze_ir::{Grammar, ProductionId, Rule, Symbol, SymbolId, Token, TokenPattern};
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 /// Create a highly ambiguous arithmetic expression grammar
 fn create_ambiguous_grammar() -> Grammar {

--- a/runtime/benches/incremental_benchmark.rs
+++ b/runtime/benches/incremental_benchmark.rs
@@ -7,7 +7,8 @@ use adze::{
 };
 use adze_glr_core::{FirstFollowSets, build_lr1_automaton};
 use adze_ir::{Grammar, ProductionId, Rule, Symbol, SymbolId, Token, TokenPattern};
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 use std::sync::Arc;
 
 /// Create arithmetic expression grammar

--- a/runtime/benches/incremental_parsing.rs
+++ b/runtime/benches/incremental_parsing.rs
@@ -7,7 +7,8 @@ use adze::{
 };
 use adze_glr_core::{FirstFollowSets, build_lr1_automaton};
 use adze_ir::{Grammar, ProductionId, Rule, Symbol, SymbolId};
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 use std::sync::Arc;
 
 /// Create a simple repetition grammar for benchmarking

--- a/runtime/benches/incremental_simple.rs
+++ b/runtime/benches/incremental_simple.rs
@@ -7,7 +7,8 @@ use adze::{
 };
 use adze_glr_core::{FirstFollowSets, build_lr1_automaton};
 use adze_ir::{Grammar, ProductionId, Rule, Symbol, SymbolId};
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 use std::sync::Arc;
 
 /// Create a simple left-recursive repetition grammar

--- a/runtime/benches/parser_bench.rs
+++ b/runtime/benches/parser_bench.rs
@@ -5,7 +5,8 @@
 
 use adze::lexer::{ErrorRecoveringLexer, ErrorRecoveryMode, GrammarLexer};
 use adze::parser_v4::{ParserV4 as ParserV2, Token};
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 // use adze::incremental::{IncrementalParser, Edit, IncrementalTree};
 use adze_glr_core::{Action, ParseTable, SymbolMetadata};
 use adze_ir::{

--- a/runtime/benches/parser_benchmark.rs
+++ b/runtime/benches/parser_benchmark.rs
@@ -1,7 +1,8 @@
 #![cfg(feature = "unstable-benches")]
 
 use adze::tree_sitter::Parser;
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 // Simple arithmetic grammar for benchmarking
 #[adze::grammar("benchmark")]

--- a/runtime/benches/perf_benchmark.rs
+++ b/runtime/benches/perf_benchmark.rs
@@ -4,17 +4,18 @@
 #![cfg(feature = "unstable-benches")]
 
 /*
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use adze::lexer::GrammarLexer;
 use adze::parallel_parser::{ParallelConfig, ParallelParser};
 use adze::parser_v3::Parser;
 use adze::simd_lexer::SimdLexer;
+use std::hint::black_box;
 */
 
 use adze::lexer::GrammarLexer;
 use adze_glr_core::{Action, ParseTable};
 use adze_ir::{Grammar, Rule, SymbolId, TokenPattern};
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use std::time::Duration;
 
 /// Create a test grammar for benchmarking

--- a/runtime/benches/runtime_parse_serialize_bench.rs
+++ b/runtime/benches/runtime_parse_serialize_bench.rs
@@ -17,7 +17,8 @@ use adze::glr_tree_bridge::{GLRTree, subtree_to_tree};
 use adze::subtree::Subtree;
 use adze_glr_core::{FirstFollowSets, build_lr1_automaton};
 use adze_ir::{Grammar, ProductionId, Rule, Symbol, SymbolId, Token, TokenPattern};
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 // ---------------------------------------------------------------------------
 // Grammar helpers

--- a/runtime/benches/simple_bench.rs
+++ b/runtime/benches/simple_bench.rs
@@ -3,7 +3,8 @@
 
 use adze::lexer::{self, GrammarLexer};
 use adze_ir::{SymbolId, TokenPattern};
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 fn configured_lexer(
     token_patterns: &[(SymbolId, TokenPattern, i32)],

--- a/tablegen/Cargo.toml
+++ b/tablegen/Cargo.toml
@@ -41,7 +41,7 @@ tree-sitter-c2rust = { version = "0.25.2", optional = true }
 proptest = "1.5"
 insta = "1.40"
 rustc-hash = "2.1"
-criterion = "0.5"
+criterion.workspace = true
 syn = { version = "2", features = ["full", "parsing"] }
 adze-bdd-grid-core = { version = "0.1.0", path = "../crates/bdd-grid-core" }
 adze-glr-core = { version = "0.8.0-dev", path = "../glr-core" }

--- a/tablegen/benches/compression.rs
+++ b/tablegen/benches/compression.rs
@@ -7,7 +7,8 @@ use adze_tablegen::{
     TableCompressor,
     helpers::{collect_token_indices, eof_accepts_or_reduces},
 };
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 /// Benchmark small grammar compression
 fn bench_small_grammar(c: &mut Criterion) {


### PR DESCRIPTION
### Motivation
- Unify and modernize the workspace benchmark dependency to a single up-to-date Criterion version to reduce maintenance friction and avoid mixed dev-dependency pins. 
- Replace `criterion::black_box` usages with the stable `std::hint::black_box` to use the standard library primitive and remove Criterion API surface usage from benches. 
- Remove `bincode` from the public workspace dependency surface and keep it only where strictly needed for legacy test coverage to avoid shipping a binary-serialization crate as a normal library dependency.

### Description
- Bumped the workspace `criterion` entry to `0.8.2` (keeps `html_reports`) and refreshed the lockfile so all benches resolve to a single Criterion version. 
- Converted crate-local `criterion = "0.5"` dev-dependencies to `criterion.workspace = true` in affected manifests (notably `runtime`, `glr-core`, and `tablegen`). 
- Replaced all `criterion::black_box` imports/usages with `use std::hint::black_box;` across the benchmark files so benches use the standard hint. 
- Removed the root `bincode = "1.3"` workspace entry and left `bincode = "1.3"` only as a documented test-only dev-dependency in `ir/Cargo.toml` with an inline comment explaining it is for legacy serde-compat tests.

### Testing
- Ran `cargo metadata --format-version 1` and `cargo tree -i criterion` to verify the workspace resolves Criterion to `0.8.2`, which succeeded. 
- Ran `cargo tree -i bincode` to confirm `bincode` is present only in the test/dev graph (dev-dependency on `adze-ir`), which succeeded. 
- Executed bench build checks `cargo bench -p adze-benchmarks --no-run`, `cargo bench -p adze-glr-core --no-run`, and `cargo bench -p adze-tablegen --no-run` to confirm benches compile under the updated Criterion, which succeeded. 
- Ran `cargo test -p adze-ir serde -- --nocapture` and `cargo fmt --all --check` to validate tests and formatting, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a8854c48333b4f7dce159238259)