### PR TITLE
Stabilize Codecov upload, add advisory `codecov.yml`, and persist `lcov.info` artifact

### DIFF
--- a/.github/CI_README.md
+++ b/.github/CI_README.md
@@ -116,12 +116,21 @@ cargo +nightly fuzz run fuzz_external_scanner
 
 ## Coverage
 
-Code coverage is generated using `cargo-llvm-cov` and uploaded to codecov.io.
+Coverage is generated with `cargo-llvm-cov` and uploaded to Codecov as LCOV.
 
-To generate coverage locally:
+Local run:
+
 ```bash
-cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
+cargo llvm-cov --workspace \
+  --exclude adze-wasm-demo \
+  --features "pure-rust,glr,incremental_glr,external_scanners,serialization,ts-compat" \
+  --lcov \
+  --output-path lcov.info
 ```
+
+The first Codecov integration is advisory. Codecov checks and comments should not be required in branch protection until the baseline has stabilized on `main`.
+
+Required branch protection remains `CI / ci-supported`.
 
 ## Maintenance
 

--- a/.github/workflows/pure-rust-ci.yml
+++ b/.github/workflows/pure-rust-ci.yml
@@ -203,8 +203,22 @@ jobs:
       run: |
         cargo llvm-cov --workspace --exclude adze-wasm-demo --features "pure-rust,glr,incremental_glr,external_scanners,serialization,ts-compat" --lcov --output-path lcov.info
     
-    - name: Upload to codecov
-      uses: codecov/codecov-action@v4
+    - name: Upload coverage artifact
+      if: always()
+      uses: actions/upload-artifact@v7.0.0
       with:
+        name: adze-lcov
+        path: lcov.info
+        if-no-files-found: error
+        retention-days: 14
+
+    - name: Upload coverage to Codecov
+      if: ${{ always() && hashFiles('lcov.info') != '' }}
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         files: lcov.info
+        flags: rust
+        name: adze-rust
         fail_ci_if_error: false
+        verbose: true

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,8 @@ benchmarks/results/
 
 # Proptest regression files
 *.proptest-regressions
+# Coverage reports
+lcov.info
+coverage.json
+coverage.txt
+

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,37 @@
+coverage:
+  precision: 2
+  round: down
+  range: "50...85"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+        informational: true
+        flags:
+          - rust
+
+    patch:
+      default:
+        target: 60%
+        threshold: 10%
+        informational: true
+        flags:
+          - rust
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: true
+
+github_checks:
+  annotations: false
+
+ignore:
+  - "target/**"
+  - "runtime/fuzz/**"
+  - "tools/ts-bridge/**"
+  - "book/book/**"
+  - "docs/archive/**"
+  - "benchmarks/results/**"


### PR DESCRIPTION
### Motivation
- Provide a stable, non-blocking Codecov integration for existing LCOV coverage output without changing the coverage generation scope. 
- Ensure `lcov.info` is preserved as a CI artifact for inspection and make Codecov configuration advisory while a baseline is established.

### Description
- Updated `.github/workflows/pure-rust-ci.yml` to keep the existing `cargo llvm-cov` generation command unchanged, add an `actions/upload-artifact@v7.0.0` step that persists `lcov.info` as `adze-lcov` with 14-day retention, and migrate the upload to `codecov/codecov-action@v5` using `token: ${{ secrets.CODECOV_TOKEN }}`, `flags: rust`, `name: adze-rust`, `verbose: true`, and `fail_ci_if_error: false`.
- Added a root `codecov.yml` that sets advisory project/patch thresholds (`project.target: auto`, `project.threshold: 2%`, `patch.target: 60%`, `patch.threshold: 10%`), disables GitHub annotations, configures reporting layout, and ignores generated/build/fuzz/book/benchmarks paths.
- Updated `.github/CI_README.md` coverage section to document the exact local `cargo llvm-cov` command used in CI and to state that the initial Codecov integration is advisory while the baseline stabilizes on `main`.
- Added coverage artifacts to `.gitignore` by including `lcov.info`, `coverage.json`, and `coverage.txt`.

### Testing
- Ran a YAML syntax validation using Ruby: `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/pure-rust-ci.yml'); YAML.load_file('codecov.yml'); puts 'YAML OK'"` and it returned `YAML OK` (success).
- Attempted Python-based YAML validation with `yaml` but it failed due to a missing Python `yaml` module (`ModuleNotFoundError`), so validation was completed with Ruby instead (noted failure of the Python check).
- Confirmed the modified files are staged/committed and visible via `git status` / `git show` after committing the change (commit message: `Stabilize Codecov coverage upload and config`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9da75750c83338c4e98a3e573c711)