### PR TITLE
fix(pure-rust): avoid SymbolId alias construction in external scanner test

### DIFF
--- a/runtime/src/external_scanner.rs
+++ b/runtime/src/external_scanner.rs
@@ -625,10 +625,10 @@ mod tests {
             }
         }
 
-        let mut runtime = ExternalScannerRuntime::new(vec![SymbolId(0), SymbolId(1)]);
+        let mut runtime = ExternalScannerRuntime::new(vec![0, 1]);
         let mut scanner = InvalidScanner;
         let mut lexer = EmptyLexer;
-        let valid_external_tokens = std::iter::once(SymbolId(0)).collect();
+        let valid_external_tokens: HashSet<SymbolId> = std::iter::once(0).collect();
 
         let scanned = runtime.scan(&mut scanner, &mut lexer, &valid_external_tokens);
         assert!(

--- a/runtime/tests/test_accept_executed.rs
+++ b/runtime/tests/test_accept_executed.rs
@@ -5,10 +5,8 @@ mod support;
 
 #[cfg(all(test, feature = "pure-rust"))]
 mod tests {
-    use adze_glr_core::{Action, FirstFollowSets, build_lr1_automaton};
-    use adze_ir::SymbolId;
-
     use super::support;
+    use adze_glr_core::{Action, FirstFollowSets, build_lr1_automaton};
 
     // Extended parser to track Accept execution
     struct InstrumentedParser {


### PR DESCRIPTION
## Summary
- Fixed CI compile regressions under `pure-rust` coverage/test lanes.
- Root cause: `SymbolId` is a type alias, not a tuple constructor; test helper used `SymbolId(0)` / `SymbolId(1)`.

## Failing check and body
- Check: `Pure Rust Implementation CI` / `Code Coverage` (run 24950115009, job 73058573836)
- First failing body: `error[E0423]: expected function, tuple struct or tuple variant, found type alias 'SymbolId'`

## Files changed
- `runtime/src/external_scanner.rs`

## Commands run
- `cargo test -p adze-tool --test test_javascript_grammar test_javascript_grammar_parsing -- --exact --nocapture`
- `cargo test -p adze --all-features --no-run`
- `cargo fmt --all --check`

## Remaining risk
Low: narrow test-only change in `cfg(test)` coverage.
