### PR TITLE
test(runtime): align incremental GLR reuse counter invariant

### DIFF
--- a/runtime/tests/glr_incremental_comprehensive.rs
+++ b/runtime/tests/glr_incremental_comprehensive.rs
@@ -694,7 +694,10 @@ mod tests {
         reset_reuse_counter();
         let f = p.parse_incremental(&new_toks, &[edit]).unwrap();
         assert!(!f.alternatives.is_empty());
-        assert!(get_reuse_count() <= new_toks.len());
+        assert!(
+            get_reuse_count() > 0,
+            "compatible incremental edit should reuse at least one subtree"
+        );
     }
 
     // ─── Test 23: Parse error on invalid input ──────────────────────


### PR DESCRIPTION
## What changed\n- Updates the incremental GLR reuse-counter test to assert semantic reuse instead of bounding reused subtree count by token count.\n\n## Why\n-  counts reused forest/subtree nodes, not newly supplied tokens. Coverage currently exposes this as .\n\n## Proof\n- cargo test -p adze --features "pure-rust,glr,incremental_glr,external_scanners,serialization,ts-compat" --test glr_incremental_comprehensive test_reuse_counter_on_incremental -- --nocapture\n- cargo test -p adze --features "pure-rust,glr,incremental_glr,external_scanners,serialization,ts-compat" --test glr_incremental_comprehensive -- --nocapture\n- cargo fmt --all --check\n