### PR TITLE
[codex] docs: sync queue after canonical parser fixes

### DIFF
--- a/CURRENT_FAILURE_MAP.md
+++ b/CURRENT_FAILURE_MAP.md
@@ -1,15 +1,25 @@
 # Current Failure Map
 
-- Date: 2026-04-26
-- Live board snapshot: 106 open PRs
-- First actionable failure: `#420` (`fix(pure-rust): avoid SymbolId alias construction in external scanner test`)
-- Current blocker: `runtime/tests/test_table_invariants.rs::test_dense_column_mapping` (`Non-dense mapping at column 0 after decode`)
+- Date: 2026-04-27
+- Live board snapshot: 96 open PRs
+- First actionable failure: `adze-glr-core` action-cell semantics (`pt38_cell_conflict_iff_multi_action`, `pt82`)
+- Current blocker: property failures in conflict-cell duplicate/`Error` normalization
+- Merged / resolved:
+  - `#420`
+  - `#421`
+  - `#422`
+  - `#390`
+  - `#392`
+  - `#401`
+  - `#405`
+  - `#423` (superseded)
+- Next active frontier:
+  - GLR conflict semantics (`#388/#389` duplicates still open)
+- Likely already merged:
+  - `#392`
 - Current merge order:
-  1. `#420`
-  2. one GLR conflict-semantics PR (`#388/#389/#390`)
-  3. one parser_v4 no-fallback PR (`#404/#405/#406/#411`)
-  4. one field-ID preservation PR (`#400/#401/#402/#403`)
-  5. one pure-Rust diagnostics PR (`#391/#392/#393/#394`)
-  6. one typed AST contract PR (`#412/#414/#415/#416`)
-  7. product-proof PR (`#395`)
-  8. one Criterion/bincode cleanup PR (`#396/#397/#398/#413`)
+  1. one GLR conflict-semantics PR (`#388/#389` against merged `#390`)
+  2. one pure-GLR routing follow-up in runtime
+  3. one typed AST contract PR (`#412/#414/#415/#416`)
+  4. product-proof PR (`#395`)
+  5. one Criterion/bincode cleanup PR (`#396/#397/#398/#413`)

--- a/CURRENT_FAILURE_MAP.md
+++ b/CURRENT_FAILURE_MAP.md
@@ -1,25 +1,27 @@
 # Current Failure Map
 
 - Date: 2026-04-27
-- Live board snapshot: 96 open PRs
-- First actionable failure: `adze-glr-core` action-cell semantics (`pt38_cell_conflict_iff_multi_action`, `pt82`)
-- Current blocker: property failures in conflict-cell duplicate/`Error` normalization
+- Live board snapshot: 90 open PRs
+- First actionable failure: `adze-glr-core` `driver_api_comprehensive` all-features EOF parity failures
+- Current blocker: `driver_api_comprehensive`/parse-table invariants with all-features
 - Merged / resolved:
   - `#420`
   - `#421`
   - `#422`
   - `#390`
+  - `#388` (superseded)
+  - `#389` (superseded)
+  - `#404` (superseded)
+  - `#405`
+  - `#406` (superseded)
+  - `#411` (superseded)
   - `#392`
   - `#401`
-  - `#405`
   - `#423` (superseded)
-- Next active frontier:
-  - GLR conflict semantics (`#388/#389` duplicates still open)
-- Likely already merged:
-  - `#392`
+- Remaining active families:
+  - typed AST contract (`#412/#414/#415/#416`)
+  - product-proof + cleanup follow-ups (`#395`, `#396/#397/#398/#413`)
 - Current merge order:
-  1. one GLR conflict-semantics PR (`#388/#389` against merged `#390`)
-  2. one pure-GLR routing follow-up in runtime
-  3. one typed AST contract PR (`#412/#414/#415/#416`)
-  4. product-proof PR (`#395`)
-  5. one Criterion/bincode cleanup PR (`#396/#397/#398/#413`)
+  1. one typed AST contract PR (`#412/#414/#415/#416`)
+  2. product-proof PR (`#395`)
+  3. one Criterion/bincode cleanup PR (`#396/#397/#398/#413`)

--- a/PR_CLUSTER_MAP.md
+++ b/PR_CLUSTER_MAP.md
@@ -1,11 +1,10 @@
 # PR Cluster Map
 
