### PR TITLE
docs: reconcile PR queue and current failure map

### DIFF
--- a/CURRENT_FAILURE_MAP.md
+++ b/CURRENT_FAILURE_MAP.md
@@ -1,0 +1,15 @@
+# Current Failure Map
+
+- Date: 2026-04-26
+- Live board snapshot: 106 open PRs
+- First actionable failure: `#420` (`fix(pure-rust): avoid SymbolId alias construction in external scanner test`)
+- Current blocker: `runtime/tests/test_table_invariants.rs::test_dense_column_mapping` (`Non-dense mapping at column 0 after decode`)
+- Current merge order:
+  1. `#420`
+  2. one GLR conflict-semantics PR (`#388/#389/#390`)
+  3. one parser_v4 no-fallback PR (`#404/#405/#406/#411`)
+  4. one field-ID preservation PR (`#400/#401/#402/#403`)
+  5. one pure-Rust diagnostics PR (`#391/#392/#393/#394`)
+  6. one typed AST contract PR (`#412/#414/#415/#416`)
+  7. product-proof PR (`#395`)
+  8. one Criterion/bincode cleanup PR (`#396/#397/#398/#413`)

--- a/PR_CLUSTER_MAP.md
+++ b/PR_CLUSTER_MAP.md
@@ -1,0 +1,10 @@
+# PR Cluster Map
+
+- Cluster A: `#420`
+- Cluster B: `#388/#389/#390`
+- Cluster C: `#404/#405/#406/#411`
+- Cluster D: `#400/#401/#402/#403`
+- Cluster E: `#391/#392/#393/#394`
+- Cluster F: `#412/#414/#415/#416`
+- Cluster G: `#396/#397/#398/#413`
+- Cluster H: `#395`

--- a/PR_OVERLAP_MAP.md
+++ b/PR_OVERLAP_MAP.md
@@ -1,0 +1,13 @@
+# PR Overlap Map
+
+- Family overlaps:
+  - GLR conflict semantics (`#388`, `#389`, `#390`) all target conflict-cell semantics in `adze-glr-core`.
+  - parser_v4 fallback/diagnostics (`#404`, `#405`, `#406`, `#411`) all target conflict handling behavior for `parser_v4`.
+  - Field-ID preservation (`#400`, `#401`, `#402`, `#403`) all target typed-field metadata retention.
+  - pure-Rust diagnostics (`#391`, `#392`, `#393`, `#394`) all target extraction-facing diagnostics in pure runtime paths.
+  - Typed AST contracts (`#412`, `#414`, `#415`, `#416`) all target contract assertions for concrete AST values.
+  - Criterion/bincode cleanup (`#396`, `#397`, `#398`, `#413`) all target benchmark/dependency cleanup.
+  - Product proof (`#395`) depends on the core merge families.
+- Duplicate closure rule after canonical merge:
+  - Close all remaining PRs in the family after the canonical PR lands.
+  - Closure note: `Closed as superseded by #<canonical>, which landed the canonical implementation/test for this family.`

--- a/PR_QUEUE_PROGRESS.md
+++ b/PR_QUEUE_PROGRESS.md
@@ -1,0 +1,15 @@
+# PR Queue Progress
+
+- Current ladder:
+  1. `#420` — current-red blocker (`test_dense_column_mapping` block persists)
+  2. GLR conflict semantics canonical family (`#388/#389/#390`)
+  3. parser_v4 no-fallback canonical family (`#404/#405/#406/#411`)
+  4. field-ID preservation family (`#400/#401/#402/#403`)
+  5. pure-Rust diagnostics family (`#391/#392/#393/#394`)
+  6. typed AST contract family (`#412/#414/#415/#416`)
+  7. product-proof CI (`#395`)
+  8. Criterion / bincode cleanup (`#396/#397/#398/#413`)
+- Completed / merged / superseded:
+  - No canonical landings yet in this local branch.
+  - All local PR families are currently in compare/select mode except `#420`.
+- Next action only: resolve #420 gate (or land dedicated table-invariant blocker fix) before advancing canonical merges.


### PR DESCRIPTION
Updates coordination tracker docs for the current PR family map and merge order. No runtime/code changes intended.