### PR TITLE
Add typed-AST expression contract test (ignored due to enum extraction gap)

### DIFF
--- a/test-mini/src/lib.rs
+++ b/test-mini/src/lib.rs
@@ -10,9 +10,31 @@ pub mod grammar {
     }
 }
 
+#[adze::grammar("typed_ast_contract")]
+pub mod typed_ast_grammar {
+    #[adze::language]
+    #[derive(Debug, PartialEq, Eq)]
+    pub struct Program {
+        pub expr: Expr,
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    pub enum Expr {
+        Number(#[adze::leaf(pattern = r"\d+", transform = |s| s.parse::<i32>().unwrap())] i32),
+        #[adze::prec_left(1)]
+        Add(Box<Expr>, #[adze::leaf(text = "+")] (), Box<Expr>),
+    }
+
+    #[adze::extra]
+    pub struct Whitespace {
+        #[adze::leaf(pattern = r"\s")]
+        pub ws: (),
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::grammar;
+    use crate::{grammar, typed_ast_grammar};
 
     #[test]
     fn test_number() {
@@ -61,5 +83,28 @@ mod tests {
         assert!(result.is_ok());
         let program: grammar::Program = result.unwrap();
         assert_eq!(program.number, "42");
+    }
+
+    #[test]
+    #[ignore = "Known typed extraction gap: recursive enum extraction can receive None nodes (panic: `Extract called with None node for enum`) for this left-recursive contract grammar."]
+    fn typed_ast_left_associative_addition_contract() {
+        use typed_ast_grammar::{Expr, Program};
+
+        let parsed = typed_ast_grammar::parse("1 + 2 + 3").expect("typed AST parse should succeed");
+
+        assert_eq!(
+            parsed,
+            Program {
+                expr: Expr::Add(
+                    Box::new(Expr::Add(
+                        Box::new(Expr::Number(1)),
+                        (),
+                        Box::new(Expr::Number(2))
+                    )),
+                    (),
+                    Box::new(Expr::Number(3))
+                )
+            }
+        );
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a small, concrete end-to-end contract that proves annotated Rust grammar types parse text into the expected typed Rust AST shape for a canonical expression grammar (numbers + left-associative addition). 
- Make the expected typed AST explicit and checkable so maintainers can point to a single test that documents the intended product contract.

### Description
- Added a focused grammar `typed_ast_grammar` in `test-mini/src/lib.rs` that defines `Expr::Number(i32)` using `#[adze::leaf(pattern = r"\d+", transform = |s| s.parse::<i32>().unwrap())]`, left-associative `Expr::Add(Box<Expr>, "+", Box<Expr>)` via `#[adze::prec_left(1)]`, and whitespace as `#[adze::extra]`.
- Added a contract test `typed_ast_left_associative_addition_contract` that parses `"1 + 2 + 3"` and asserts the exact nested typed AST `Program { expr: Add(Add(Number(1), Number(2)), Number(3)) }`.
- The contract test is marked `#[ignore = "Known typed extraction gap: recursive enum extraction can receive None nodes (panic: `Extract called with None node for enum`) for this left-recursive contract grammar."]` because running it currently panics during typed extraction, documenting the blocker for implementers.
- No runtime logic or macro expansion changes were made; the test lives in `test-mini` to exercise the full build/generate/parse flow using existing harness patterns.

### Testing
- Ran formatting check with `cargo fmt --all --check`, which succeeded.
- Built and ran the focused tests: `cargo test -p adze typed_ast -- --nocapture` and `cargo test -p test-mini typed_ast -- --nocapture`; the `test-mini` contract test exists but is `ignored` with the documented reason, and enabling it previously produced the panic `Extract called with None node for enum` (reproducible failure), so the test is intentionally ignored.
- Verified macro and tool crates compile/tests via `cargo test -p adze-macro --no-run` and `cargo test -p adze-tool --no-run`, which completed successfully (no runtime changes required).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6a76532883338958ca08eb03a21d)