-- Cluster A: `#420`
 - Cluster A (resolved): `#420/#421/#422/#423`
-- Cluster B: `#388/#389` (duplicates after merged `#390`)
-- Cluster C (merged canonical): `#405`
-- Cluster D (merged canonical): `#401`
-- Cluster E (merged canonical): `#392`
-- Cluster F: `#412/#414/#415/#416`
-- Cluster G: `#396/#397/#398/#413`
-- Cluster H (blocked on core spine): `#395`
+- Cluster B (resolved): `#390`, `#388`, `#389`
+- Cluster C (resolved): `#405`, `#404`, `#406`, `#411`
+- Cluster D (resolved): `#401`, `#400`, `#402`, `#403`
+- Cluster E (resolved): `#392`, `#391`, `#393`, `#394`
+- Cluster F (active): `#412/#414/#415/#416`
+- Cluster G (active): `#396/#397/#398/#413`
+- Cluster H (blocked on runtime follow-up): `#395`

--- a/PR_CLUSTER_MAP.md
+++ b/PR_CLUSTER_MAP.md
@@ -1,10 +1,11 @@
 # PR Cluster Map
 
 - Cluster A: `#420`
-- Cluster B: `#388/#389/#390`
-- Cluster C: `#404/#405/#406/#411`
-- Cluster D: `#400/#401/#402/#403`
-- Cluster E: `#391/#392/#393/#394`
+- Cluster A (resolved): `#420/#421/#422/#423`
+- Cluster B: `#388/#389` (duplicates after merged `#390`)
+- Cluster C (merged canonical): `#405`
+- Cluster D (merged canonical): `#401`
+- Cluster E (merged canonical): `#392`
 - Cluster F: `#412/#414/#415/#416`
 - Cluster G: `#396/#397/#398/#413`
-- Cluster H: `#395`
+- Cluster H (blocked on core spine): `#395`

--- a/PR_OVERLAP_MAP.md
+++ b/PR_OVERLAP_MAP.md
@@ -14,6 +14,8 @@
   - `#401` canonical for field metadata retention.
   - `#392` canonical for pure-Rust diagnostics.
 - Duplicate closure rule after canonical merge:
-  - `#423` is superseded by `#420 + #422` (now closed).
-  - `#388` and `#389` should be closed as superseded by `#390` once live property status for pt38/pt82 is verified green.
+  - `#423` is superseded by `#420 + #422`.
+  - `#388` and `#389` are superseded by `#390` and closed.
+  - `#404`, `#406`, `#411` are superseded by `#405` and closed.
+  - `#391`, `#393`, `#394` are superseded by `#392` and closed.
   - Closure note: `Closed as superseded by #<canonical>, which landed the canonical implementation/test for this family.`

--- a/PR_OVERLAP_MAP.md
+++ b/PR_OVERLAP_MAP.md
@@ -1,13 +1,19 @@
 # PR Overlap Map
 
 - Family overlaps:
-  - GLR conflict semantics (`#388`, `#389`, `#390`) all target conflict-cell semantics in `adze-glr-core`.
-  - parser_v4 fallback/diagnostics (`#404`, `#405`, `#406`, `#411`) all target conflict handling behavior for `parser_v4`.
-  - Field-ID preservation (`#400`, `#401`, `#402`, `#403`) all target typed-field metadata retention.
-  - pure-Rust diagnostics (`#391`, `#392`, `#393`, `#394`) all target extraction-facing diagnostics in pure runtime paths.
-  - Typed AST contracts (`#412`, `#414`, `#415`, `#416`) all target contract assertions for concrete AST values.
+  - GLR conflict semantics (`#388`, `#389`, `#390`) target conflict-cell semantics in `adze-glr-core`.
+  - parser_v4 fallback/diagnostics (`#404`, `#405`, `#406`, `#411`) target conflict handling behavior for `parser_v4`.
+  - Field-ID preservation (`#400`, `#401`, `#402`, `#403`) target typed-field metadata retention.
+  - pure-Rust diagnostics (`#391`, `#392`, `#393`, `#394`) target extraction-facing diagnostics in pure runtime paths.
+  - Typed AST contracts (`#412`, `#414`, `#415`, `#416`) target contract assertions for concrete AST values.
   - Criterion/bincode cleanup (`#396`, `#397`, `#398`, `#413`) all target benchmark/dependency cleanup.
   - Product proof (`#395`) depends on the core merge families.
