### PR TITLE
tool: keep grammar.js builder stable under all-features

### DIFF
--- a/tool/src/pure_rust_builder.rs
+++ b/tool/src/pure_rust_builder.rs
@@ -318,13 +318,14 @@ pub fn build_parser_from_grammar_js(
 
     // Grammar converted successfully
 
-    #[cfg(feature = "optimize")]
-    let grammar = {
-        use adze_ir::optimizer::optimize_grammar;
-        optimize_grammar(grammar).context("Failed to optimize grammar")?
-    };
-
-    // Grammar optimized successfully
+    // TODO: Re-enable optimization after fixing unit rule elimination.
+    //
+    // The grammar.js path produces pattern-wrapper unit productions such as
+    // `source -> item` and `item -> TOKEN`. The current optimizer can remove
+    // those unit productions without preserving an equivalent start rule,
+    // leaving a grammar with tokens but no rules under `--all-features`.
+    // Keep this aligned with `build_parser_from_json` until that optimizer
+    // behavior is fixed.
 
     // Build the parser
     build_parser(grammar, options)


### PR DESCRIPTION
## What changed
- Keeps the grammar.js pure-Rust builder path aligned with the JSON builder by not running the current optional optimizer there.
- Documents why: the optimizer can eliminate pattern-wrapper unit productions under `--all-features`, leaving tokens but no rules for simple grammar.js inputs.

## Why
Current main CI coverage/all-features failed in `adze-tool --test build_pipeline` with:

```text
Failed to build LR(1) automaton: Grammar error: Unresolved symbol reference: Symbol(0)
Grammar stats: 1 tokens, 0 rules, 0 externals
```

## Proof
- `cargo test -p adze-tool --all-features --test build_pipeline -- --nocapture`
- `cargo fmt --all --check`
- local pre-commit test connectivity/goto checks passed
