### PR TITLE
[codex] test: add typed AST exact-value contract

### DIFF
--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -19,6 +19,7 @@ pub mod regex_grammar;
 pub mod repetitions;
 pub mod test_precedence;
 pub mod test_whitespace;
+pub mod typed_ast_contract;
 pub mod words;
 
 // Tree-sitter compatibility language helpers

--- a/example/src/typed_ast_contract.rs
+++ b/example/src/typed_ast_contract.rs
@@ -1,0 +1,17 @@
+#[adze::grammar("typed_ast_contract")]
+pub mod grammar {
+    #[derive(Debug, PartialEq, Eq)]
+    #[adze::language]
+    pub enum Expr {
+        Number(#[adze::leaf(pattern = r"\d+", transform = |s| s.parse::<i32>().unwrap())] i32),
+
+        #[adze::prec_left(1)]
+        Add(Box<Expr>, #[adze::leaf(text = "+")] (), Box<Expr>),
+    }
+
+    #[adze::extra]
+    struct Whitespace {
+        #[adze::leaf(pattern = r"\s")]
+        _ws: (),
+    }
+}

--- a/runtime/tests/typed_ast_contract.rs
+++ b/runtime/tests/typed_ast_contract.rs
@@ -1,0 +1,18 @@
+#[test]
+fn typed_ast_contract_left_associative_addition() {
+    let parsed = adze_example::typed_ast_contract::grammar::parse("1 + 2 + 3")
+        .expect("input should parse into Expr");
+
+    assert_eq!(
+        parsed,
+        adze_example::typed_ast_contract::grammar::Expr::Add(
+            Box::new(adze_example::typed_ast_contract::grammar::Expr::Add(
+                Box::new(adze_example::typed_ast_contract::grammar::Expr::Number(1)),
+                (),
+                Box::new(adze_example::typed_ast_contract::grammar::Expr::Number(2)),
+            )),
+            (),
+            Box::new(adze_example::typed_ast_contract::grammar::Expr::Number(3)),
+        )
+    );
+}

--- a/test-mini/src/lib.rs
+++ b/test-mini/src/lib.rs
@@ -22,6 +22,7 @@ pub mod typed_ast {
     }
 
     #[adze::extra]
+    #[allow(dead_code)]
     struct Whitespace {
         #[adze::leaf(pattern = r"\s")]
         _ws: (),

--- a/test-mini/src/lib.rs
+++ b/test-mini/src/lib.rs
@@ -10,9 +10,27 @@ pub mod grammar {
     }
 }
 
+#[adze::grammar("typed_ast_contract")]
+pub mod typed_ast {
+    #[derive(Debug, PartialEq, Eq)]
+    #[adze::language]
+    pub enum Expr {
+        Number(#[adze::leaf(pattern = r"\d+", transform = |s| s.parse::<i32>().unwrap())] i32),
+
+        #[adze::prec_left(1)]
+        Add(Box<Expr>, #[adze::leaf(text = "+")] (), Box<Expr>),
+    }
+
+    #[adze::extra]
+    struct Whitespace {
+        #[adze::leaf(pattern = r"\s")]
+        _ws: (),
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::grammar;
+    use crate::{grammar, typed_ast};
 
     #[test]
     fn test_number() {
@@ -61,5 +79,23 @@ mod tests {
         assert!(result.is_ok());
         let program: grammar::Program = result.unwrap();
         assert_eq!(program.number, "42");
+    }
+
+    #[test]
+    fn typed_ast_left_associative_addition_contract() {
+        let parsed = typed_ast::parse("1 + 2 + 3").expect("typed AST parse should succeed");
+
+        assert_eq!(
+            parsed,
+            typed_ast::Expr::Add(
+                Box::new(typed_ast::Expr::Add(
+                    Box::new(typed_ast::Expr::Number(1)),
+                    (),
+                    Box::new(typed_ast::Expr::Number(2)),
+                )),
+                (),
+                Box::new(typed_ast::Expr::Number(3)),
+            )
+        );
     }
 }


### PR DESCRIPTION
## Summary

Adds unignored exact-value typed AST contracts for the minimal recursive expression grammar.

The contract proves:

```rust
parse("1 + 2 + 3") == Expr::Add(
    Box::new(Expr::Add(
        Box::new(Expr::Number(1)),
        (),
        Box::new(Expr::Number(2)),
    )),
    (),
    Box::new(Expr::Number(3)),
)
```

## Why

The older typed-AST PR family added useful canaries, but the strongest product proof is an unignored exact Rust value assertion. This PR keeps that proof in both the runtime integration surface and the `test-mini` canary so the documented commands run real tests.

This PR is stacked on the true-GLR routing/extraction branch because the contract depends on the extraction fixes there.

## Validation

- `cargo test -p adze --test typed_ast_contract -- --nocapture`
- `cargo test -p test-mini typed_ast -- --nocapture`
- `cargo test -p adze-macro --no-run`
- `cargo test -p adze-tool --no-run`
- `cargo fmt --all --check`