+- Canonical landings:
+  - `#390` currently canonical for conflict-cell semantics.
+  - `#405` canonical for parser_v4 conflict behavior.
+  - `#401` canonical for field metadata retention.
+  - `#392` canonical for pure-Rust diagnostics.
 - Duplicate closure rule after canonical merge:
-  - Close all remaining PRs in the family after the canonical PR lands.
+  - `#423` is superseded by `#420 + #422` (now closed).
+  - `#388` and `#389` should be closed as superseded by `#390` once live property status for pt38/pt82 is verified green.
   - Closure note: `Closed as superseded by #<canonical>, which landed the canonical implementation/test for this family.`

--- a/PR_QUEUE_PROGRESS.md
+++ b/PR_QUEUE_PROGRESS.md
@@ -1,15 +1,16 @@
 # PR Queue Progress
 
 - Current ladder:
-  1. `#420` — current-red blocker (`test_dense_column_mapping` block persists)
-  2. GLR conflict semantics canonical family (`#388/#389/#390`)
-  3. parser_v4 no-fallback canonical family (`#404/#405/#406/#411`)
-  4. field-ID preservation family (`#400/#401/#402/#403`)
-  5. pure-Rust diagnostics family (`#391/#392/#393/#394`)
-  6. typed AST contract family (`#412/#414/#415/#416`)
-  7. product-proof CI (`#395`)
-  8. Criterion / bincode cleanup (`#396/#397/#398/#413`)
+  1. GLR conflict semantics follow-on (`#388/#389` against merged `#390`)
+  2. typed AST contract family (`#412/#414/#415/#416`)
+  3. product-proof CI (`#395`)
+  4. Criterion / bincode cleanup (`#396/#397/#398/#413`)
 - Completed / merged / superseded:
-  - No canonical landings yet in this local branch.
-  - All local PR families are currently in compare/select mode except `#420`.
-- Next action only: resolve #420 gate (or land dedicated table-invariant blocker fix) before advancing canonical merges.
+  - `#420` / `#421` / `#422` merged.
+  - `#390` merged.
+  - `#405` merged.
+  - `#401` merged.
+  - `#392` merged.
+  - `#423` superseded/closed.
+  - `#388` and `#389` remain open and should be closed once property failures are resolved.
+  - Next action: verify/fix `adze-glr-core` pt38/pt82 semantic status on current main and then close duplicate PRs.

--- a/PR_QUEUE_PROGRESS.md
+++ b/PR_QUEUE_PROGRESS.md
@@ -1,7 +1,7 @@
 # PR Queue Progress
 
 - Current ladder:
-  1. GLR conflict semantics follow-on (`#388/#389` against merged `#390`)
+  1. true GLR routing follow-up in runtime (`runtime`)
   2. typed AST contract family (`#412/#414/#415/#416`)
   3. product-proof CI (`#395`)
   4. Criterion / bincode cleanup (`#396/#397/#398/#413`)
@@ -12,5 +12,8 @@
   - `#401` merged.
   - `#392` merged.
   - `#423` superseded/closed.
-  - `#388` and `#389` remain open and should be closed once property failures are resolved.
-  - Next action: verify/fix `adze-glr-core` pt38/pt82 semantic status on current main and then close duplicate PRs.
+  - `#388` and `#389` superseded/closed.
+  - `#404`, `#406`, `#411` superseded/closed.
+  - `#391`, `#393`, `#394` superseded/closed.
+  - Parser-v4 canonical `#405` landed; e2e follow-up still has known ambiguity routing gaps.
+  - Runtime/GLR parser follow-up still blocked on ambiguity/`Parse` integration tests.


### PR DESCRIPTION
## Summary

Updates the queue/status tracker docs after the current-red fixes and canonical GLR/parser-v4 closeout.

## Why

The live PR state has moved past the dense-column/SymbolId current-red loop and the GLR/parser-v4 duplicate families. The tracker docs need to reflect the canonical path so follow-up work starts from field-preserving extraction, GLR routing, typed-AST proof, and product-proof CI instead of stale branch-sprawl notes.

## Validation

- Docs-only change.
- Commit hooks completed during local commits.
