### PR TITLE
Add governed Clippy policy baseline, ratchet MSRV to 1.93, and add xtask lint-policy checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,8 +449,11 @@ dependencies = [
  "adze",
  "adze-javascript",
  "adze-python",
+ "adze-tool",
  "anyhow",
+ "serde_json",
  "sha2",
+ "tempfile",
 ]
 
 [[package]]
@@ -3950,6 +3953,7 @@ dependencies = [
  "serde_json",
  "similar",
  "tempfile",
+ "toml 0.8.23",
  "walkdir",
  "xshell",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,14 +99,134 @@ homepage = "https://github.com/effortlessmetrics/adze"
 license = "Apache-2.0 OR MIT"
 publish = false
 repository = "https://github.com/effortlessmetrics/adze"
-rust-version = "1.92.0"
+rust-version = "1.93.0"
 
 
 [workspace.lints.rust]
+unsafe_code = "forbid"
 unsafe_op_in_unsafe_fn = "deny"
 unused_must_use = "deny"
+unexpected_cfgs = "warn"
+const_item_interior_mutations = "deny"
+function_casts_as_integer = "deny"
 missing_docs = "warn"
 unused_extern_crates = "deny"
+
+[workspace.lints.clippy]
+# Panic-free production and tests
+dbg_macro = "deny"
+todo = "deny"
+unimplemented = "deny"
+panic = "deny"
+unreachable = "deny"
+unwrap_used = "deny"
+expect_used = "deny"
+get_unwrap = "deny"
+unwrap_in_result = "deny"
+panic_in_result_fn = "deny"
+string_slice = "deny"
+indexing_slicing = "deny"
+out_of_bounds_indexing = "deny"
+unchecked_time_subtraction = "deny"
+
+# AST / parser / UTF-8 / slice safety
+char_indices_as_byte_indices = "deny"
+sliced_string_as_bytes = "deny"
+index_refutable_slice = "deny"
+
+# Silent failure
+let_underscore_future = "deny"
+let_underscore_must_use = "deny"
+let_underscore_lock = "deny"
+unused_result_ok = "deny"
+map_err_ignore = "deny"
+assertions_on_result_states = "deny"
+lines_filter_map_ok = "deny"
+
+# Async / concurrency
+await_holding_lock = "deny"
+await_holding_refcell_ref = "deny"
+await_holding_invalid_type = "deny"
+future_not_send = "warn"
+large_futures = "warn"
+arc_with_non_send_sync = "deny"
+rc_mutex = "deny"
+mut_mutex_lock = "deny"
+readonly_write_lock = "deny"
+
+# Unsafe / memory
+mem_forget = "deny"
+forget_non_drop = "deny"
+drop_non_drop = "deny"
+undocumented_unsafe_blocks = "deny"
+multiple_unsafe_ops_per_block = "deny"
+repr_packed_without_abi = "deny"
+
+# Numeric correctness
+float_cmp = "deny"
+float_cmp_const = "deny"
+float_equality_without_abs = "deny"
+lossy_float_literal = "deny"
+cast_sign_loss = "deny"
+cast_possible_wrap = "warn"
+cast_possible_truncation = "warn"
+cast_precision_loss = "warn"
+invalid_upcast_comparisons = "deny"
+cast_abs_to_unsigned = "deny"
+cast_enum_truncation = "deny"
+cast_nan_to_int = "deny"
+manual_midpoint = "warn"
+manual_is_multiple_of = "warn"
+manual_div_ceil = "warn"
+arithmetic_side_effects = "warn"
+
+# File/process/path footguns
+suspicious_open_options = "deny"
+nonsensical_open_options = "deny"
+ineffective_open_options = "deny"
+path_buf_push_overwrite = "deny"
+join_absolute_paths = "deny"
+read_line_without_trim = "warn"
+exit = "deny"
+
+# API / trait correctness
+iter_not_returning_iterator = "deny"
+expl_impl_clone_on_copy = "deny"
+infallible_try_from = "deny"
+fallible_impl_from = "deny"
+error_impl_error = "deny"
+result_unit_err = "warn"
+result_large_err = "warn"
+
+# Good taste that pays rent
+format_in_format_args = "deny"
+to_string_in_format_args = "deny"
+unused_format_specs = "deny"
+unnecessary_debug_formatting = "warn"
+uninlined_format_args = "warn"
+manual_let_else = "warn"
+manual_ok_or = "warn"
+manual_strip = "warn"
+manual_split_once = "warn"
+manual_is_variant_and = "warn"
+filter_map_next = "warn"
+flat_map_option = "warn"
+match_result_ok = "deny"
+cloned_instead_of_copied = "warn"
+iter_cloned_collect = "warn"
+iter_overeager_cloned = "warn"
+needless_collect = "warn"
+redundant_closure = "warn"
+redundant_closure_for_method_calls = "warn"
+missing_panics_doc = "deny"
+missing_errors_doc = "warn"
+
+# Suppression governance
+allow_attributes = "deny"
+allow_attributes_without_reason = "deny"
+blanket_clippy_restriction_lints = "deny"
+ignore_without_reason = "deny"
+should_panic_without_expect = "deny"
 
 [workspace.dependencies]
 tree-sitter = "=0.26.7"
@@ -128,6 +248,7 @@ rayon = "1.10"
 rustc-hash = "2.1"
 smallvec = "1.13"
 regex = "1.11"
+toml = "0.8"
 
 [profile.ci]
 inherits = "dev"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,6 @@
+# Effortless Metrics Clippy policy configuration.
+#
+# Keep this file for repo-specific disallowed methods/types/macros and other
+# Clippy configuration that cannot live in Cargo.toml. Tests must use the same
+# panic-free policy as production code; do not configure test-only relaxations
+# here.

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adze-common"
 version = "0.8.0-dev"
 edition = "2024"
-rust-version = "1.92"
+rust-version.workspace = true
 authors = ["Steven Zimmerman, CPA"]
 description = "Shared grammar expansion logic for the Adze macro and tool crates"
 license = "Apache-2.0 OR MIT"

--- a/crates/ts-c-harness/Cargo.toml
+++ b/crates/ts-c-harness/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adze-ts-c-harness"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.92.0"
+rust-version = "1.93.0"
 license = "Apache-2.0 OR MIT"
 description = "Internal Tree-sitter C FFI parity test harness."
 repository = "https://github.com/EffortlessMetrics/adze"

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -1,0 +1,80 @@
+# Effortless Metrics Clippy Policy
+
+Adze treats Clippy as a governed engineering surface, not as a local taste file.
+The root workspace owns the strict lint baseline, `policy/clippy-lints.toml`
+records the active and planned lint state, and temporary exceptions must be
+represented as structured policy data instead of broad configuration carveouts.
+
+## Baseline
+
+The workspace baseline is panic-free, parser-safe, suppression-governed, and
+reviewability-oriented:
+
+- no panic-family shortcuts in production or tests (`unwrap`, `expect`,
+  `panic!`, `todo!`, `unimplemented!`, `unreachable!`, and related lints);
+- no silent failure or swallowed work (`let _` futures/must-use values,
+  ignored `map_err`, ignored `Result::ok`, and line iteration footguns);
+- AST/parser-safe string, byte, and index defaults;
+- async, locking, memory, numeric, filesystem, and process footguns called out
+  explicitly; and
+- no broad suppression culture.
+
+The policy is intentionally workspace-wide: tests are part of the quality
+surface. Do not add Clippy test carveouts such as `allow-unwrap-in-tests`,
+`allow-expect-in-tests`, `allow-panic-in-tests`, `allow-indexing-slicing-in-tests`,
+or `allow-dbg-in-tests` to `clippy.toml`.
+
+## Source of truth
+
+- `Cargo.toml` contains the active workspace lint block.
+- `clippy.toml` is reserved for repo-specific Clippy configuration such as
+  disallowed methods or disallowed types; it must not contain test carveouts.
+- `policy/clippy-lints.toml` is the machine-readable ledger for active lints and
+  planned Rust 1.94/1.95 flips.
+- `policy/clippy-debt.toml` records temporary lint debt with owner, path, lint,
+  reason, and expiry.
+- `policy/no-panic-allowlist.toml` records semantic panic-family exceptions when
+  a follow-up migration needs a temporary receipt.
+- `policy/non-rust-allowlist.toml` records why non-Rust source surfaces exist and
+  what covers them in CI.
+
+## Suppressions
+
+Use narrow `#[expect(..., reason = "...")]` suppressions only when a lint is
+wrong for a local, reviewed reason. Avoid `#[allow(...)]` for new code. An
+`expect` should be placed as close as possible to the reviewed expression or item
+and the reason must explain why the exception is safe, not merely that Clippy is
+noisy.
+
+```rust
+#[expect(
+    clippy::indexing_slicing,
+    reason = "generated parse table bounds are validated during table construction"
+)]
+fn generated_table_lookup(table: &[u16], index: usize) -> u16 {
+    table[index]
+}
+```
+
+## Planned Rust upgrades
+
+Adze tracks future lint flips before the MSRV bump. The policy ledger currently
+records Rust 1.94 candidates (`same_length_and_capacity`, `manual_ilog2`,
+`decimal_bitwise_operands`, `needless_type_cast`) and Rust 1.95 candidates
+(`disallowed_fields`, `manual_checked_ops`, `manual_take`, `manual_pop_if`,
+`duration_suboptimal_units`, `unnecessary_trailing_comma`). Planned lints must
+remain in the ledger until the workspace MSRV reaches their activation version.
+
+## Local checks
+
+Run the policy check after editing the lint block, Clippy configuration, or
+policy ledgers:
+
+```bash
+cargo xtask check-lint-policy
+```
+
+The check verifies the MSRV ratchet, required policy files, root lint block,
+planned upgrade ledger, debt metadata, and the absence of Clippy test carveouts.
+As strict lint inheritance is rolled out crate-by-crate, temporary exceptions
+must move into policy debt rather than weakening the root lint block.

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -3,7 +3,7 @@ name = "adze-fuzz"
 version = "0.0.0"
 publish = false
 edition = "2024"
-rust-version = "1.92.0"
+rust-version = "1.93.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/glr-core/Cargo.toml
+++ b/glr-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adze-glr-core"
 version = "0.8.0-dev"
 edition = "2024"
-rust-version = "1.92"
+rust-version.workspace = true
 description = "GLR parser generation algorithms for pure-Rust Tree-sitter"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/effortlessmetrics/adze"

--- a/ir/Cargo.toml
+++ b/ir/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adze-ir"
 version = "0.8.0-dev"
 edition = "2024"
-rust-version = "1.92"
+rust-version.workspace = true
 description = "Grammar Intermediate Representation for pure-Rust Tree-sitter"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/effortlessmetrics/adze"

--- a/justfile
+++ b/justfile
@@ -73,6 +73,7 @@ ci-supported:
     export CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-2}"
     export RUST_TEST_THREADS="${RUST_TEST_THREADS:-2}"
     cargo fmt --all -- --check
