### PR TITLE
Add typed-AST extraction contract for recursive expression grammar

### DIFF
--- a/test-mini/src/lib.rs
+++ b/test-mini/src/lib.rs
@@ -10,9 +10,27 @@ pub mod grammar {
     }
 }
 
+#[adze::grammar("typed_ast")]
+pub mod typed_ast {
+    #[derive(Debug, PartialEq, Eq)]
+    #[adze::language]
+    pub enum Expr {
+        Number(#[adze::leaf(pattern = r"\d+", transform = |s| s.parse::<i32>().unwrap())] i32),
+
+        #[adze::prec_left(1)]
+        Add(Box<Expr>, #[adze::leaf(text = "+")] (), Box<Expr>),
+    }
+
+    #[adze::extra]
+    struct Whitespace {
+        #[adze::leaf(pattern = r"\s")]
+        _whitespace: (),
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::grammar;
+    use crate::{grammar, typed_ast};
 
     #[test]
     fn test_number() {
@@ -61,5 +79,24 @@ mod tests {
         assert!(result.is_ok());
         let program: grammar::Program = result.unwrap();
         assert_eq!(program.number, "42");
+    }
+
+    #[test]
+    #[ignore = "blocked: Extract called with None node for enum when parsing recursive Expr in generated typed extraction"]
+    fn typed_ast_left_associative_addition_contract() {
+        let expr = typed_ast::parse("1 + 2 + 3").expect("typed AST parse should succeed");
+
+        assert_eq!(
+            expr,
+            typed_ast::Expr::Add(
+                Box::new(typed_ast::Expr::Add(
+                    Box::new(typed_ast::Expr::Number(1)),
+                    (),
+                    Box::new(typed_ast::Expr::Number(2)),
+                )),
+                (),
+                Box::new(typed_ast::Expr::Number(3)),
+            )
+        );
     }
 }


### PR DESCRIPTION
### Motivation

- Provide a focused end-to-end contract that proves "Rust types in → text parsed → typed Rust AST out" using a minimal expression grammar with numeric leaves and left-associative addition. 
- Surface any small runtime/macro extraction gaps by exercising a recursive enum (`Expr`) with a `transform` leaf and left-recursive `Add` variant.

### Description

- Added a new annotated grammar `typed_ast` in `test-mini/src/lib.rs` defining `pub enum Expr { Number(i32), Add(Box<Expr>, '+', Box<Expr>) }` with `Number` using `#[adze::leaf(pattern = r"\d+", transform = |s| s.parse::<i32>().unwrap())]` and `Add` marked `#[adze::prec_left(1)]`.
- Added an end-to-end test `typed_ast_left_associative_addition_contract` that parses `"1 + 2 + 3"` and asserts the exact nested typed AST shape `Add(Add(Number(1), (), Number(2)), (), Number(3))`.
- Marked the new test `#[ignore]` with the precise blocker message `Extract called with None node for enum when parsing recursive Expr in generated typed extraction` to document a current extraction limitation while keeping the contract in-tree.

### Testing

- Ran `cargo test -p test-mini typed_ast -- --nocapture` which now shows the contract test present but ignored with reason: `blocked: Extract called with None node for enum when parsing recursive Expr in generated typed extraction`.
- Ran compile/no-run checks `cargo test -p adze-macro --no-run` and `cargo test -p adze-tool --no-run` which completed successfully.
- Ran `cargo test -p adze typed_ast -- --nocapture` to validate the core runtime build used by the contract and it completed (no failing tests filtered in that run).
- Ran `cargo fmt --all --check` which passed; an interim `cargo clean` was executed to resolve a temporary disk-space issue encountered during CI-style runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a76532883338958ca08eb03a21d)