### PR TITLE
ci: install wasm target for product-proof canary

### DIFF
--- a/.github/workflows/product-proof.yml
+++ b/.github/workflows/product-proof.yml
@@ -21,6 +21,11 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
+      - name: Ensure workspace toolchain has WASM target
+        run: |
+          TOOLCHAIN="$(sed -n 's/^channel = "\(.*\)"$/\1/p' rust-toolchain.toml)"
+          rustup target add --toolchain "$TOOLCHAIN" wasm32-unknown-unknown
+
       - uses: Swatinem/rust-cache@v2
 
       - name: Show canary plan (dry-run)


### PR DESCRIPTION
## What changed\n- Explicitly installs wasm32-unknown-unknown for the pinned workspace toolchain before running the advisory product-proof canaries.\n\n## Why\n- The first manual product-proof run reached the wasm-demo canary and failed with E0463 because the target was not installed for the rust-toolchain.toml toolchain.\n\n## Proof\n- git diff --check\n- bash -n scripts/ci-product.sh\n