### PR TITLE
runtime: harden GLR lexer against recursive invalid-byte handling

### DIFF
--- a/runtime/src/__private.rs
+++ b/runtime/src/__private.rs
@@ -506,6 +506,15 @@ fn parse_with_true_glr_runtime<T: Extract<T>>(
     while let Some(token) = lexer.next_token() {
         parser.process_token(token.symbol_id, &token.text, token.byte_offset);
     }
+    if let Some((start, end)) = lexer.invalid_span() {
+        return Err(vec![crate::errors::ParseError {
+            reason: crate::errors::ParseErrorReason::UnexpectedToken(
+                "unexpected token while lexing".to_string(),
+            ),
+            start,
+            end,
+        }]);
+    }
 
     parser.process_eof(source.len());
     let root_node = match parser.finish() {

--- a/runtime/src/glr_lexer.rs
+++ b/runtime/src/glr_lexer.rs
@@ -25,6 +25,8 @@ pub struct GLRLexer {
     input: String,
     /// Current position in input
     position: usize,
+    /// First invalid byte span encountered during lexing
+    invalid_span: Option<(usize, usize)>,
 }
 
 /// Token matching strategy
@@ -116,92 +118,84 @@ impl GLRLexer {
             token_patterns,
             input,
             position: 0,
+            invalid_span: None,
         })
     }
 
     /// Get the next token from input
     pub fn next_token(&mut self) -> Option<TokenWithPosition> {
-        // Skip whitespace
-        self.skip_whitespace();
+        loop {
+            // Skip whitespace
+            self.skip_whitespace();
 
-        if self.position >= self.input.len() {
-            return None;
-        }
-
-        let start_pos = self.position;
-
-        // Try each token pattern
-        for (symbol_id, matcher) in &self.token_patterns {
-            if let Some(len) = matcher.matches_at(&self.input, self.position) {
-                if len == 0 {
-                    // Defensive no-progress guard for any future matcher regressions.
-                    self.position += 1;
-                    return self.next_token();
-                }
-                // Ensure we're not splitting a UTF-8 sequence
-                let end_pos = self.position + len;
-                if !self.input.is_char_boundary(end_pos) {
-                    continue;
-                }
-
-                let text = self.input[self.position..end_pos].to_string();
-                self.position = end_pos;
-
-                return Some(TokenWithPosition {
-                    symbol_id: *symbol_id,
-                    text,
-                    byte_offset: start_pos,
-                    byte_length: len,
-                });
+            if self.position >= self.input.len() {
+                return None;
             }
-        }
 
-        // No token matched - skip one UTF-8 character and try again
-        // Find the next character boundary
-        let mut next_pos = self.position + 1;
-        while next_pos < self.input.len() && !self.input.is_char_boundary(next_pos) {
-            next_pos += 1;
-        }
-        self.position = next_pos;
+            let start_pos = self.position;
 
-        if self.position < self.input.len() {
-            self.next_token()
-        } else {
-            None
+            // Try each token pattern
+            for (symbol_id, matcher) in &self.token_patterns {
+                if let Some(len) = matcher.matches_at(&self.input, self.position) {
+                    if len == 0 {
+                        // Defensive no-progress guard for any future matcher regressions.
+                        self.position = self.advance_one_char(self.position);
+                        continue;
+                    }
+                    // Ensure we're not splitting a UTF-8 sequence
+                    let end_pos = self.position + len;
+                    if !self.input.is_char_boundary(end_pos) {
+                        continue;
+                    }
+
+                    let text = self.input[self.position..end_pos].to_string();
+                    self.position = end_pos;
+
+                    return Some(TokenWithPosition {
+                        symbol_id: *symbol_id,
+                        text,
+                        byte_offset: start_pos,
+                        byte_length: len,
+                    });
+                }
+            }
+
+            // No token matched - report the first invalid character span and stop lexing.
+            let end_pos = self.advance_one_char(self.position);
+            self.invalid_span.get_or_insert((start_pos, end_pos));
+            self.position = end_pos;
+            return None;
         }
     }
 
     /// Skip whitespace characters
     fn skip_whitespace(&mut self) {
-        let input_chars: Vec<char> = self.input.chars().collect();
-        let mut char_pos = 0;
-        let mut byte_pos = 0;
-
-        // Find current position in characters
-        for (i, ch) in self.input.chars().enumerate() {
-            if byte_pos >= self.position {
-                char_pos = i;
-                break;
-            }
-            byte_pos += ch.len_utf8();
-        }
-
-        // Skip whitespace characters
-        while char_pos < input_chars.len() {
-            match input_chars[char_pos] {
-                ' ' | '\t' | '\n' | '\r' => {
-                    self.position += input_chars[char_pos].len_utf8();
-                    char_pos += 1;
-                }
+        while self.position < self.input.len() {
+            match self.input.as_bytes()[self.position] {
+                b' ' | b'\t' | b'\n' | b'\r' => self.position += 1,
                 _ => break,
             }
         }
+    }
+
+    fn advance_one_char(&self, pos: usize) -> usize {
+        let mut next_pos = pos.saturating_add(1);
+        while next_pos < self.input.len() && !self.input.is_char_boundary(next_pos) {
+            next_pos += 1;
+        }
+        next_pos
+    }
+
+    /// Returns the first invalid byte range encountered while tokenizing.
+    pub fn invalid_span(&self) -> Option<(usize, usize)> {
+        self.invalid_span
     }
 
     /// Reset lexer to beginning
     #[allow(dead_code)]
     pub fn reset(&mut self) {
         self.position = 0;
+        self.invalid_span = None;
     }
 
     /// Get all tokens from input
@@ -393,9 +387,9 @@ mod tests {
         let mut lexer = GLRLexer::new(&grammar, input).unwrap();
         let tokens = lexer.tokenize_all();
 
-        // Should tokenize only the ASCII letters, skipping the emoji
-        assert_eq!(tokens.len(), 2);
+        // Lexer should stop at first unknown multibyte character
+        assert_eq!(tokens.len(), 1);
         assert_eq!(tokens[0].text, "a");
-        assert_eq!(tokens[1].text, "b");
+        assert_eq!(lexer.invalid_span(), Some((1, 5)));
     }
 }

--- a/runtime/src/glr_lexer.rs
+++ b/runtime/src/glr_lexer.rs
@@ -124,7 +124,7 @@ impl GLRLexer {
 
     /// Get the next token from input
     pub fn next_token(&mut self) -> Option<TokenWithPosition> {
-        loop {
+        'tokenize: loop {
             // Skip whitespace
             self.skip_whitespace();
 
@@ -140,7 +140,7 @@ impl GLRLexer {
                     if len == 0 {
                         // Defensive no-progress guard for any future matcher regressions.
                         self.position = self.advance_one_char(self.position);
-                        continue;
+                        continue 'tokenize;
                     }
                     // Ensure we're not splitting a UTF-8 sequence
                     let end_pos = self.position + len;

--- a/runtime/tests/lexer_tests.rs
+++ b/runtime/tests/lexer_tests.rs
@@ -591,7 +591,7 @@ fn error_recovering_lexer_fail_mode() {
 }
 
 #[test]
-fn glr_lexer_skips_unknown_and_continues() {
+fn glr_lexer_stops_at_unknown_input() {
     let mut grammar = Grammar::new("test".to_string());
     grammar.tokens.insert(
         SymbolId(1),
@@ -602,11 +602,11 @@ fn glr_lexer_skips_unknown_and_continues() {
         },
     );
 
-    // '@' is not matched — GLRLexer skips it and continues
+    // '@' is not matched — GLRLexer now stops at first unknown input
     let mut lexer = GLRLexer::new(&grammar, "@ 42".to_string()).unwrap();
     let tokens = lexer.tokenize_all();
-    assert_eq!(tokens.len(), 1);
-    assert_eq!(tokens[0].text, "42");
+    assert!(tokens.is_empty());
+    assert_eq!(lexer.invalid_span(), Some((0, 1)));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- A regression made true-GLR routing exercise `GLRLexer::next_token()` which used recursive retry + byte-skipping, enabling stack-exhaustion and silent dropping of attacker-controlled bytes. 
- `skip_whitespace` also rebuilt character vectors per call, worsening worst-case cost on large inputs.

### Description
- Replace recursive retry in `GLRLexer::next_token()` with an iterative loop to eliminate unbounded recursion and stack-growth risk. 
- Stop lexing at the first unmatched byte span instead of skipping bytes silently; record the span in a new `invalid_span` field on `GLRLexer` and expose it via `invalid_span()`. 
- Add `advance_one_char()` helper for correct UTF-8-aware single-character advancement and use it for no-progress guards and invalid-span calculation. 
- Replace expensive per-call `Vec<char>` allocation in `skip_whitespace()` with an in-place byte-scan that advances over ASCII whitespace. 
- Propagate lexer-detected invalid spans to the true-GLR parser path by returning a parse error from `parse_with_true_glr_runtime` when `lexer.invalid_span()` is set. 
- Update unit tests in `runtime/tests/lexer_tests.rs` and expectations in `runtime/src/glr_lexer.rs` to assert the new fail-fast behavior on unknown/multibyte input.

### Testing
- Ran `cargo test -p adze --test lexer_tests glr_lexer_stops_at_unknown_input` and it passed. 
- Ran `cargo test -p adze glr_lexer::tests::test_multibyte_character_handling` and it passed. 
- Ran `cargo fmt --all` to ensure formatting; it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f03cd43afc8333bec59a90157ae693)