### PR TITLE
Stabilize Codecov upload and add advisory coverage config

### DIFF
--- a/.github/CI_README.md
+++ b/.github/CI_README.md
@@ -116,12 +116,21 @@ cargo +nightly fuzz run fuzz_external_scanner
 
 ## Coverage
 
-Code coverage is generated using `cargo-llvm-cov` and uploaded to codecov.io.
+Coverage is generated with `cargo-llvm-cov` and uploaded to Codecov as LCOV.
 
-To generate coverage locally:
+Local run:
+
 ```bash
-cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
+cargo llvm-cov --workspace \
+  --exclude adze-wasm-demo \
+  --features "pure-rust,glr,incremental_glr,external_scanners,serialization,ts-compat" \
+  --lcov \
+  --output-path lcov.info
 ```
+
+The first Codecov integration is advisory. Codecov checks and comments should not be required in branch protection until the baseline has stabilized on `main`.
+
+Required branch protection remains `CI / ci-supported`.
 
 ## Maintenance
 

--- a/.github/workflows/pure-rust-ci.yml
+++ b/.github/workflows/pure-rust-ci.yml
@@ -203,8 +203,22 @@ jobs:
       run: |
         cargo llvm-cov --workspace --exclude adze-wasm-demo --features "pure-rust,glr,incremental_glr,external_scanners,serialization,ts-compat" --lcov --output-path lcov.info
     
-    - name: Upload to codecov
-      uses: codecov/codecov-action@v4
+    - name: Upload coverage artifact
+      if: always()
+      uses: actions/upload-artifact@v7.0.0
       with:
+        name: adze-lcov
+        path: lcov.info
+        if-no-files-found: error
+        retention-days: 14
+
+    - name: Upload coverage to Codecov
+      if: ${{ always() && hashFiles('lcov.info') != '' }}
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         files: lcov.info
+        flags: rust
+        name: adze-rust
         fail_ci_if_error: false
+        verbose: true

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,8 @@ benchmarks/results/
 
 # Proptest regression files
 *.proptest-regressions
+# Coverage reports
+lcov.info
+coverage.json
+coverage.txt
+

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,37 @@
+coverage:
+  precision: 2
+  round: down
+  range: "50...85"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+        informational: true
+        flags:
+          - rust
+
+    patch:
+      default:
+        target: 60%
+        threshold: 10%
+        informational: true
+        flags:
+          - rust
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: true
+
+github_checks:
+  annotations: false
+
+ignore:
+  - "target/**"
+  - "runtime/fuzz/**"
+  - "tools/ts-bridge/**"
+  - "book/book/**"
+  - "docs/archive/**"
+  - "benchmarks/results/**"


### PR DESCRIPTION
### Motivation

- Stabilize the existing coverage job by making the LCOV artifact available and upgrading the Codecov uploader without changing the existing coverage generation command.
- Use a secure `CODECOV_TOKEN`-backed upload path and keep coverage advisory while a baseline is established on `main`.
- Add a root `codecov.yml` to make Codecov reporting informational and ignore noisy/generated paths.

### Description

- Updated `.github/workflows/pure-rust-ci.yml` to keep the existing `cargo llvm-cov ... --output-path lcov.info` generation command, add an `actions/upload-artifact@v7.0.0` step that stores `lcov.info` as `adze-lcov` with 14-day retention, and replace the Codecov upload with `codecov/codecov-action@v5` using `token: ${{ secrets.CODECOV_TOKEN }}`, `files: lcov.info`, `flags: rust`, `name: adze-rust`, `fail_ci_if_error: false`, and `verbose: true` guarded by `if: ${{ always() && hashFiles('lcov.info') != '' }}`. 
- Added `codecov.yml` at the repository root to set `project.target: auto`, informational project/patch statuses, `patch.target: 60%`, `patch.threshold: 10%`, GitHub annotations disabled, and ignore rules for `target/**`, fuzz, ts-bridge, generated book output, docs archive, and benchmark results. 
- Updated `.github/CI_README.md` Coverage section to document the exact local `cargo llvm-cov` command used in CI and to state that the first Codecov integration is advisory and branch protection remains `CI / ci-supported`. 
- Added coverage artifacts to `.gitignore`: `lcov.info`, `coverage.json`, and `coverage.txt`.

### Testing

- Validated YAML parsing of `.github/workflows/pure-rust-ci.yml` and `codecov.yml` using Ruby `YAML.load_file`, which succeeded. 
- Attempted YAML validation with Python `PyYAML` but the environment lacked `PyYAML`, so that check was skipped due to missing dependency. 
- Confirmed that the CI coverage generation command was left unchanged and that the workflow syntax parses cleanly with the applied changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9da75750c83338c4e98a3e573c711)