### PR TITLE
[codex] runtime: route conflicted tables through true GLR

### DIFF
--- a/macro/src/expansion.rs
+++ b/macro/src/expansion.rs
@@ -377,8 +377,9 @@ pub fn expand_grammar(input: ItemMod) -> Result<ItemMod> {
                                     let node = node.expect("Extract called with None node for enum");
 
                                     fn unwrap_hidden_rules<'a>(node: &'a ::adze::pure_parser::ParsedNode) -> &'a ::adze::pure_parser::ParsedNode {
-                                        if (node.kind().starts_with('_') || node.children.len() == 1) && node.children.len() > 0 {
-                                            return unwrap_hidden_rules(&node.children[0]);
+                                        let non_extra_children: Vec<_> = node.children.iter().filter(|c| !c.is_extra).collect();
+                                        if (node.kind().starts_with('_') || non_extra_children.len() == 1) && !non_extra_children.is_empty() {
+                                            return unwrap_hidden_rules(non_extra_children[0]);
                                         }
                                         node
                                     }
@@ -395,7 +396,7 @@ pub fn expand_grammar(input: ItemMod) -> Result<ItemMod> {
                                     let node = unwrapped_node;
                                     #(#variant_detection_logic)*
 
-                                    if unwrapped_node.children.is_empty() {
+                                    if non_extra_children.is_empty() {
                                         let node = unwrapped_node;
                                         #(#leaf_variant_detection)*
                                     }
@@ -415,9 +416,11 @@ pub fn expand_grammar(input: ItemMod) -> Result<ItemMod> {
                                     let node = node.expect("Extract called with None node for enum");
 
                                     fn unwrap_hidden_rules(node: ::adze::tree_sitter::Node) -> ::adze::tree_sitter::Node {
-                                        if (node.kind().starts_with('_') || node.child_count() == 1) && node.child_count() > 0 {
-                                            if let Some(child) = node.child(0) {
-                                                return unwrap_hidden_rules(child);
+                                        let mut cursor = node.walk();
+                                        let non_extra_children: Vec<_> = node.children(&mut cursor).filter(|c| !c.is_extra()).collect();
+                                        if (node.kind().starts_with('_') || non_extra_children.len() == 1) && !non_extra_children.is_empty() {
+                                            if let Some(child) = non_extra_children.first() {
+                                                return unwrap_hidden_rules(*child);
                                             }
                                         }
                                         node

--- a/macro/src/snapshots/adze_macro__tests__enum_prec_left.snap
+++ b/macro/src/snapshots/adze_macro__tests__enum_prec_left.snap
@@ -18,11 +18,16 @@ mod grammar {
         ) -> Self {
             let node = node.expect("Extract called with None node for enum");
             fn unwrap_hidden_rules(node: ::adze::tree_sitter::Node) -> ::adze::tree_sitter::Node {
-                if (node.kind().starts_with('_') || node.child_count() == 1)
-                    && node.child_count() > 0
+                let mut cursor = node.walk();
+                let non_extra_children: Vec<_> = node
+                    .children(&mut cursor)
+                    .filter(|c| !c.is_extra())
+                    .collect();
+                if (node.kind().starts_with('_') || non_extra_children.len() == 1)
+                    && !non_extra_children.is_empty()
                 {
-                    if let Some(child) = node.child(0) {
-                        return unwrap_hidden_rules(child);
+                    if let Some(child) = non_extra_children.first() {
+                        return unwrap_hidden_rules(*child);
                     }
                 }
                 node

--- a/macro/src/snapshots/adze_macro__tests__enum_prec_left__pure_rust.snap
+++ b/macro/src/snapshots/adze_macro__tests__enum_prec_left__pure_rust.snap
@@ -21,10 +21,12 @@ mod grammar {
             fn unwrap_hidden_rules<'a>(
                 node: &'a ::adze::pure_parser::ParsedNode,
             ) -> &'a ::adze::pure_parser::ParsedNode {
-                if (node.kind().starts_with('_') || node.children.len() == 1)
-                    && node.children.len() > 0
+                let non_extra_children: Vec<_> =
+                    node.children.iter().filter(|c| !c.is_extra).collect();
+                if (node.kind().starts_with('_') || non_extra_children.len() == 1)
+                    && !non_extra_children.is_empty()
                 {
-                    return unwrap_hidden_rules(&node.children[0]);
+                    return unwrap_hidden_rules(non_extra_children[0]);
                 }
                 node
             }
@@ -74,7 +76,7 @@ mod grammar {
                     },
                 );
             }
-            if unwrapped_node.children.is_empty() {
+            if non_extra_children.is_empty() {
                 let node = unwrapped_node;
                 return {
                     let value = <adze::WithLeaf<i32> as ::adze::Extract<_>>::extract(

--- a/macro/src/snapshots/adze_macro__tests__enum_prec_no_assoc.snap
+++ b/macro/src/snapshots/adze_macro__tests__enum_prec_no_assoc.snap
@@ -18,11 +18,16 @@ mod grammar {
         ) -> Self {
             let node = node.expect("Extract called with None node for enum");
             fn unwrap_hidden_rules(node: ::adze::tree_sitter::Node) -> ::adze::tree_sitter::Node {
-                if (node.kind().starts_with('_') || node.child_count() == 1)
-                    && node.child_count() > 0
+                let mut cursor = node.walk();
+                let non_extra_children: Vec<_> = node
+                    .children(&mut cursor)
+                    .filter(|c| !c.is_extra())
+                    .collect();
+                if (node.kind().starts_with('_') || non_extra_children.len() == 1)
+                    && !non_extra_children.is_empty()
                 {
-                    if let Some(child) = node.child(0) {
-                        return unwrap_hidden_rules(child);
+                    if let Some(child) = non_extra_children.first() {
+                        return unwrap_hidden_rules(*child);
                     }
                 }
                 node

--- a/macro/src/snapshots/adze_macro__tests__enum_prec_no_assoc__pure_rust.snap
+++ b/macro/src/snapshots/adze_macro__tests__enum_prec_no_assoc__pure_rust.snap
@@ -21,10 +21,12 @@ mod grammar {
             fn unwrap_hidden_rules<'a>(
                 node: &'a ::adze::pure_parser::ParsedNode,
             ) -> &'a ::adze::pure_parser::ParsedNode {
-                if (node.kind().starts_with('_') || node.children.len() == 1)
-                    && node.children.len() > 0
+                let non_extra_children: Vec<_> =
+                    node.children.iter().filter(|c| !c.is_extra).collect();
+                if (node.kind().starts_with('_') || non_extra_children.len() == 1)
+                    && !non_extra_children.is_empty()
                 {
-                    return unwrap_hidden_rules(&node.children[0]);
+                    return unwrap_hidden_rules(non_extra_children[0]);
                 }
                 node
             }
@@ -74,7 +76,7 @@ mod grammar {
                     },
                 );
             }
-            if unwrapped_node.children.is_empty() {
+            if non_extra_children.is_empty() {
                 let node = unwrapped_node;
                 return {
                     let value = <adze::WithLeaf<i32> as ::adze::Extract<_>>::extract(

--- a/macro/src/snapshots/adze_macro__tests__enum_prec_right.snap
+++ b/macro/src/snapshots/adze_macro__tests__enum_prec_right.snap
@@ -18,11 +18,16 @@ mod grammar {
         ) -> Self {
             let node = node.expect("Extract called with None node for enum");
             fn unwrap_hidden_rules(node: ::adze::tree_sitter::Node) -> ::adze::tree_sitter::Node {
-                if (node.kind().starts_with('_') || node.child_count() == 1)
-                    && node.child_count() > 0
+                let mut cursor = node.walk();
+                let non_extra_children: Vec<_> = node
+                    .children(&mut cursor)
+                    .filter(|c| !c.is_extra())
+                    .collect();
+                if (node.kind().starts_with('_') || non_extra_children.len() == 1)
+                    && !non_extra_children.is_empty()
                 {
-                    if let Some(child) = node.child(0) {
-                        return unwrap_hidden_rules(child);
+                    if let Some(child) = non_extra_children.first() {
+                        return unwrap_hidden_rules(*child);
                     }
                 }
                 node

--- a/macro/src/snapshots/adze_macro__tests__enum_prec_right__pure_rust.snap
+++ b/macro/src/snapshots/adze_macro__tests__enum_prec_right__pure_rust.snap
@@ -21,10 +21,12 @@ mod grammar {
             fn unwrap_hidden_rules<'a>(
                 node: &'a ::adze::pure_parser::ParsedNode,
             ) -> &'a ::adze::pure_parser::ParsedNode {
-                if (node.kind().starts_with('_') || node.children.len() == 1)
-                    && node.children.len() > 0
+                let non_extra_children: Vec<_> =
+                    node.children.iter().filter(|c| !c.is_extra).collect();
+                if (node.kind().starts_with('_') || non_extra_children.len() == 1)
+                    && !non_extra_children.is_empty()
                 {
-                    return unwrap_hidden_rules(&node.children[0]);
+                    return unwrap_hidden_rules(non_extra_children[0]);
                 }
                 node
             }
@@ -74,7 +76,7 @@ mod grammar {
                     },
                 );
             }
-            if unwrapped_node.children.is_empty() {
+            if non_extra_children.is_empty() {
                 let node = unwrapped_node;
                 return {
                     let value = <adze::WithLeaf<i32> as ::adze::Extract<_>>::extract(

--- a/macro/src/snapshots/adze_macro__tests__enum_recursive.snap
+++ b/macro/src/snapshots/adze_macro__tests__enum_recursive.snap
@@ -18,11 +18,16 @@ mod grammar {
         ) -> Self {
             let node = node.expect("Extract called with None node for enum");
             fn unwrap_hidden_rules(node: ::adze::tree_sitter::Node) -> ::adze::tree_sitter::Node {
-                if (node.kind().starts_with('_') || node.child_count() == 1)
-                    && node.child_count() > 0
+                let mut cursor = node.walk();
+                let non_extra_children: Vec<_> = node
+                    .children(&mut cursor)
+                    .filter(|c| !c.is_extra())
+                    .collect();
+                if (node.kind().starts_with('_') || non_extra_children.len() == 1)
+                    && !non_extra_children.is_empty()
                 {
-                    if let Some(child) = node.child(0) {
-                        return unwrap_hidden_rules(child);
+                    if let Some(child) = non_extra_children.first() {
+                        return unwrap_hidden_rules(*child);
                     }
                 }
                 node

--- a/macro/src/snapshots/adze_macro__tests__enum_recursive__pure_rust.snap
+++ b/macro/src/snapshots/adze_macro__tests__enum_recursive__pure_rust.snap
@@ -21,10 +21,12 @@ mod grammar {
             fn unwrap_hidden_rules<'a>(
                 node: &'a ::adze::pure_parser::ParsedNode,
             ) -> &'a ::adze::pure_parser::ParsedNode {
-                if (node.kind().starts_with('_') || node.children.len() == 1)
-                    && node.children.len() > 0
+                let non_extra_children: Vec<_> =
+                    node.children.iter().filter(|c| !c.is_extra).collect();
+                if (node.kind().starts_with('_') || non_extra_children.len() == 1)
+                    && !non_extra_children.is_empty()
                 {
-                    return unwrap_hidden_rules(&node.children[0]);
+                    return unwrap_hidden_rules(non_extra_children[0]);
                 }
                 node
             }
@@ -69,7 +71,7 @@ mod grammar {
                     },
                 );
             }
-            if unwrapped_node.children.is_empty() {
+            if non_extra_children.is_empty() {
                 let node = unwrapped_node;
                 return {
                     let value = <adze::WithLeaf<i32> as ::adze::Extract<_>>::extract(

--- a/macro/src/snapshots/adze_macro__tests__enum_transformed_fields.snap
+++ b/macro/src/snapshots/adze_macro__tests__enum_transformed_fields.snap
@@ -17,11 +17,16 @@ mod grammar {
         ) -> Self {
             let node = node.expect("Extract called with None node for enum");
             fn unwrap_hidden_rules(node: ::adze::tree_sitter::Node) -> ::adze::tree_sitter::Node {
-                if (node.kind().starts_with('_') || node.child_count() == 1)
-                    && node.child_count() > 0
+                let mut cursor = node.walk();
+                let non_extra_children: Vec<_> = node
+                    .children(&mut cursor)
+                    .filter(|c| !c.is_extra())
+                    .collect();
+                if (node.kind().starts_with('_') || non_extra_children.len() == 1)
+                    && !non_extra_children.is_empty()
                 {
-                    if let Some(child) = node.child(0) {
-                        return unwrap_hidden_rules(child);
+                    if let Some(child) = non_extra_children.first() {
+                        return unwrap_hidden_rules(*child);
                     }
                 }
                 node

--- a/macro/src/snapshots/adze_macro__tests__enum_transformed_fields__pure_rust.snap
+++ b/macro/src/snapshots/adze_macro__tests__enum_transformed_fields__pure_rust.snap
@@ -20,10 +20,12 @@ mod grammar {
             fn unwrap_hidden_rules<'a>(
                 node: &'a ::adze::pure_parser::ParsedNode,
             ) -> &'a ::adze::pure_parser::ParsedNode {
-                if (node.kind().starts_with('_') || node.children.len() == 1)
-                    && node.children.len() > 0
+                let non_extra_children: Vec<_> =
+                    node.children.iter().filter(|c| !c.is_extra).collect();
+                if (node.kind().starts_with('_') || non_extra_children.len() == 1)
+                    && !non_extra_children.is_empty()
                 {
-                    return unwrap_hidden_rules(&node.children[0]);
+                    return unwrap_hidden_rules(non_extra_children[0]);
                 }
                 node
             }
@@ -49,7 +51,7 @@ mod grammar {
                     Expression::Number(value)
                 };
             }
-            if unwrapped_node.children.is_empty() {
+            if non_extra_children.is_empty() {
                 let node = unwrapped_node;
                 return {
                     let value = <adze::WithLeaf<i32> as ::adze::Extract<_>>::extract(

--- a/macro/src/snapshots/adze_macro__tests__enum_unit_variant_leaf.snap
+++ b/macro/src/snapshots/adze_macro__tests__enum_unit_variant_leaf.snap
@@ -19,11 +19,16 @@ mod grammar {
         ) -> Self {
             let node = node.expect("Extract called with None node for enum");
             fn unwrap_hidden_rules(node: ::adze::tree_sitter::Node) -> ::adze::tree_sitter::Node {
-                if (node.kind().starts_with('_') || node.child_count() == 1)
-                    && node.child_count() > 0
+                let mut cursor = node.walk();
+                let non_extra_children: Vec<_> = node
+                    .children(&mut cursor)
+                    .filter(|c| !c.is_extra())
+                    .collect();
+                if (node.kind().starts_with('_') || non_extra_children.len() == 1)
+                    && !non_extra_children.is_empty()
                 {
-                    if let Some(child) = node.child(0) {
-                        return unwrap_hidden_rules(child);
+                    if let Some(child) = non_extra_children.first() {
+                        return unwrap_hidden_rules(*child);
                     }
                 }
                 node

--- a/macro/src/snapshots/adze_macro__tests__enum_unit_variant_leaf__pure_rust.snap
+++ b/macro/src/snapshots/adze_macro__tests__enum_unit_variant_leaf__pure_rust.snap
@@ -22,10 +22,12 @@ mod grammar {
             fn unwrap_hidden_rules<'a>(
                 node: &'a ::adze::pure_parser::ParsedNode,
             ) -> &'a ::adze::pure_parser::ParsedNode {
-                if (node.kind().starts_with('_') || node.children.len() == 1)
-                    && node.children.len() > 0
+                let non_extra_children: Vec<_> =
+                    node.children.iter().filter(|c| !c.is_extra).collect();
+                if (node.kind().starts_with('_') || non_extra_children.len() == 1)
+                    && !non_extra_children.is_empty()
                 {
-                    return unwrap_hidden_rules(&node.children[0]);
+                    return unwrap_hidden_rules(non_extra_children[0]);
                 }
                 node
             }
@@ -79,7 +81,7 @@ mod grammar {
                     },
                 );
             }
-            if unwrapped_node.children.is_empty() {
+            if non_extra_children.is_empty() {
                 let node = unwrapped_node;
             }
             panic ! ("Could not determine enum variant from tree structure: node kind='{}', symbol={}, child_count={}" , unwrapped_node . kind () , unwrapped_node . symbol , unwrapped_node . children . len ())

--- a/macro/src/snapshots/adze_macro__tests__enum_with_named_field.snap
+++ b/macro/src/snapshots/adze_macro__tests__enum_with_named_field.snap
@@ -18,11 +18,16 @@ mod grammar {
         ) -> Self {
             let node = node.expect("Extract called with None node for enum");
             fn unwrap_hidden_rules(node: ::adze::tree_sitter::Node) -> ::adze::tree_sitter::Node {
-                if (node.kind().starts_with('_') || node.child_count() == 1)
-                    && node.child_count() > 0
+                let mut cursor = node.walk();
+                let non_extra_children: Vec<_> = node
+                    .children(&mut cursor)
+                    .filter(|c| !c.is_extra())
+                    .collect();
+                if (node.kind().starts_with('_') || non_extra_children.len() == 1)
+                    && !non_extra_children.is_empty()
                 {
-                    if let Some(child) = node.child(0) {
-                        return unwrap_hidden_rules(child);
+                    if let Some(child) = non_extra_children.first() {
+                        return unwrap_hidden_rules(*child);
                     }
                 }
                 node

--- a/macro/src/snapshots/adze_macro__tests__enum_with_named_field__pure_rust.snap
+++ b/macro/src/snapshots/adze_macro__tests__enum_with_named_field__pure_rust.snap
@@ -21,10 +21,12 @@ mod grammar {
             fn unwrap_hidden_rules<'a>(
                 node: &'a ::adze::pure_parser::ParsedNode,
             ) -> &'a ::adze::pure_parser::ParsedNode {
-                if (node.kind().starts_with('_') || node.children.len() == 1)
-                    && node.children.len() > 0
+                let non_extra_children: Vec<_> =
+                    node.children.iter().filter(|c| !c.is_extra).collect();
+                if (node.kind().starts_with('_') || non_extra_children.len() == 1)
+                    && !non_extra_children.is_empty()
                 {
-                    return unwrap_hidden_rules(&node.children[0]);
+                    return unwrap_hidden_rules(non_extra_children[0]);
                 }
                 node
             }
@@ -67,7 +69,7 @@ mod grammar {
                     },
                 );
             }
-            if unwrapped_node.children.is_empty() {
+            if non_extra_children.is_empty() {
                 let node = unwrapped_node;
                 return {
                     let value = <adze::WithLeaf<u32> as ::adze::Extract<_>>::extract(

--- a/macro/src/snapshots/adze_macro__tests__enum_with_unamed_vector.snap
+++ b/macro/src/snapshots/adze_macro__tests__enum_with_unamed_vector.snap
@@ -43,11 +43,16 @@ mod grammar {
         ) -> Self {
             let node = node.expect("Extract called with None node for enum");
             fn unwrap_hidden_rules(node: ::adze::tree_sitter::Node) -> ::adze::tree_sitter::Node {
-                if (node.kind().starts_with('_') || node.child_count() == 1)
-                    && node.child_count() > 0
+                let mut cursor = node.walk();
+                let non_extra_children: Vec<_> = node
+                    .children(&mut cursor)
+                    .filter(|c| !c.is_extra())
+                    .collect();
+                if (node.kind().starts_with('_') || non_extra_children.len() == 1)
+                    && !non_extra_children.is_empty()
                 {
-                    if let Some(child) = node.child(0) {
-                        return unwrap_hidden_rules(child);
+                    if let Some(child) = non_extra_children.first() {
+                        return unwrap_hidden_rules(*child);
                     }
                 }
                 node

--- a/macro/src/snapshots/adze_macro__tests__enum_with_unamed_vector__pure_rust.snap
+++ b/macro/src/snapshots/adze_macro__tests__enum_with_unamed_vector__pure_rust.snap
@@ -47,10 +47,12 @@ mod grammar {
             fn unwrap_hidden_rules<'a>(
                 node: &'a ::adze::pure_parser::ParsedNode,
             ) -> &'a ::adze::pure_parser::ParsedNode {
-                if (node.kind().starts_with('_') || node.children.len() == 1)
-                    && node.children.len() > 0
+                let non_extra_children: Vec<_> =
+                    node.children.iter().filter(|c| !c.is_extra).collect();
+                if (node.kind().starts_with('_') || non_extra_children.len() == 1)
+                    && !non_extra_children.is_empty()
                 {
-                    return unwrap_hidden_rules(&node.children[0]);
+                    return unwrap_hidden_rules(non_extra_children[0]);
                 }
                 node
             }
@@ -77,7 +79,7 @@ mod grammar {
                     },
                 );
             }
-            if unwrapped_node.children.is_empty() {
+            if non_extra_children.is_empty() {
                 let node = unwrapped_node;
             }
             panic ! ("Could not determine enum variant from tree structure: node kind='{}', symbol={}, child_count={}" , unwrapped_node . kind () , unwrapped_node . symbol , unwrapped_node . children . len ())

--- a/macro/src/snapshots/adze_macro__tests__grammar_unboxed_field.snap
+++ b/macro/src/snapshots/adze_macro__tests__grammar_unboxed_field.snap
@@ -39,11 +39,16 @@ mod grammar {
         ) -> Self {
             let node = node.expect("Extract called with None node for enum");
             fn unwrap_hidden_rules(node: ::adze::tree_sitter::Node) -> ::adze::tree_sitter::Node {
-                if (node.kind().starts_with('_') || node.child_count() == 1)
-                    && node.child_count() > 0
+                let mut cursor = node.walk();
+                let non_extra_children: Vec<_> = node
+                    .children(&mut cursor)
+                    .filter(|c| !c.is_extra())
+                    .collect();
+                if (node.kind().starts_with('_') || non_extra_children.len() == 1)
+                    && !non_extra_children.is_empty()
                 {
-                    if let Some(child) = node.child(0) {
-                        return unwrap_hidden_rules(child);
+                    if let Some(child) = non_extra_children.first() {
+                        return unwrap_hidden_rules(*child);
                     }
                 }
                 node

--- a/macro/src/snapshots/adze_macro__tests__grammar_unboxed_field__pure_rust.snap
+++ b/macro/src/snapshots/adze_macro__tests__grammar_unboxed_field__pure_rust.snap
@@ -43,10 +43,12 @@ mod grammar {
             fn unwrap_hidden_rules<'a>(
                 node: &'a ::adze::pure_parser::ParsedNode,
             ) -> &'a ::adze::pure_parser::ParsedNode {
-                if (node.kind().starts_with('_') || node.children.len() == 1)
-                    && node.children.len() > 0
+                let non_extra_children: Vec<_> =
+                    node.children.iter().filter(|c| !c.is_extra).collect();
+                if (node.kind().starts_with('_') || non_extra_children.len() == 1)
+                    && !non_extra_children.is_empty()
                 {
-                    return unwrap_hidden_rules(&node.children[0]);
+                    return unwrap_hidden_rules(non_extra_children[0]);
                 }
                 node
             }
@@ -72,7 +74,7 @@ mod grammar {
                     Expression::Number(value)
                 };
             }
-            if unwrapped_node.children.is_empty() {
+            if non_extra_children.is_empty() {
                 let node = unwrapped_node;
                 return {
                     let value = <adze::WithLeaf<i32> as ::adze::Extract<_>>::extract(

--- a/macro/src/snapshots/adze_macro__tests__leaf_text_literal.snap
+++ b/macro/src/snapshots/adze_macro__tests__leaf_text_literal.snap
@@ -18,11 +18,16 @@ mod grammar {
         ) -> Self {
             let node = node.expect("Extract called with None node for enum");
             fn unwrap_hidden_rules(node: ::adze::tree_sitter::Node) -> ::adze::tree_sitter::Node {
-                if (node.kind().starts_with('_') || node.child_count() == 1)
-                    && node.child_count() > 0
+                let mut cursor = node.walk();
+                let non_extra_children: Vec<_> = node
+                    .children(&mut cursor)
+                    .filter(|c| !c.is_extra())
+                    .collect();
+                if (node.kind().starts_with('_') || non_extra_children.len() == 1)
+                    && !non_extra_children.is_empty()
                 {
-                    if let Some(child) = node.child(0) {
-                        return unwrap_hidden_rules(child);
+                    if let Some(child) = non_extra_children.first() {
+                        return unwrap_hidden_rules(*child);
                     }
                 }
                 node

--- a/macro/src/snapshots/adze_macro__tests__leaf_text_literal__pure_rust.snap
+++ b/macro/src/snapshots/adze_macro__tests__leaf_text_literal__pure_rust.snap
@@ -21,10 +21,12 @@ mod grammar {
             fn unwrap_hidden_rules<'a>(
                 node: &'a ::adze::pure_parser::ParsedNode,
             ) -> &'a ::adze::pure_parser::ParsedNode {
-                if (node.kind().starts_with('_') || node.children.len() == 1)
-                    && node.children.len() > 0
+                let non_extra_children: Vec<_> =
+                    node.children.iter().filter(|c| !c.is_extra).collect();
+                if (node.kind().starts_with('_') || non_extra_children.len() == 1)
+                    && !non_extra_children.is_empty()
                 {
-                    return unwrap_hidden_rules(&node.children[0]);
+                    return unwrap_hidden_rules(non_extra_children[0]);
                 }
                 node
             }
@@ -65,7 +67,7 @@ mod grammar {
                     },
                 );
             }
-            if unwrapped_node.children.is_empty() {
+            if non_extra_children.is_empty() {
                 let node = unwrapped_node;
             }
             panic ! ("Could not determine enum variant from tree structure: node kind='{}', symbol={}, child_count={}" , unwrapped_node . kind () , unwrapped_node . symbol , unwrapped_node . children . len ())

--- a/macro/src/snapshots/adze_macro__tests__struct_extra.snap
+++ b/macro/src/snapshots/adze_macro__tests__struct_extra.snap
@@ -17,11 +17,16 @@ mod grammar {
         ) -> Self {
             let node = node.expect("Extract called with None node for enum");
             fn unwrap_hidden_rules(node: ::adze::tree_sitter::Node) -> ::adze::tree_sitter::Node {
-                if (node.kind().starts_with('_') || node.child_count() == 1)
-                    && node.child_count() > 0
+                let mut cursor = node.walk();
+                let non_extra_children: Vec<_> = node
+                    .children(&mut cursor)
+                    .filter(|c| !c.is_extra())
+                    .collect();
+                if (node.kind().starts_with('_') || non_extra_children.len() == 1)
+                    && !non_extra_children.is_empty()
                 {
-                    if let Some(child) = node.child(0) {
-                        return unwrap_hidden_rules(child);
+                    if let Some(child) = non_extra_children.first() {
+                        return unwrap_hidden_rules(*child);
                     }
                 }
                 node

--- a/macro/src/snapshots/adze_macro__tests__struct_extra__pure_rust.snap
+++ b/macro/src/snapshots/adze_macro__tests__struct_extra__pure_rust.snap
@@ -20,10 +20,12 @@ mod grammar {
             fn unwrap_hidden_rules<'a>(
                 node: &'a ::adze::pure_parser::ParsedNode,
             ) -> &'a ::adze::pure_parser::ParsedNode {
-                if (node.kind().starts_with('_') || node.children.len() == 1)
-                    && node.children.len() > 0
+                let non_extra_children: Vec<_> =
+                    node.children.iter().filter(|c| !c.is_extra).collect();
+                if (node.kind().starts_with('_') || non_extra_children.len() == 1)
+                    && !non_extra_children.is_empty()
                 {
-                    return unwrap_hidden_rules(&node.children[0]);
+                    return unwrap_hidden_rules(non_extra_children[0]);
                 }
                 node
             }
@@ -49,7 +51,7 @@ mod grammar {
                     Expression::Number(value)
                 };
             }
-            if unwrapped_node.children.is_empty() {
+            if non_extra_children.is_empty() {
                 let node = unwrapped_node;
                 return {
                     let value = <adze::WithLeaf<i32> as ::adze::Extract<_>>::extract(

--- a/runtime/src/__private.rs
+++ b/runtime/src/__private.rs
@@ -201,6 +201,19 @@ pub fn extract_field<LT: Extract<T>, T>(
                 } else {
                     return LT::extract(None, source, *last_idx, closure_ref);
                 }
+            } else if field_name
+                .parse::<usize>()
+                .is_ok_and(|idx| idx == cursor.current_index)
+            {
+                let out = LT::extract(Some(n), source, *last_idx, closure_ref);
+
+                if !cursor.goto_next_sibling() {
+                    *cursor_opt = None;
+                }
+
+                *last_idx = n.end_byte;
+
+                return out;
             } else {
                 *last_idx = n.end_byte;
             }
@@ -411,21 +424,19 @@ fn parse_with_glr<T: Extract<T>>(
     input: &str,
     language: impl Fn() -> &'static crate::pure_parser::TSLanguage,
 ) -> core::result::Result<T, Vec<crate::errors::ParseError>> {
-    // GLR Parser Integration (In Progress)
-    //
-    // Current Status:
-    // ✅ parser_v4 module exists with GLR fork/merge logic
-    // ✅ parser_v4::from_language() can load from TSLanguage structs
-    // ✅ parser_v4::parse() now returns an arena-backed Tree
-    // ✅ parser_v4::parse_tree() returns ParseNode for conversion
-    //
-    // Design Note:
-    // parser_v4::parse() now returns Tree for callers that need tree-shaped APIs,
-    // while parse_tree() is used by typed extraction.
     use crate::parser_v4::Parser;
+    use adze_glr_core::conflict_inspection::state_has_conflicts;
+    use adze_ir::StateId;
 
-    // Get the language
+    // Get the language and inspect the parse table for real conflicts.
     let lang = language();
+    let parse_table = crate::decoder::decode_parse_table(lang);
+    let has_conflicts = (0..parse_table.state_count)
+        .any(|state| state_has_conflicts(&parse_table, StateId(state as u16)));
+
+    if has_conflicts {
+        return parse_with_true_glr_runtime::<T>(input, lang, parse_table);
+    }
 
     // Create parser from TSLanguage with the correct grammar name for external scanner lookup
     let mut parser = Parser::from_language(lang, T::GRAMMAR_NAME.to_string());
@@ -469,6 +480,123 @@ fn parse_with_glr<T: Extract<T>>(
         0,
         None,
     ))
+}
+
+#[cfg(all(feature = "glr", feature = "pure-rust"))]
+fn parse_with_true_glr_runtime<T: Extract<T>>(
+    input: &str,
+    language: &'static crate::pure_parser::TSLanguage,
+    parse_table: adze_glr_core::ParseTable,
+) -> core::result::Result<T, Vec<crate::errors::ParseError>> {
+    let source = input.as_bytes();
+    let grammar = crate::decoder::decode_grammar(language);
+    let mut lexer = match crate::glr_lexer::GLRLexer::new(&grammar, input.to_string()) {
+        Ok(lexer) => lexer,
+        Err(message) => {
+            return Err(vec![crate::errors::ParseError {
+                reason: crate::errors::ParseErrorReason::UnexpectedToken(message),
+                start: 0,
+                end: source.len(),
+            }]);
+        }
+    };
+
+    let mut parser = crate::glr_parser::GLRParser::new(parse_table, grammar);
+
+    while let Some(token) = lexer.next_token() {
+        parser.process_token(token.symbol_id, &token.text, token.byte_offset);
+    }
+
+    parser.process_eof(source.len());
+    let root_node = match parser.finish() {
+        Ok(root_node) => root_node,
+        Err(message) => {
+            return Err(vec![crate::errors::ParseError {
+                reason: crate::errors::ParseErrorReason::UnexpectedToken(message),
+                start: 0,
+                end: source.len(),
+            }]);
+        }
+    };
+
+    let parsed_node = convert_subtree_to_pure(&root_node, language, source);
+    let non_extra_root_children: Vec<_> = parsed_node
+        .children
+        .iter()
+        .filter(|c| !c.is_extra)
+        .collect();
+    let extract_node = if parsed_node.kind() == "source_file" && non_extra_root_children.len() == 1
+    {
+        non_extra_root_children[0]
+    } else {
+        &parsed_node
+    };
+
+    if extract_node.has_error() {
+        let mut errors = vec![];
+        crate::errors::collect_parsing_errors(extract_node, source, &mut errors);
+        if !errors.is_empty() {
+            return Err(errors);
+        }
+    }
+
+    Ok(<T as crate::Extract<_>>::extract(
+        Some(extract_node),
+        source,
+        0,
+        None,
+    ))
+}
+
+#[cfg(all(feature = "glr", feature = "pure-rust"))]
+fn convert_subtree_to_pure(
+    subtree: &crate::subtree::Subtree,
+    language: &'static crate::pure_parser::TSLanguage,
+    source: &[u8],
+) -> crate::pure_parser::ParsedNode {
+    let is_named = if (subtree.node.symbol_id.0 as usize) < language.symbol_count as usize
+        && !language.symbol_metadata.is_null()
+    {
+        // SAFETY: `symbol_metadata` is a pointer to `symbol_count` entries.
+        // `subtree.node.symbol_id` was checked to be in bounds above.
+        let metadata = unsafe {
+            *language
+                .symbol_metadata
+                .add(subtree.node.symbol_id.0 as usize)
+        };
+        (metadata & 0x02) != 0
+    } else {
+        true
+    };
+
+    let children = subtree
+        .children
+        .iter()
+        .map(|child| {
+            let mut parsed_child = convert_subtree_to_pure(&child.subtree, language, source);
+            parsed_child.field_id = if child.field_id == crate::subtree::FIELD_NONE {
+                None
+            } else {
+                Some(child.field_id)
+            };
+            parsed_child
+        })
+        .collect();
+
+    crate::pure_parser::ParsedNode {
+        symbol: subtree.node.symbol_id.0,
+        children,
+        start_byte: subtree.node.byte_range.start,
+        end_byte: subtree.node.byte_range.end,
+        start_point: byte_to_point(source, subtree.node.byte_range.start),
+        end_point: byte_to_point(source, subtree.node.byte_range.end),
+        is_extra: false,
+        is_error: subtree.node.is_error,
+        is_missing: false,
+        is_named,
+        field_id: None,
+        language: Some(language as *const _),
+    }
 }
 
 /// Convert parser_v4::ParseNode to pure_parser::ParsedNode

--- a/runtime/src/decoder.rs
+++ b/runtime/src/decoder.rs
@@ -622,7 +622,6 @@ pub fn decode_grammar_with_patterns(
 }
 
 fn decode_rules(lang: &TSLanguage) -> Vec<ParseRule> {
-    const DEBUG_RULE_PRINT_LIMIT: usize = 5;
     let production_count = lang.production_count as usize;
 
     // Prevent excessive allocations to avoid DoS
@@ -835,10 +834,11 @@ pub fn decode_parse_table(lang: &'static TSLanguage) -> ParseTable {
 
                 if action_idx != 0 {
                     let raw = &*lang.parse_actions.add(action_idx as usize);
-                    if raw.extra != 0 && raw.action_type == TSActionTag::Shift as u8 {
-                        if let Some(&sym) = index_to_symbol.get(symbol) {
-                            extras_set.insert(sym);
-                        }
+                    if raw.extra != 0
+                        && raw.action_type == TSActionTag::Shift as u8
+                        && let Some(&sym) = index_to_symbol.get(symbol)
+                    {
+                        extras_set.insert(sym);
                     }
                     decode_action(raw, &rules, &rid_by_pair)
                 } else {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -425,11 +425,7 @@ impl<L> Extract<L> for WithLeaf<L> {
         leaf_fn: Option<&Self::LeafFn>,
     ) -> L {
         let text = node
-            .and_then(|n| {
-                // Extract text from node's byte range
-                let text = &source[n.start_byte..n.end_byte];
-                std::str::from_utf8(text).ok()
-            })
+            .and_then(|n| pure_node_leaf_text(n, source))
             .unwrap_or_default();
 
         if let Some(f) = leaf_fn {
@@ -440,6 +436,22 @@ impl<L> Extract<L> for WithLeaf<L> {
             )
         }
     }
+}
+
+#[cfg(feature = "pure-rust")]
+fn pure_node_leaf_text<'a>(
+    node: &crate::pure_parser::ParsedNode,
+    source: &'a [u8],
+) -> Option<&'a str> {
+    let end = node
+        .children
+        .iter()
+        .filter(|child| child.is_extra)
+        .map(|child| child.start_byte)
+        .min()
+        .unwrap_or(node.end_byte);
+    let text = source.get(node.start_byte..end)?;
+    std::str::from_utf8(text).ok()
 }
 
 #[cfg(test)]
@@ -1083,13 +1095,9 @@ impl Extract<String> for String {
         _last_idx: usize,
         _leaf_fn: Option<&Self::LeafFn>,
     ) -> String {
-        node.and_then(|n| {
-            // Extract text from node's byte range
-            let text = &source[n.start_byte..n.end_byte];
-            std::str::from_utf8(text).ok()
-        })
-        .unwrap_or_default()
-        .to_string()
+        node.and_then(|n| pure_node_leaf_text(n, source))
+            .unwrap_or_default()
+            .to_string()
     }
 }
 
@@ -1117,12 +1125,9 @@ macro_rules! impl_extract_for_primitive {
                 _last_idx: usize,
                 _leaf_fn: Option<&Self::LeafFn>,
             ) -> $t {
-                node.and_then(|n| {
-                    let text = &source[n.start_byte..n.end_byte];
-                    std::str::from_utf8(text).ok()
-                })
-                .and_then(|s| s.parse().ok())
-                .unwrap_or_default()
+                node.and_then(|n| pure_node_leaf_text(n, source))
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or_default()
             }
         }
     };

--- a/runtime/tests/test_table_invariants.rs
+++ b/runtime/tests/test_table_invariants.rs
@@ -308,7 +308,6 @@ fn test_accept_goto_shape() {
                 .any(|a| matches!(a, Action::Accept)),
             "Accept state shape not preserved after decode"
         );
-    } else {
     }
 }
 
@@ -332,13 +331,7 @@ fn test_eof_column_placement() {
         .symbol_to_index
         .get(&eof)
         .expect("EOF col missing");
-    let tcols = (decoded_table.token_count + decoded_table.external_token_count) as usize;
-
-    // This is a soft invariant - some grammars might place EOF elsewhere
-    // But for standard grammars, EOF should be within the token band
-    if eof_col >= tcols {
-    } else {
-    }
+    let _ = eof_col;
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Routes conflicted pure-rust parse tables through the true GLR runtime instead of leaving parser_v4 as a permanent stop sign.

Also tightens the extraction boundary needed by the GLR/parser_v4 product spine:

- preserves field IDs when converting GLR `Subtree` values into `ParsedNode`
- unwraps GLR `source_file` roots before typed extraction
- supports positional tuple extraction for generated unnamed fields
- handles pure-rust leaf text when extras are nested under token wrapper nodes
- updates generated enum wrapper handling to ignore extras when selecting the meaningful variant child

## Why

`#405` made parser_v4 honest by refusing conflicted tables. This follows through with real GLR routing for conflicted tables while keeping conflict-free grammars on the deterministic parser_v4 path.

The root extraction failure was the typed enum path receiving a missing/wrong child shape after pure-rust parsing. The fix makes the parser tree shape line up with generated enum extraction and preserves field metadata through the remaining conversion path.

## Validation

- `cargo test -p adze --features glr --test test_parser_routing -- --nocapture`
- `cargo test -p adze --features glr --test test_e2e_ambiguous_grammar_glr -- --nocapture`
- `cargo test -p adze field -- --nocapture`
- `cargo test -p adze --test extract_trait_v9 field -- --nocapture`
- `cargo test -p adze --test extract_trait_v9 -- --nocapture`
- `cargo test -p adze-macro --no-run`
- `cargo fmt --all --check`

## Known residual

`cargo test -p adze-glr-core --all-features` still has existing EOF parse-table validation failures in `driver_api_comprehensive`. The focused GLR conflict properties `pt38` and `pt82` passed locally before this PR.
