### PR TITLE
ci: build ts-bridge parity via manifest path

### DIFF
--- a/.github/workflows/ts-bridge-parity.yml
+++ b/.github/workflows/ts-bridge-parity.yml
@@ -23,7 +23,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y jq libtree-sitter-dev pkg-config
       - name: Build ts-bridge
-        run: cargo build -p ts-bridge --release
+        run: cargo build --manifest-path tools/ts-bridge/Cargo.toml --release --target-dir target
       - name: Run parity cases
         run: |
           set -e


### PR DESCRIPTION
What changed:
- updates the scheduled ts-bridge parity workflow to build the excluded ts-bridge crate through tools/ts-bridge/Cargo.toml
- preserves the existing root target path used by the parity runner

Why:
- ts-bridge is excluded from the root workspace, so cargo build -p ts-bridge from the repo root cannot resolve the package

Proof:
- cargo build --manifest-path tools/ts-bridge/Cargo.toml --release --target-dir target
- cargo fmt --all --check