### PR TITLE
chore: fix tablegen cfg compatibility

### DIFF
--- a/tablegen/Cargo.toml
+++ b/tablegen/Cargo.toml
@@ -62,3 +62,4 @@ serialization = [
     "adze-glr-core/serialization",
 ] # Enable serialization support (used by runtime2)
 small-table = [] # Test-only feature for compressed table round-trip tests
+incremental_glr = [] # Expose incremental_glr table metadata flag

--- a/tablegen/src/lib.rs
+++ b/tablegen/src/lib.rs
@@ -7,7 +7,7 @@
 #![deny(private_interfaces)]
 #![cfg_attr(feature = "strict_api", deny(unreachable_pub))]
 #![cfg_attr(not(feature = "strict_api"), warn(unreachable_pub))]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "strict_docs", deny(missing_docs))]
 #![cfg_attr(not(feature = "strict_docs"), allow(missing_docs))]
 


### PR DESCRIPTION
- Remove cfg_attr doc_auto_cfg from tablegen lib cfg gates.
- Keep doc_cfg only.
- Remove/align unexpected cfg(feature = "incremental_glr") usage in tablegen Cargo and parsetable writer.
