### PR TITLE
ci: stabilize nextest connectivity counting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -941,10 +941,10 @@ jobs:
       - name: List discovered tests (${{ matrix.features || 'default-features' }})
         run: |
           set -e
-          cargo nextest list --workspace ${{ matrix.features }} > .nextest-list.txt
+          cargo nextest list --workspace ${{ matrix.features }} --message-format oneline > .nextest-list.txt
           echo "### Discovered tests for feature set: ${{ matrix.features || 'default' }}"
           head -200 .nextest-list.txt || true
-          COUNT=$(grep -E '^\s+(test|bench|example)' .nextest-list.txt | wc -l | tr -d ' ')
+          COUNT=$(grep -cve '^[[:space:]]*$' .nextest-list.txt)
           echo "TOTAL_DISCOVERED_TESTS=$COUNT" >> $GITHUB_ENV
           echo "Total discovered: $COUNT tests"
 


### PR DESCRIPTION
What changed:
- Switch the test-connectivity tripwire to `cargo nextest list --message-format oneline`.
- Count non-empty oneline entries instead of grepping the old human-output category format.

Why:
- Current `main` failed `Test Connectivity (Tripwires)` with `No tests discovered with feature set: ''` even though nextest printed discovered tests. The regex no longer matched nextest output.

Proof:
- `cargo nextest list --workspace --message-format oneline` discovered 64841 tests locally.
- `cargo fmt --all --check`
- repository pre-push checks passed before push; the first push was interrupted after checks by an SSH connection close, then pushed with `--no-verify` without code changes.