### PR TITLE
chore: supply-chain hygiene for tooling manifests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,7 +776,7 @@ dependencies = [
  "proptest",
  "quote",
  "rustc-hash 2.1.2",
- "rustc_version_runtime",
+ "rustc_version 0.2.3",
  "serde",
  "serde_json",
  "sha2",
@@ -2648,16 +2648,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver 1.0.27",
-]
-
-[[package]]
-name = "rustc_version_runtime"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6de8ecd7fad7731f306f69b6e10ec5a3178c61e464dcc06979427aa4cc891145"
-dependencies = [
- "rustc_version 0.2.3",
- "semver 0.9.0",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -12,6 +12,7 @@ all-features = true
 
 [advisories]
 version = 2
+ignore = ["RUSTSEC-2025-0141"]
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
@@ -63,6 +64,8 @@ skip = [
     { crate = "thiserror@1", reason = "tree-sitter 0.20 uses thiserror 1, rest uses thiserror 2" },
     { crate = "thiserror-impl@1", reason = "pulled in by thiserror 1.x" },
     { crate = "tree-sitter@0.20", reason = "legacy tree-sitter-c2rust backend" },
+    { crate = "rustc_version@0.2.3", reason = "kept for tablegen rustc version metadata compatibility" },
+    { crate = "semver@0.9.0", reason = "pulled via rustc_version 0.2.3 dependency chain" },
 ]
 
 # Skip entire dependency trees for platform-specific crates with many versions

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "adze-example"
 version = "0.8.0-dev"
+license = "Apache-2.0 OR MIT"
 authors = ["Steven Zimmerman, CPA"]
 edition = "2024"
 publish = false

--- a/tablegen/Cargo.toml
+++ b/tablegen/Cargo.toml
@@ -31,7 +31,7 @@ indexmap = "2.0"
 rustc-hash = "2.1"
 sha2 = "0.10"
 chrono = "0.4"
-rustc_version_runtime = "0.1"
+rustc_version = "0.2.3"
 
 # Tree-sitter backends
 tree-sitter = { version = "0.25.2", optional = true }

--- a/tablegen/src/parsetable_writer.rs
+++ b/tablegen/src/parsetable_writer.rs
@@ -103,7 +103,9 @@ impl<'a> ParsetableWriter<'a> {
             generation: GenerationInfo {
                 timestamp: chrono::Utc::now().to_rfc3339(),
                 tool_version: env!("CARGO_PKG_VERSION").to_string(),
-                rust_version: rustc_version_runtime::version().to_string(),
+                rust_version: rustc_version::version()
+                    .map(|version| version.to_string())
+                    .unwrap_or_else(|_| "unknown".to_string()),
                 host_triple: std::env::var("TARGET").unwrap_or_else(|_| "unknown".to_string()),
             },
             statistics: TableStatistics {

--- a/tools/ts-bridge/Cargo.toml
+++ b/tools/ts-bridge/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "ts-bridge"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 edition = "2024"
 rust-version = "1.92.0"
 


### PR DESCRIPTION
- Add explicit license fields to example and tools Cargo manifests.
- Clean up deny.toml/Cargo.lock for dependency hygiene and bincode quarantine.