+    cargo xtask check-lint-policy
     cargo clippy {{supported_crates}} --all-targets -- -D warnings
     cargo test {{supported_crates}} --lib --tests --bins -- --test-threads="$RUST_TEST_THREADS"
     cargo test -p adze-glr-core --features serialization --doc -- --test-threads="$RUST_TEST_THREADS"

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adze-macro"
 version = "0.8.0-dev"
 edition = "2024"
-rust-version = "1.92"
+rust-version.workspace = true
 authors = ["Steven Zimmerman, CPA"]
 description = "Procedural macros for defining tree-sitter grammars alongside Rust logic"
 license = "Apache-2.0 OR MIT"

--- a/policy/clippy-debt.toml
+++ b/policy/clippy-debt.toml
@@ -1,0 +1,5 @@
+schema = 1
+
+# Temporary lint exceptions belong here once a lint is inherited by crates that
+# cannot be cleaned up in the same change. Entries must include lint, path,
+# owner, reason, and expires before policy enforcement can accept them.

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -1,0 +1,814 @@
+schema = 1
+msrv = "1.93.0"
+
+[policy]
+panic_free_tests = true
+allow_test_carveouts = false
+suppression_style = "expect-with-reason"
+blanket_categories = false
+# This initial PR lands the platform policy and checks. Workspace members are
+# then migrated to inherit the strict block as lint debt is burned down.
+lint_inheritance = "staged"
+
+# Active workspace baseline. This mirrors the root Cargo.toml lint block.
+
+[[lint]]
+name = "rust::unsafe_code"
+level = "forbid"
+status = "active"
+class = "rust"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "rust::unsafe_op_in_unsafe_fn"
+level = "deny"
+status = "active"
+class = "rust"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "rust::unused_must_use"
+level = "deny"
+status = "active"
+class = "rust"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "rust::unexpected_cfgs"
+level = "warn"
+status = "active"
+class = "rust"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "rust::const_item_interior_mutations"
+level = "deny"
+status = "active"
+class = "rust"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "rust::function_casts_as_integer"
+level = "deny"
+status = "active"
+class = "rust"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "rust::missing_docs"
+level = "warn"
+status = "active"
+class = "rust"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "rust::unused_extern_crates"
+level = "deny"
+status = "active"
+class = "rust"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::dbg_macro"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::todo"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::unimplemented"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::panic"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::unreachable"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::unwrap_used"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::expect_used"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::get_unwrap"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::unwrap_in_result"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::panic_in_result_fn"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::string_slice"
+level = "deny"
+status = "active"
+class = "parser-safety"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::indexing_slicing"
+level = "deny"
+status = "active"
+class = "parser-safety"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::out_of_bounds_indexing"
+level = "deny"
+status = "active"
+class = "parser-safety"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::unchecked_time_subtraction"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::char_indices_as_byte_indices"
+level = "deny"
+status = "active"
+class = "parser-safety"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::sliced_string_as_bytes"
+level = "deny"
+status = "active"
+class = "parser-safety"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::index_refutable_slice"
+level = "deny"
+status = "active"
+class = "parser-safety"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::let_underscore_future"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::let_underscore_must_use"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::let_underscore_lock"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::unused_result_ok"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::map_err_ignore"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::assertions_on_result_states"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::lines_filter_map_ok"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::await_holding_lock"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::await_holding_refcell_ref"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::await_holding_invalid_type"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::future_not_send"
+level = "warn"
+status = "active"
+class = "concurrency"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::large_futures"
+level = "warn"
+status = "active"
+class = "concurrency"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::arc_with_non_send_sync"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::rc_mutex"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::mut_mutex_lock"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::readonly_write_lock"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::mem_forget"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::forget_non_drop"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::drop_non_drop"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::undocumented_unsafe_blocks"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::multiple_unsafe_ops_per_block"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::repr_packed_without_abi"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::float_cmp"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::float_cmp_const"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::float_equality_without_abs"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::lossy_float_literal"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::cast_sign_loss"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::cast_possible_wrap"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::cast_possible_truncation"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::cast_precision_loss"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::invalid_upcast_comparisons"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::cast_abs_to_unsigned"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::cast_enum_truncation"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::cast_nan_to_int"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::manual_midpoint"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::manual_is_multiple_of"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::manual_div_ceil"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::arithmetic_side_effects"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::suspicious_open_options"
+level = "deny"
+status = "active"
+class = "file-process-path"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::nonsensical_open_options"
+level = "deny"
+status = "active"
+class = "file-process-path"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::ineffective_open_options"
+level = "deny"
+status = "active"
+class = "file-process-path"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::path_buf_push_overwrite"
+level = "deny"
+status = "active"
+class = "file-process-path"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::join_absolute_paths"
+level = "deny"
+status = "active"
+class = "file-process-path"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::read_line_without_trim"
+level = "warn"
+status = "active"
+class = "file-process-path"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::exit"
+level = "deny"
+status = "active"
+class = "file-process-path"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::iter_not_returning_iterator"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::expl_impl_clone_on_copy"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::infallible_try_from"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::fallible_impl_from"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::error_impl_error"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::result_unit_err"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::result_large_err"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::format_in_format_args"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::to_string_in_format_args"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::unused_format_specs"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::unnecessary_debug_formatting"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::uninlined_format_args"
+level = "warn"
+status = "active"
+class = "file-process-path"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::manual_let_else"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::manual_ok_or"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::manual_strip"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::manual_split_once"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::manual_is_variant_and"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::filter_map_next"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::flat_map_option"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::match_result_ok"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::cloned_instead_of_copied"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::iter_cloned_collect"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::iter_overeager_cloned"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::needless_collect"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::redundant_closure"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::redundant_closure_for_method_calls"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::missing_panics_doc"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::missing_errors_doc"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::allow_attributes"
+level = "deny"
+status = "active"
+class = "suppression"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::allow_attributes_without_reason"
+level = "deny"
+status = "active"
+class = "suppression"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::blanket_clippy_restriction_lints"
+level = "deny"
+status = "active"
+class = "suppression"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::ignore_without_reason"
+level = "deny"
+status = "active"
+class = "suppression"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::should_panic_without_expect"
+level = "deny"
+status = "active"
+class = "suppression"
+reason = "Effortless Metrics strict workspace baseline."
+
+[[lint]]
+name = "clippy::same_length_and_capacity"
+level = "deny"
+status = "planned"
+activate_when_msrv = "1.94"
+class = "upgrade"
+reason = "Catch raw-parts reconstruction mistakes."
+
+[[lint]]
+name = "clippy::manual_ilog2"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.94"
+class = "upgrade"
+reason = "Prefer the standard integer log helper."
+
+[[lint]]
+name = "clippy::decimal_bitwise_operands"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.94"
+class = "upgrade"
+reason = "Make bit masks visually inspectable."
+
+[[lint]]
+name = "clippy::needless_type_cast"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.94"
+class = "upgrade"
+reason = "Avoid stale numeric type drift."
+
+[[lint]]
+name = "clippy::disallowed_fields"
+level = "deny"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "upgrade"
+reason = "Allow architecture policy to ban direct field access across protected seams."
+
+[[lint]]
+name = "clippy::manual_checked_ops"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "upgrade"
+reason = "Prefer checked arithmetic over manual divide-by-zero guards."
+
+[[lint]]
+name = "clippy::manual_take"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "upgrade"
+reason = "Use standard ownership helper instead of local reimplementation."
+
+[[lint]]
+name = "clippy::manual_pop_if"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "upgrade"
+reason = "Use collection APIs that encode predicate-and-pop intent directly."
+
+[[lint]]
+name = "clippy::duration_suboptimal_units"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "upgrade"
+reason = "Make durations legible without mental unit conversion."
+
+[[lint]]
+name = "clippy::unnecessary_trailing_comma"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "upgrade"
+reason = "Keep generated and hand-written format macro calls clean."

