### PR TITLE
Stabilize Codecov uploads, add advisory `codecov.yml`, and retain `lcov.info` artifact

### DIFF
--- a/.github/CI_README.md
+++ b/.github/CI_README.md
@@ -116,12 +116,21 @@ cargo +nightly fuzz run fuzz_external_scanner
 
 ## Coverage
 
-Code coverage is generated using `cargo-llvm-cov` and uploaded to codecov.io.
+Coverage is generated with `cargo-llvm-cov` and uploaded to Codecov as LCOV.
 
-To generate coverage locally:
+Local run:
+
 ```bash
-cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
+cargo llvm-cov --workspace \
+  --exclude adze-wasm-demo \
+  --features "pure-rust,glr,incremental_glr,external_scanners,serialization,ts-compat" \
+  --lcov \
+  --output-path lcov.info
 ```
+
+The first Codecov integration is advisory. Codecov checks and comments should not be required in branch protection until the baseline has stabilized on `main`.
+
+Required branch protection remains `CI / ci-supported`.
 
 ## Maintenance
 

--- a/.github/workflows/pure-rust-ci.yml
+++ b/.github/workflows/pure-rust-ci.yml
@@ -203,8 +203,22 @@ jobs:
       run: |
         cargo llvm-cov --workspace --exclude adze-wasm-demo --features "pure-rust,glr,incremental_glr,external_scanners,serialization,ts-compat" --lcov --output-path lcov.info
     
-    - name: Upload to codecov
-      uses: codecov/codecov-action@v4
+    - name: Upload coverage artifact
+      if: always()
+      uses: actions/upload-artifact@v7.0.0
       with:
+        name: adze-lcov
+        path: lcov.info
+        if-no-files-found: error
+        retention-days: 14
+
+    - name: Upload coverage to Codecov
+      if: ${{ always() && hashFiles('lcov.info') != '' }}
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         files: lcov.info
+        flags: rust
+        name: adze-rust
         fail_ci_if_error: false
+        verbose: true

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,8 @@ benchmarks/results/
 
 # Proptest regression files
 *.proptest-regressions
+
+# Coverage reports
+lcov.info
+coverage.json
+coverage.txt

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,37 @@
+coverage:
+  precision: 2
+  round: down
+  range: "50...85"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+        informational: true
+        flags:
+          - rust
+
+    patch:
+      default:
+        target: 60%
+        threshold: 10%
+        informational: true
+        flags:
+          - rust
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: true
+
+github_checks:
+  annotations: false
+
+ignore:
+  - "target/**"
+  - "runtime/fuzz/**"
+  - "tools/ts-bridge/**"
+  - "book/book/**"
+  - "docs/archive/**"
+  - "benchmarks/results/**"


### PR DESCRIPTION
### Motivation

- Stabilize the existing coverage job so LCOV artifacts are retained and Codecov uploads use the modern v5 action with token-based authentication.  
- Keep coverage generation exactly as-is to avoid changing scope while fixing upload reliability.  
- Make Codecov advisory initially so coverage visibility is available without making it a required PR gate.  
- Add ignore rules and local documentation so repository noise from coverage artifacts and generated outputs is reduced.

### Description

- Replaced the old Codecov upload in ` .github/workflows/pure-rust-ci.yml` with an `actions/upload-artifact@v7.0.0` step that retains `lcov.info` as `adze-lcov` (14-day retention) and a `codecov/codecov-action@v5` upload that uses `token: ${{ secrets.CODECOV_TOKEN }}`, `flags: rust`, `name: adze-rust`, `fail_ci_if_error: false`, and `verbose: true`, while preserving the existing `cargo llvm-cov` generation command.  
- Added a root-level `codecov.yml` that sets advisory project and patch status targets (`project.target: auto`, `project.threshold: 2%`, `patch.target: 60%`, `patch.threshold: 10%`), disables GitHub annotations, configures comment layout, and `ignore` globs for `target/**`, `runtime/fuzz/**`, `tools/ts-bridge/**`, `book/book/**`, `docs/archive/**`, and `benchmarks/results/**`.  
- Added coverage report files to `.gitignore`: `lcov.info`, `coverage.json`, and `coverage.txt`.  
- Updated `.github/CI_README.md` coverage section to include the exact local `cargo llvm-cov` command (matching CI invocation) and to state that Codecov integration is advisory until the `main` baseline stabilizes.

### Testing

- Validated YAML syntax for ` .github/workflows/pure-rust-ci.yml` and `codecov.yml` using `ruby -e 'require "yaml"; [".github/workflows/pure-rust-ci.yml","codecov.yml"].each{|f| YAML.load_file(f); puts "OK #{f}"}'` and received `OK` for both files.  
- Confirmed that the updated coverage workflow still contains the original `cargo llvm-cov` command and that the new artifact and Codecov upload steps are present in ` .github/workflows/pure-rust-ci.yml` via automated file inspection.  
- Ensured `codecov.yml` is present at repository root and parses cleanly with YAML tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9da75750c83338c4e98a3e573c711)