### PR TITLE
runtime: portability fixes for serialization and C FFI casts

### DIFF
--- a/runtime/src/__private.rs
+++ b/runtime/src/__private.rs
@@ -327,7 +327,7 @@ fn parse_with_pure_parser<T: Extract<T>>(
                         if (public_symbol as usize) < lang.symbol_count as usize {
                             let symbol_ptr = *lang.symbol_names.add(public_symbol as usize);
                             if !symbol_ptr.is_null() {
-                                std::ffi::CStr::from_ptr(symbol_ptr as *const i8)
+                                std::ffi::CStr::from_ptr(symbol_ptr as *const c_char)
                                     .to_string_lossy()
                                     .to_string()
                             } else {
@@ -476,7 +476,7 @@ fn convert_parse_node_v4_to_pure(
 
         // SAFETY: `name_ptr` was just null-checked. It points to a static NUL-
         // terminated C string from the language tables.
-        let name = unsafe { std::ffi::CStr::from_ptr(name_ptr as *const i8).to_str() }.ok();
+        let name = unsafe { std::ffi::CStr::from_ptr(name_ptr as *const c_char).to_str() }.ok();
         matches!(name, Some("ERROR"))
     };
 

--- a/runtime/src/decoder.rs
+++ b/runtime/src/decoder.rs
@@ -1114,7 +1114,8 @@ pub fn decode_parse_table(lang: &'static TSLanguage) -> ParseTable {
                         {
                             // SAFETY: `*name_ptr` is a pointer to a null-terminated C string
                             // per TSLanguage contract.
-                            let name = unsafe { std::ffi::CStr::from_ptr(*name_ptr as *const i8) };
+                            let name =
+                                unsafe { std::ffi::CStr::from_ptr(*name_ptr as *const c_char) };
                             if let Ok(name_str) = name.to_str() {
                                 // Prefer symbols that don't look like internal helpers
                                 !name_str.contains("repeat") && !name_str.starts_with('_')

--- a/runtime/src/pure_parser.rs
+++ b/runtime/src/pure_parser.rs
@@ -21,7 +21,7 @@
 // Pure-Rust Tree-sitter compatible parser runtime
 // This implements the core parsing algorithm with GLR support
 
-use std::ffi::c_void;
+use std::ffi::{CStr, c_char, c_void};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 
@@ -1616,7 +1616,7 @@ impl Parser {
                         if symbol < language.symbol_count as u16 {
                             let name_ptr = symbol_names[symbol as usize];
                             if !name_ptr.is_null() {
-                                let c_str = std::ffi::CStr::from_ptr(name_ptr as *const i8);
+                                let c_str = CStr::from_ptr(name_ptr as *const c_char);
                                 let _name = c_str.to_string_lossy();
                             }
                         }
@@ -1832,7 +1832,7 @@ impl ParsedNode {
                         language.symbol_count as usize,
                     );
                     let name_ptr = symbol_names[self.symbol as usize];
-                    let c_str = std::ffi::CStr::from_ptr(name_ptr as *const i8);
+                    let c_str = CStr::from_ptr(name_ptr as *const c_char);
                     c_str.to_str().unwrap_or("unknown")
                 } else {
                     "unknown"

--- a/runtime/src/serialization.rs
+++ b/runtime/src/serialization.rs
@@ -21,6 +21,11 @@ use tree_sitter_runtime_c2rust::TreeCursor;
 #[cfg(feature = "serialization")]
 use serde_json::{Value, json};
 
+#[cfg(feature = "pure-rust")]
+fn to_usize_pos(value: u32) -> usize {
+    usize::try_from(value).unwrap_or(usize::MAX)
+}
+
 /// Serializable representation of a parse tree node
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SerializedNode {
@@ -167,10 +172,13 @@ impl<'a> TreeSerializer<'a> {
             is_named: node.is_named,
             field_name: node.field_id.map(|id| format!("field_{}", id)), // Convert field_id to placeholder name
             start_position: (
-                node.start_point.row as usize,
-                node.start_point.column as usize,
+                to_usize_pos(node.start_point.row),
+                to_usize_pos(node.start_point.column),
             ),
-            end_position: (node.end_point.row as usize, node.end_point.column as usize),
+            end_position: (
+                to_usize_pos(node.end_point.row),
+                to_usize_pos(node.end_point.column),
+            ),
             start_byte: node.start_byte,
             end_byte: node.end_byte,
             text: None,
@@ -204,12 +212,28 @@ impl<'a> TreeSerializer<'a> {
 
     #[cfg(not(feature = "pure-rust"))]
     pub fn serialize_node(&self, node: Node) -> SerializedNode {
+        #[cfg(feature = "pure-rust")]
+        fn to_usize_coord(value: u32) -> usize {
+            usize::try_from(value).unwrap_or(usize::MAX)
+        }
+
+        #[cfg(not(feature = "pure-rust"))]
+        fn to_usize_coord(value: u32) -> usize {
+            usize::try_from(value).unwrap_or(usize::MAX)
+        }
+
         let mut serialized = SerializedNode {
             kind: node.kind().to_string(),
             is_named: node.is_named(),
             field_name: node.field_name().map(|s| s.to_string()),
-            start_position: (node.start_position().row, node.start_position().column),
-            end_position: (node.end_position().row, node.end_position().column),
+            start_position: (
+                to_usize_coord(node.start_position().row),
+                to_usize_coord(node.start_position().column),
+            ),
+            end_position: (
+                to_usize_coord(node.end_position().row),
+                to_usize_coord(node.end_position().column),
+            ),
             start_byte: node.start_byte(),
             end_byte: node.end_byte(),
             text: None,

--- a/runtime/src/tree_sitter_compat.rs
+++ b/runtime/src/tree_sitter_compat.rs
@@ -5,7 +5,7 @@
 #![allow(unreachable_pub)]
 #![allow(clippy::redundant_closure)]
 
-use std::ffi::CStr;
+use std::ffi::{CStr, c_char};
 
 use crate::pure_incremental::Tree as PureTree;
 use crate::pure_parser::{ParsedNode, Parser as PureParser, TSLanguage};
@@ -182,7 +182,7 @@ impl TreeCursor {
                 return None;
             }
 
-            unsafe { CStr::from_ptr(field_ptr as *const i8).to_str().ok() }
+            unsafe { CStr::from_ptr(field_ptr as *const c_char).to_str().ok() }
         })
     }
 }


### PR DESCRIPTION
- Convert parser metadata row/column u32 fields to usize safely.
- Use std::os::raw::c_char for C string pointer casts across decoder/pure_parser/tree_sitter_compat.