--- a/policy/no-panic-allowlist.toml
+++ b/policy/no-panic-allowlist.toml
@@ -1,0 +1,6 @@
+schema_version = "0.3"
+
+# No panic-family exceptions are approved for the workspace baseline. If a
+# follow-up cleanup needs a temporary exception, add an [[allow]] entry using
+# path + family + selector identity, owner, classification, explanation, and an
+# optional expires date.

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -1,0 +1,28 @@
+schema_version = "1.0"
+
+[[allow]]
+glob = ".github/workflows/*.yml"
+kind = "ci_declarative"
+owner = "release/ci"
+reason = "GitHub Actions workflow definitions are platform-required YAML."
+surface = "ci"
+classification = "config"
+covered_by = ["cargo xtask check-lint-policy"]
+
+[[allow]]
+glob = "docs/**/*.md"
+kind = "documentation"
+owner = "docs"
+reason = "Project documentation is intentionally Markdown."
+surface = "docs"
+classification = "documentation"
+covered_by = ["cargo xtask check-lint-policy"]
+
+[[allow]]
+glob = "scripts/**/*"
+kind = "repo_tooling"
+owner = "dev-infra"
+reason = "Repository shell and Python helpers support CI and local developer workflows."
+surface = "tooling"
+classification = "tooling"
+covered_by = ["just ci-supported"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adze"
 version = "0.8.0-dev"
 edition = "2024"
-rust-version = "1.92"
+rust-version.workspace = true
 authors = ["Steven Zimmerman, CPA"]
 description = "Define tree-sitter grammars alongside Rust logic with AST-first parsing"
 license = "Apache-2.0 OR MIT"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.92.0"
+channel = "1.93.0"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/tablegen/Cargo.toml
+++ b/tablegen/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adze-tablegen"
 version = "0.8.0-dev"
 edition = "2024"
-rust-version = "1.92"
+rust-version.workspace = true
 description = "Table generation and compression for pure-Rust Tree-sitter"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/effortlessmetrics/adze"

--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adze-tool"
 version = "0.8.0-dev"
 edition = "2024"
-rust-version = "1.92"
+rust-version.workspace = true
 authors = ["Steven Zimmerman, CPA"]
 description = "Build-time code generation tool for Adze grammar definitions"
 license = "Apache-2.0 OR MIT"

--- a/tools/ts-bridge/Cargo.toml
+++ b/tools/ts-bridge/Cargo.toml
@@ -3,7 +3,7 @@ name = "ts-bridge"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
 edition = "2024"
-rust-version = "1.92.0"
+rust-version = "1.93.0"
 
 [lib]
 crate-type = ["rlib", "cdylib"]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -16,5 +16,6 @@ walkdir = "2.5.0"
 glob = "0.3.3"
 chrono = "0.4.44"
 serde.workspace = true
+toml.workspace = true
 adze-tool = { version = "0.8.0-dev", path = "../tool" }
 tempfile.workspace = true

--- a/xtask/src/lint_policy.rs
+++ b/xtask/src/lint_policy.rs
@@ -1,0 +1,461 @@
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+use std::{collections::BTreeMap, fs, path::Path};
+
+const POLICY_PATH: &str = "policy/clippy-lints.toml";
+const DEBT_PATH: &str = "policy/clippy-debt.toml";
+const CLIPPY_CONFIG_PATH: &str = "clippy.toml";
+const TOOLCHAIN_PATH: &str = "rust-toolchain.toml";
+const CARGO_PATH: &str = "Cargo.toml";
+
+const TEST_CARVEOUTS: &[&str] = &[
+    "allow-unwrap-in-tests",
+    "allow-expect-in-tests",
+    "allow-panic-in-tests",
+    "allow-indexing-slicing-in-tests",
+    "allow-dbg-in-tests",
+];
+
+const REQUIRED_PLANNED: &[(&str, &str, &str)] = &[
+    ("clippy::same_length_and_capacity", "deny", "1.94"),
+    ("clippy::manual_ilog2", "warn", "1.94"),
+    ("clippy::decimal_bitwise_operands", "warn", "1.94"),
+    ("clippy::needless_type_cast", "warn", "1.94"),
+    ("clippy::disallowed_fields", "deny", "1.95"),
+    ("clippy::manual_checked_ops", "warn", "1.95"),
+    ("clippy::manual_take", "warn", "1.95"),
+    ("clippy::manual_pop_if", "warn", "1.95"),
+    ("clippy::duration_suboptimal_units", "warn", "1.95"),
+    ("clippy::unnecessary_trailing_comma", "warn", "1.95"),
+];
+
+#[derive(Debug, Deserialize)]
+struct LintPolicy {
+    schema: u64,
+    msrv: String,
+    policy: PolicyConfig,
+    #[serde(default)]
+    lint: Vec<LintEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PolicyConfig {
+    panic_free_tests: bool,
+    allow_test_carveouts: bool,
+    suppression_style: String,
+    blanket_categories: bool,
+    #[serde(default)]
+    lint_inheritance: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LintEntry {
+    name: String,
+    level: String,
+    status: String,
+    reason: String,
+    #[serde(default)]
+    activate_when_msrv: Option<String>,
+    #[serde(default)]
+    class: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DebtLedger {
+    schema: u64,
+    #[serde(default)]
+    debt: Vec<DebtEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DebtEntry {
+    lint: String,
+    path: String,
+    owner: String,
+    reason: String,
+    expires: String,
+}
+
+pub fn check_lint_policy() -> Result<()> {
+    let root_cargo = fs::read_to_string(CARGO_PATH).context("reading root Cargo.toml")?;
+    let root_value = parse_toml(CARGO_PATH, &root_cargo)?;
+    let policy_text =
+        fs::read_to_string(POLICY_PATH).context("reading policy/clippy-lints.toml")?;
+    let policy: LintPolicy =
+        toml::from_str(&policy_text).context("parsing policy/clippy-lints.toml")?;
+
+    let mut errors = Vec::new();
+    let mut warnings = Vec::new();
+
+    check_policy_header(&policy, &mut errors);
+    check_msrv(&root_value, &policy, &mut errors)?;
+    check_toolchain(&policy, &mut errors)?;
+    check_root_lints(&root_value, &policy, &mut errors);
+    check_planned_lints(&policy, &mut errors);
+    check_clippy_config(&policy, &mut errors)?;
+    check_debt_ledger(&mut errors)?;
+    check_allowlists_exist(&mut errors);
+    check_lint_inheritance(&root_cargo, &policy, &mut errors, &mut warnings)?;
+
+    for warning in &warnings {
+        eprintln!("warning: {warning}");
+    }
+
+    if !errors.is_empty() {
+        for error in &errors {
+            eprintln!("error: {error}");
+        }
+        bail!("lint policy check failed with {} error(s)", errors.len());
+    }
+
+    println!(
+        "lint policy OK: {} active lint(s), {} planned upgrade lint(s)",
+        policy
+            .lint
+            .iter()
+            .filter(|lint| lint.status == "active")
+            .count(),
+        policy
+            .lint
+            .iter()
+            .filter(|lint| lint.status == "planned")
+            .count()
+    );
+    Ok(())
+}
+
+fn parse_toml(path: &str, contents: &str) -> Result<toml::Value> {
+    contents
+        .parse::<toml::Value>()
+        .with_context(|| format!("parsing {path}"))
+}
+
+fn check_policy_header(policy: &LintPolicy, errors: &mut Vec<String>) {
+    if policy.schema != 1 {
+        errors.push(format!("{POLICY_PATH} schema must be 1"));
+    }
+    if !policy.policy.panic_free_tests {
+        errors.push("policy.panic_free_tests must be true".to_string());
+    }
+    if policy.policy.allow_test_carveouts {
+        errors.push("policy.allow_test_carveouts must be false".to_string());
+    }
+    if policy.policy.suppression_style != "expect-with-reason" {
+        errors.push("policy.suppression_style must be expect-with-reason".to_string());
+    }
+    if policy.policy.blanket_categories {
+        errors.push("policy.blanket_categories must be false".to_string());
+    }
+}
+
+fn check_msrv(
+    root_value: &toml::Value,
+    policy: &LintPolicy,
+    errors: &mut Vec<String>,
+) -> Result<()> {
+    let workspace_msrv = root_value
+        .get("workspace")
+        .and_then(|workspace| workspace.get("package"))
+        .and_then(|package| package.get("rust-version"))
+        .and_then(toml::Value::as_str)
+        .context("workspace.package.rust-version is missing")?;
+    if workspace_msrv != policy.msrv {
+        errors.push(format!(
+            "workspace.package.rust-version ({workspace_msrv}) must match {POLICY_PATH} msrv ({})",
+            policy.msrv
+        ));
+    }
+    Ok(())
+}
+
+fn check_toolchain(policy: &LintPolicy, errors: &mut Vec<String>) -> Result<()> {
+    let toolchain_text =
+        fs::read_to_string(TOOLCHAIN_PATH).context("reading rust-toolchain.toml")?;
+    let toolchain = parse_toml(TOOLCHAIN_PATH, &toolchain_text)?;
+    let channel = toolchain
+        .get("toolchain")
+        .and_then(|toolchain| toolchain.get("channel"))
+        .and_then(toml::Value::as_str)
+        .context("toolchain.channel is missing")?;
+    if channel != policy.msrv {
+        errors.push(format!(
+            "rust-toolchain.toml channel ({channel}) must match {POLICY_PATH} msrv ({})",
+            policy.msrv
+        ));
+    }
+    Ok(())
+}
+
+fn check_root_lints(root_value: &toml::Value, policy: &LintPolicy, errors: &mut Vec<String>) {
+    let Some(workspace_lints) = root_value
+        .get("workspace")
+        .and_then(|workspace| workspace.get("lints"))
+    else {
+        errors.push("root Cargo.toml must define [workspace.lints]".to_string());
+        return;
+    };
+
+    let mut active = BTreeMap::new();
+    for entry in policy.lint.iter().filter(|entry| entry.status == "active") {
+        active.insert(entry.name.as_str(), entry.level.as_str());
+        if entry.reason.trim().is_empty() {
+            errors.push(format!("active lint {} must include a reason", entry.name));
+        }
+        if entry.class.as_deref().unwrap_or_default().trim().is_empty() {
+            errors.push(format!("active lint {} must include a class", entry.name));
+        }
+    }
+
+    for (name, expected_level) in active {
+        let Some((tool, lint_name)) = name.split_once("::") else {
+            errors.push(format!("lint name {name} must include a tool namespace"));
+            continue;
+        };
+        let Some(actual_level) = workspace_lints
+            .get(tool)
+            .and_then(|tool_lints| tool_lints.get(lint_name))
+            .and_then(toml::Value::as_str)
+        else {
+            errors.push(format!("root Cargo.toml is missing active lint {name}"));
+            continue;
+        };
+        if actual_level != expected_level {
+            errors.push(format!(
+                "root Cargo.toml lint {name} is {actual_level}, expected {expected_level}"
+            ));
+        }
+    }
+}
+
+fn check_planned_lints(policy: &LintPolicy, errors: &mut Vec<String>) {
+    let planned: BTreeMap<_, _> = policy
+        .lint
+        .iter()
+        .filter(|entry| entry.status == "planned")
+        .map(|entry| (entry.name.as_str(), entry))
+        .collect();
+
+    for (name, level, activate_when_msrv) in REQUIRED_PLANNED {
+        let Some(entry) = planned.get(name) else {
+            errors.push(format!("missing planned lint {name}"));
+            continue;
+        };
+        if entry.level != *level {
+            errors.push(format!(
+                "planned lint {name} has level {}, expected {level}",
+                entry.level
+            ));
+        }
+        if entry.activate_when_msrv.as_deref() != Some(*activate_when_msrv) {
+            errors.push(format!(
+                "planned lint {name} must activate at MSRV {activate_when_msrv}"
+            ));
+        }
+        if entry.reason.trim().is_empty() {
+            errors.push(format!("planned lint {name} must include a reason"));
+        }
+    }
+
+    for entry in policy.lint.iter().filter(|entry| entry.status == "planned") {
+        let Some(activate) = entry.activate_when_msrv.as_deref() else {
+            errors.push(format!(
+                "planned lint {} must include activate_when_msrv",
+                entry.name
+            ));
+            continue;
+        };
+        if compare_version(&policy.msrv, activate).is_ge() {
+            errors.push(format!(
+                "planned lint {} is still planned even though MSRV {} has reached {}",
+                entry.name, policy.msrv, activate
+            ));
+        }
+    }
+}
+
+fn check_clippy_config(policy: &LintPolicy, errors: &mut Vec<String>) -> Result<()> {
+    let config = fs::read_to_string(CLIPPY_CONFIG_PATH).context("reading clippy.toml")?;
+    for carveout in TEST_CARVEOUTS {
+        if config.contains(carveout) && !policy.policy.allow_test_carveouts {
+            errors.push(format!(
+                "clippy.toml must not contain test carveout {carveout}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn check_debt_ledger(errors: &mut Vec<String>) -> Result<()> {
+    let debt_text = fs::read_to_string(DEBT_PATH).context("reading policy/clippy-debt.toml")?;
+    let debt: DebtLedger = toml::from_str(&debt_text).context("parsing policy/clippy-debt.toml")?;
+    if debt.schema != 1 {
+        errors.push(format!("{DEBT_PATH} schema must be 1"));
+    }
+    let today = chrono::Utc::now().date_naive();
+    for (idx, entry) in debt.debt.iter().enumerate() {
+        let label = format!("{DEBT_PATH} debt entry #{idx}");
+        if entry.lint.trim().is_empty() {
+            errors.push(format!("{label} must include lint"));
+        }
+        if entry.path.trim().is_empty() {
+            errors.push(format!("{label} must include path"));
+        }
+        if entry.owner.trim().is_empty() {
+            errors.push(format!("{label} must include owner"));
+        }
+        if entry.reason.trim().is_empty() {
+            errors.push(format!("{label} must include reason"));
+        }
+        match chrono::NaiveDate::parse_from_str(&entry.expires, "%Y-%m-%d") {
+            Ok(expires) if expires < today => {
+                errors.push(format!("{label} expired on {expires}"));
+            }
+            Ok(_) => {}
+            Err(err) => errors.push(format!("{label} has invalid expires date: {err}")),
+        }
+    }
+    Ok(())
+}
+
+fn check_allowlists_exist(errors: &mut Vec<String>) {
+    for path in [
+        "policy/no-panic-allowlist.toml",
+        "policy/non-rust-allowlist.toml",
+    ] {
+        if !Path::new(path).exists() {
+            errors.push(format!("missing required policy allowlist {path}"));
+        }
+    }
+}
+
+fn check_lint_inheritance(
+    root_cargo: &str,
+    policy: &LintPolicy,
+    errors: &mut Vec<String>,
+    warnings: &mut Vec<String>,
+) -> Result<()> {
+    let metadata = cargo_metadata()?;
+    let root = std::env::current_dir().context("resolving current directory")?;
+    let enforce = policy.policy.lint_inheritance.as_deref() == Some("required");
+    let mut missing = Vec::new();
+    let members = metadata
+        .get("workspace_members")
+        .and_then(serde_json::Value::as_array)
+        .context("cargo metadata missing workspace_members")?;
+    let packages = metadata
+        .get("packages")
+        .and_then(serde_json::Value::as_array)
+        .context("cargo metadata missing packages")?;
+
+    for member in members {
+        let Some(member_id) = member.as_str() else {
+            continue;
+        };
+        let Some(package) = packages.iter().find(|package| {
+            package.get("id").and_then(serde_json::Value::as_str) == Some(member_id)
+        }) else {
+            continue;
+        };
+        let Some(manifest_path) = package
+            .get("manifest_path")
+            .and_then(serde_json::Value::as_str)
+        else {
+            continue;
+        };
+        let manifest = Path::new(manifest_path);
+        if manifest == Path::new(CARGO_PATH) {
+            continue;
+        }
+        let contents = fs::read_to_string(manifest)
+            .with_context(|| format!("reading {}", manifest.display()))?;
+        if !manifest_has_lint_inheritance(&contents) {
+            let rel = manifest.strip_prefix(&root).unwrap_or(manifest);
+            missing.push(rel.display().to_string());
+        }
+    }
+
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    let message = format!(
+        "{} workspace member manifest(s) do not yet inherit [lints] workspace = true",
+        missing.len()
+    );
+    if enforce {
+        errors.push(format!("{message}: {}", missing.join(", ")));
+    } else {
+        warnings.push(format!(
+            "{message}; policy is staged until existing lint debt is migrated"
+        ));
+    }
+
+    if !root_cargo.contains("[workspace.lints.clippy]") {
+        errors.push("root Cargo.toml must include [workspace.lints.clippy]".to_string());
+    }
+    Ok(())
+}
+
+fn cargo_metadata() -> Result<serde_json::Value> {
+    let output = std::process::Command::new("cargo")
+        .args(["metadata", "--no-deps", "--format-version", "1"])
+        .output()
+        .context("running cargo metadata")?;
+    if !output.status.success() {
+        bail!(
+            "cargo metadata failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    serde_json::from_slice(&output.stdout).context("parsing cargo metadata JSON")
+}
+
+fn manifest_has_lint_inheritance(contents: &str) -> bool {
+    let mut in_lints = false;
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') {
+            in_lints = trimmed == "[lints]";
+            continue;
+        }
+        if in_lints && trimmed == "workspace = true" {
+            return true;
+        }
+    }
+    false
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum VersionOrdering {
+    Lt,
+    Eq,
+    Gt,
+}
+
+impl VersionOrdering {
+    fn is_ge(&self) -> bool {
+        matches!(self, Self::Eq | Self::Gt)
+    }
+}
+
+fn compare_version(lhs: &str, rhs: &str) -> VersionOrdering {
+    let parse = |version: &str| -> Vec<u64> {
+        version
+            .split('.')
+            .map(|part| part.parse::<u64>().unwrap_or(0))
+            .collect()
+    };
+    let lhs = parse(lhs);
+    let rhs = parse(rhs);
+    for idx in 0..lhs.len().max(rhs.len()) {
+        let left = lhs.get(idx).copied().unwrap_or(0);
+        let right = rhs.get(idx).copied().unwrap_or(0);
+        if left < right {
+            return VersionOrdering::Lt;
+        }
+        if left > right {
+            return VersionOrdering::Gt;
+        }
+    }
+    VersionOrdering::Eq
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -10,6 +10,7 @@ mod fixtures;
 mod golden;
 mod grammar_json;
 mod lint;
+mod lint_policy;
 mod profile;
 mod test_grammars;
 mod test_local_grammars;
@@ -169,6 +170,8 @@ enum Commands {
         #[arg(last = true)]
         clippy_args: Vec<String>,
     },
+    /// Verify the workspace lint policy, debt ledger, and Clippy configuration
+    CheckLintPolicy,
     /// Generate arithmetic expression fixtures for benchmarking
     GenerateFixtures {
         /// Output directory for fixtures
@@ -361,6 +364,9 @@ fn main() -> Result<()> {
             clippy_args,
         } => {
             lint::lint(&sh, fix, changed_only, since, fast, clippy_args)?;
+        }
+        Commands::CheckLintPolicy => {
+            lint_policy::check_lint_policy()?;
         }
         Commands::GenerateFixtures { output, force } => {
             fixtures::generate_fixtures(&sh, &output, force)?;


### PR DESCRIPTION
### Motivation
- Establish a governed, workspace-wide Clippy baseline (panic-free, parser-safe, suppression-governed) so linting is an organizational policy rather than a per-crate taste file.
- Ratchet the workspace MSRV/toolchain to `1.93.0` so planned Clippy flips for Rust `1.94`/`1.95` can be tracked and staged safely.
- Provide machine-readable policy ledgers and allowlists so temporary exceptions are explicit, reviewable, and expiring instead of hidden in local configs.
- Add an `xtask` policy gate so CI can verify MSRV and lint inheritance, forbid test-carveouts, and require debt metadata before forcing full inheritance.

### Description
- Bumped workspace MSRV to `1.93.0` and updated `rust-toolchain.toml` and several crate `rust-version` fields to inherit the workspace (`rust-version.workspace = true`).
- Added a strict workspace lint block under `[workspace.lints.clippy]` and extended `[workspace.lints.rust]` in `Cargo.toml` to encode the Effortless Metrics baseline (panic-family, parser-safety, silent-failure, concurrency, numeric, file/process, reviewability, and suppression governance lints).
- Added repo policy artifacts: `policy/clippy-lints.toml` (machine-readable active + planned lints), `policy/clippy-debt.toml` (debt ledger), `policy/no-panic-allowlist.toml` and `policy/non-rust-allowlist.toml` (TOML allowlists), plus `clippy.toml` and `docs/CLIPPY_POLICY.md` documenting the model and suppression style.
- Implemented `xtask/src/lint_policy.rs` and wired a `CheckLintPolicy` command into `xtask` and the `just ci-supported` lane to validate: workspace MSRV vs. policy, root lint block presence, no test carveouts in `clippy.toml`, planned 1.94/1.95 entries, debt metadata/expiry, and presence of required allowlists; the check reports staged inheritance as a warning until debt is migrated.

### Testing
- Ran `cargo +1.93.0 fmt --all -- --check`, which succeeded.
- Ran `cargo +1.93.0 xtask check-lint-policy`, which succeeded and printed: `lint policy OK: 103 active lint(s), 10 planned upgrade lint(s)` while warning that many workspace members still need to flip to `workspace = true` inheritance (policy is staged).
- Built and checked the new xtask command with `cargo +1.93.0 check -p xtask`, which succeeded.
- Ran the repository MSRV verification script (the same logic used by `just check-msrv`) and fixed mismatched crate `rust-version` entries; the check completed successfully after updates.
- Note: a full workspace `cargo clippy` run is long-running and was not fully validated in this ephemeral environment; `xtask` and the CI lane now include the new `cargo xtask check-lint-policy` step before `clippy` so the policy is enforced in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb0855588c833384e22ae937396536)