### PR TITLE
Add governed Clippy policy scaffolding, ratchet MSRV to 1.93, and xtask policy checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Instructions for autonomous AI agents (OpenAI Codex, etc.) working on this repos
 Adze is an AST-first grammar toolchain for Rust. It generates Tree-sitter parsers from Rust type annotations using a pure-Rust GLR implementation.
 
 - **Language**: Rust 2024 edition
-- **MSRV**: 1.92.0
+- **MSRV**: 1.93
 - **Workspace**: 75 crates
 - **Command runner**: `just` (see `justfile`)
 
@@ -17,7 +17,7 @@ The toolchain is auto-configured via `rust-toolchain.toml` — no manual Rust in
 
 ```bash
 # Verify toolchain
-rustc --version   # Should be >= 1.92.0
+rustc --version   # Should be >= 1.93
 just --version    # Command runner
 
 # System dependency (only needed for ts-bridge)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,8 +449,11 @@ dependencies = [
  "adze",
  "adze-javascript",
  "adze-python",
+ "adze-tool",
  "anyhow",
+ "serde_json",
  "sha2",
+ "tempfile",
 ]
 
 [[package]]
@@ -3129,6 +3132,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.1.0",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
@@ -3149,6 +3167,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -3950,6 +3977,7 @@ dependencies = [
  "serde_json",
  "similar",
  "tempfile",
+ "toml 0.9.12+spec-1.1.0",
  "walkdir",
  "xshell",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,14 +99,134 @@ homepage = "https://github.com/effortlessmetrics/adze"
 license = "Apache-2.0 OR MIT"
 publish = false
 repository = "https://github.com/effortlessmetrics/adze"
-rust-version = "1.92.0"
+rust-version = "1.93"
 
 
 [workspace.lints.rust]
+unsafe_code = "forbid"
 unsafe_op_in_unsafe_fn = "deny"
 unused_must_use = "deny"
+unexpected_cfgs = "warn"
+const_item_interior_mutations = "deny"
+function_casts_as_integer = "deny"
 missing_docs = "warn"
 unused_extern_crates = "deny"
+
+[workspace.lints.clippy]
+# Panic-free production and tests
+dbg_macro = "deny"
+todo = "deny"
+unimplemented = "deny"
+panic = "deny"
+unreachable = "deny"
+unwrap_used = "deny"
+expect_used = "deny"
+get_unwrap = "deny"
+unwrap_in_result = "deny"
+panic_in_result_fn = "deny"
+string_slice = "deny"
+indexing_slicing = "deny"
+out_of_bounds_indexing = "deny"
+unchecked_time_subtraction = "deny"
+
+# AST / parser / UTF-8 / slice safety
+char_indices_as_byte_indices = "deny"
+sliced_string_as_bytes = "deny"
+index_refutable_slice = "deny"
+
+# Silent failure
+let_underscore_future = "deny"
+let_underscore_must_use = "deny"
+let_underscore_lock = "deny"
+unused_result_ok = "deny"
+map_err_ignore = "deny"
+assertions_on_result_states = "deny"
+lines_filter_map_ok = "deny"
+
+# Async / concurrency
+await_holding_lock = "deny"
+await_holding_refcell_ref = "deny"
+await_holding_invalid_type = "deny"
+future_not_send = "warn"
+large_futures = "warn"
+arc_with_non_send_sync = "deny"
+rc_mutex = "deny"
+mut_mutex_lock = "deny"
+readonly_write_lock = "deny"
+
+# Unsafe / memory
+mem_forget = "deny"
+forget_non_drop = "deny"
+drop_non_drop = "deny"
+undocumented_unsafe_blocks = "deny"
+multiple_unsafe_ops_per_block = "deny"
+repr_packed_without_abi = "deny"
+
+# Numeric correctness
+float_cmp = "deny"
+float_cmp_const = "deny"
+float_equality_without_abs = "deny"
+lossy_float_literal = "deny"
+cast_sign_loss = "deny"
+cast_possible_wrap = "warn"
+cast_possible_truncation = "warn"
+cast_precision_loss = "warn"
+invalid_upcast_comparisons = "deny"
+cast_abs_to_unsigned = "deny"
+cast_enum_truncation = "deny"
+cast_nan_to_int = "deny"
+manual_midpoint = "warn"
+manual_is_multiple_of = "warn"
+manual_div_ceil = "warn"
+arithmetic_side_effects = "warn"
+
+# File/process/path footguns
+suspicious_open_options = "deny"
+nonsensical_open_options = "deny"
+ineffective_open_options = "deny"
+path_buf_push_overwrite = "deny"
+join_absolute_paths = "deny"
+read_line_without_trim = "warn"
+exit = "deny"
+
+# API / trait correctness
+iter_not_returning_iterator = "deny"
+expl_impl_clone_on_copy = "deny"
+infallible_try_from = "deny"
+fallible_impl_from = "deny"
+error_impl_error = "deny"
+result_unit_err = "warn"
+result_large_err = "warn"
+
+# Good taste that pays rent
+format_in_format_args = "deny"
+to_string_in_format_args = "deny"
+unused_format_specs = "deny"
+unnecessary_debug_formatting = "warn"
+uninlined_format_args = "warn"
+manual_let_else = "warn"
+manual_ok_or = "warn"
+manual_strip = "warn"
+manual_split_once = "warn"
+manual_is_variant_and = "warn"
+filter_map_next = "warn"
+flat_map_option = "warn"
+match_result_ok = "deny"
+cloned_instead_of_copied = "warn"
+iter_cloned_collect = "warn"
+iter_overeager_cloned = "warn"
+needless_collect = "warn"
+redundant_closure = "warn"
+redundant_closure_for_method_calls = "warn"
+missing_panics_doc = "deny"
+missing_errors_doc = "warn"
+
+# Suppression governance
+allow_attributes = "deny"
+allow_attributes_without_reason = "deny"
+blanket_clippy_restriction_lints = "deny"
+ignore_without_reason = "deny"
+should_panic_without_expect = "deny"
 
 [workspace.dependencies]
 tree-sitter = "=0.26.7"
@@ -128,6 +248,7 @@ rayon = "1.10"
 rustc-hash = "2.1"
 smallvec = "1.13"
 regex = "1.11"
+toml = "0.9.8"
 
 [profile.ci]
 inherits = "dev"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,7 @@
+# Repo-local Clippy configuration for Adze.
+#
+# Keep lint levels in Cargo.toml and policy/clippy-lints.toml. This file is only
+# for domain-specific disallowed-methods/types/macros or lint configuration that
+# Clippy cannot express through [workspace.lints]. Do not add test carveouts such
+# as allow-unwrap-in-tests, allow-expect-in-tests, allow-panic-in-tests,
+# allow-indexing-slicing-in-tests, or allow-dbg-in-tests.

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adze-common"
 version = "0.8.0-dev"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.93"
 authors = ["Steven Zimmerman, CPA"]
 description = "Shared grammar expansion logic for the Adze macro and tool crates"
 license = "Apache-2.0 OR MIT"

--- a/crates/parser-backend-core/src/lib.rs
+++ b/crates/parser-backend-core/src/lib.rs
@@ -5,7 +5,13 @@
 #![cfg_attr(feature = "strict_api", deny(unreachable_pub))]
 #![cfg_attr(not(feature = "strict_api"), warn(unreachable_pub))]
 #![cfg_attr(feature = "strict_docs", deny(missing_docs))]
-#![cfg_attr(not(feature = "strict_docs"), allow(missing_docs))]
+#![cfg_attr(
+    not(feature = "strict_docs"),
+    allow(
+        missing_docs,
+        reason = "strict docs are enforced only when the strict_docs feature is enabled"
+    )
+)]
 
 use core::fmt::{self, Display, Formatter};
 
@@ -73,6 +79,10 @@ impl ParserBackend {
     ///
     /// # Panics
     /// Panics if `has_conflicts` is true and the `pure-rust` feature is enabled without the `glr` feature.
+    #[expect(
+        clippy::panic,
+        reason = "public API preserves the documented panic contract for incompatible backend features"
+    )]
     pub const fn select(_has_conflicts: bool) -> Self {
         match Self::select_contract(_has_conflicts) {
             ParserBackendSelection::Backend(backend) => backend,

--- a/crates/ts-c-harness/Cargo.toml
+++ b/crates/ts-c-harness/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adze-ts-c-harness"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.92.0"
+rust-version = "1.93"
 license = "Apache-2.0 OR MIT"
 description = "Internal Tree-sitter C FFI parity test harness."
 repository = "https://github.com/EffortlessMetrics/adze"

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -1,0 +1,83 @@
+# Clippy Policy
+
+Adze treats Clippy as a governed engineering surface, not as a local taste file.
+The root workspace owns the active lint levels, `policy/clippy-lints.toml` records
+why each active lint exists and which future lints are planned, and `cargo xtask
+check-lint-policy` verifies that the manifest, policy ledger, and suppression
+posture stay coherent.
+
+## Active baseline
+
+The active workspace baseline is in the root `Cargo.toml` under
+`[workspace.lints.rust]` and `[workspace.lints.clippy]`. This first policy PR
+lands the shared surface and advisory inheritance report; follow-up PRs should
+ratchet workspace packages into enforcement with:
+
+```toml
+[lints]
+workspace = true
+```
+
+The baseline is intentionally workspace-wide: production code, examples, and tests
+all follow the same panic-free and silent-failure rules. In particular, do not add
+Clippy test carveouts such as `allow-unwrap-in-tests`, `allow-expect-in-tests`,
+`allow-panic-in-tests`, `allow-indexing-slicing-in-tests`, or
+`allow-dbg-in-tests`.
+
+## Suppression style
+
+Use narrow `#[expect(..., reason = "...")]` attributes when a lint must be
+suppressed at a specific site. Do not use broad `#[allow(...)]` attributes unless
+a future policy file explicitly permits the exception.
+
+```rust
+#[expect(
+    clippy::indexing_slicing,
+    reason = "generated parse table is bounded by tablegen invariants"
+)]
+fn lookup_generated_table(row: &[u16], idx: usize) -> u16 {
+    row[idx]
+}
+```
+
+Suppression debt belongs in `policy/clippy-debt.toml` when it is broader than one
+reviewed call site. Debt entries must include the lint, path, owner, reason, and
+expiry date so the exception remains temporary and attributable.
+
+## Policy ledger
+
+`policy/clippy-lints.toml` is the machine-readable source of truth for:
+
+- active Rust and Clippy lints;
+- the expected MSRV for the lint profile;
+- panic-free test posture;
+- suppression style;
+- planned Rust 1.94 and 1.95 lint flips.
+
+Planned lints stay in the ledger before the MSRV bump. They must not be activated
+in `Cargo.toml` until `activate_when_msrv` is reached.
+
+## Repo-local `clippy.toml`
+
+`clippy.toml` is intentionally not a second lint-level file. It is reserved for
+Clippy configuration that cannot be expressed in `[workspace.lints]`, such as
+future `disallowed-methods`, `disallowed-types`, or parser-specific policy data.
+It must not weaken the workspace posture or add test carveouts.
+
+## Checks
+
+Run the policy gate with:
+
+```bash
+cargo xtask check-lint-policy
+cargo xtask check-no-panic-family
+cargo xtask check-file-policy
+cargo xtask policy-report
+```
+
+The check verifies that the workspace MSRV matches the policy ledger, reports
+which workspace members still need lint inheritance, checks that active lints
+match `Cargo.toml`, ensures planned 1.94/1.95 lints are not active early, rejects
+`clippy.toml` test carveouts, and validates that lint debt is complete and
+unexpired. Set `ADZE_ENFORCE_LINT_INHERITANCE=1` in a follow-up ratchet to make
+missing `[lints] workspace = true` entries fail.

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -3,7 +3,7 @@ name = "adze-fuzz"
 version = "0.0.0"
 publish = false
 edition = "2024"
-rust-version = "1.92.0"
+rust-version = "1.93"
 
 [package.metadata]
 cargo-fuzz = true

--- a/glr-core/Cargo.toml
+++ b/glr-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adze-glr-core"
 version = "0.8.0-dev"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.93"
 description = "GLR parser generation algorithms for pure-Rust Tree-sitter"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/effortlessmetrics/adze"

--- a/ir/Cargo.toml
+++ b/ir/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adze-ir"
 version = "0.8.0-dev"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.93"
 description = "Grammar Intermediate Representation for pure-Rust Tree-sitter"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/effortlessmetrics/adze"

--- a/justfile
+++ b/justfile
@@ -23,6 +23,12 @@ test:
 check-fast:
     cargo check -p adze -p adze-ir -p adze-glr-core --profile dev-fast
 
+# Check governed policy ledgers
+check-lint-policy:
+    cargo xtask check-lint-policy
+    cargo xtask check-no-panic-family
+    cargo xtask check-file-policy
+
 # Run pre-commit checks
 pre:
     .githooks/pre-commit
@@ -73,6 +79,9 @@ ci-supported:
     export CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-2}"
     export RUST_TEST_THREADS="${RUST_TEST_THREADS:-2}"
     cargo fmt --all -- --check
+    cargo xtask check-lint-policy
+    cargo xtask check-no-panic-family
+    cargo xtask check-file-policy
     cargo clippy {{supported_crates}} --all-targets -- -D warnings
     cargo test {{supported_crates}} --lib --tests --bins -- --test-threads="$RUST_TEST_THREADS"
     cargo test -p adze-glr-core --features serialization --doc -- --test-threads="$RUST_TEST_THREADS"

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adze-macro"
 version = "0.8.0-dev"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.93"
 authors = ["Steven Zimmerman, CPA"]
 description = "Procedural macros for defining tree-sitter grammars alongside Rust logic"
 license = "Apache-2.0 OR MIT"

--- a/policy/clippy-debt.toml
+++ b/policy/clippy-debt.toml
@@ -1,0 +1,11 @@
+schema = 1
+
+# Temporary lint exceptions belong here, not in broad clippy.toml test carveouts.
+# Each debt entry must include lint, path, owner, reason, and expires.
+#
+# [[debt]]
+# lint = "clippy::indexing_slicing"
+# path = "crates/example/src/parser/table.rs"
+# owner = "parser"
+# reason = "Generated table access; replace with checked table abstraction."
+# expires = "2026-07-01"

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -1,0 +1,809 @@
+schema = 1
+msrv = "1.93"
+
+[policy]
+panic_free_tests = true
+allow_test_carveouts = false
+suppression_style = "expect-with-reason"
+blanket_categories = false
+
+[[lint]]
+name = "unsafe_code"
+level = "forbid"
+status = "active"
+class = "unsafe-memory"
+reason = "Keep unsafe and memory-sensitive shapes explicit and reviewable."
+
+[[lint]]
+name = "unsafe_op_in_unsafe_fn"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Keep unsafe and memory-sensitive shapes explicit and reviewable."
+
+[[lint]]
+name = "unused_must_use"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Prevent dropped futures, ignored Result values, and swallowed work."
+
+[[lint]]
+name = "unexpected_cfgs"
+level = "warn"
+status = "active"
+class = "tooling"
+reason = "Keep workspace compiler and toolchain configuration coherent."
+
+[[lint]]
+name = "const_item_interior_mutations"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Keep unsafe and memory-sensitive shapes explicit and reviewable."
+
+[[lint]]
+name = "function_casts_as_integer"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Keep unsafe and memory-sensitive shapes explicit and reviewable."
+
+[[lint]]
+name = "missing_docs"
+level = "warn"
+status = "active"
+class = "api-contract"
+reason = "Keep public APIs and trait implementations semantically correct and reviewable."
+
+[[lint]]
+name = "unused_extern_crates"
+level = "deny"
+status = "active"
+class = "tooling"
+reason = "Keep workspace compiler and toolchain configuration coherent."
+
+[[lint]]
+name = "clippy::dbg_macro"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Keep production and test code panic-free unless a narrow semantic allowlist covers the site."
+
+[[lint]]
+name = "clippy::todo"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Keep production and test code panic-free unless a narrow semantic allowlist covers the site."
+
+[[lint]]
+name = "clippy::unimplemented"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Keep production and test code panic-free unless a narrow semantic allowlist covers the site."
+
+[[lint]]
+name = "clippy::panic"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Keep production and test code panic-free unless a narrow semantic allowlist covers the site."
+
+[[lint]]
+name = "clippy::unreachable"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Keep production and test code panic-free unless a narrow semantic allowlist covers the site."
+
+[[lint]]
+name = "clippy::unwrap_used"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Keep production and test code panic-free unless a narrow semantic allowlist covers the site."
+
+[[lint]]
+name = "clippy::expect_used"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Keep production and test code panic-free unless a narrow semantic allowlist covers the site."
+
+[[lint]]
+name = "clippy::get_unwrap"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Keep production and test code panic-free unless a narrow semantic allowlist covers the site."
+
+[[lint]]
+name = "clippy::unwrap_in_result"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Keep production and test code panic-free unless a narrow semantic allowlist covers the site."
+
+[[lint]]
+name = "clippy::panic_in_result_fn"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Keep production and test code panic-free unless a narrow semantic allowlist covers the site."
+
+[[lint]]
+name = "clippy::string_slice"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Keep production and test code panic-free unless a narrow semantic allowlist covers the site."
+
+[[lint]]
+name = "clippy::indexing_slicing"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Keep production and test code panic-free unless a narrow semantic allowlist covers the site."
+
+[[lint]]
+name = "clippy::out_of_bounds_indexing"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Keep production and test code panic-free unless a narrow semantic allowlist covers the site."
+
+[[lint]]
+name = "clippy::unchecked_time_subtraction"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Keep production and test code panic-free unless a narrow semantic allowlist covers the site."
+
+[[lint]]
+name = "clippy::char_indices_as_byte_indices"
+level = "deny"
+status = "active"
+class = "parser-safety"
+reason = "Protect parser and AST code from UTF-8, indexing, and slice boundary mistakes."
+
+[[lint]]
+name = "clippy::sliced_string_as_bytes"
+level = "deny"
+status = "active"
+class = "parser-safety"
+reason = "Protect parser and AST code from UTF-8, indexing, and slice boundary mistakes."
+
+[[lint]]
+name = "clippy::index_refutable_slice"
+level = "deny"
+status = "active"
+class = "parser-safety"
+reason = "Protect parser and AST code from UTF-8, indexing, and slice boundary mistakes."
+
+[[lint]]
+name = "clippy::let_underscore_future"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Prevent dropped futures, ignored Result values, and swallowed work."
+
+[[lint]]
+name = "clippy::let_underscore_must_use"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Prevent dropped futures, ignored Result values, and swallowed work."
+
+[[lint]]
+name = "clippy::let_underscore_lock"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Prevent dropped futures, ignored Result values, and swallowed work."
+
+[[lint]]
+name = "clippy::unused_result_ok"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Prevent dropped futures, ignored Result values, and swallowed work."
+
+[[lint]]
+name = "clippy::map_err_ignore"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Prevent dropped futures, ignored Result values, and swallowed work."
+
+[[lint]]
+name = "clippy::assertions_on_result_states"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Prevent dropped futures, ignored Result values, and swallowed work."
+
+[[lint]]
+name = "clippy::lines_filter_map_ok"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Prevent dropped futures, ignored Result values, and swallowed work."
+
+[[lint]]
+name = "clippy::await_holding_lock"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Catch async and lock misuse before it becomes runtime flakiness."
+
+[[lint]]
+name = "clippy::await_holding_refcell_ref"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Catch async and lock misuse before it becomes runtime flakiness."
+
+[[lint]]
+name = "clippy::await_holding_invalid_type"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Catch async and lock misuse before it becomes runtime flakiness."
+
+[[lint]]
+name = "clippy::future_not_send"
+level = "warn"
+status = "active"
+class = "concurrency"
+reason = "Catch async and lock misuse before it becomes runtime flakiness."
+
+[[lint]]
+name = "clippy::large_futures"
+level = "warn"
+status = "active"
+class = "concurrency"
+reason = "Catch async and lock misuse before it becomes runtime flakiness."
+
+[[lint]]
+name = "clippy::arc_with_non_send_sync"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Catch async and lock misuse before it becomes runtime flakiness."
+
+[[lint]]
+name = "clippy::rc_mutex"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Catch async and lock misuse before it becomes runtime flakiness."
+
+[[lint]]
+name = "clippy::mut_mutex_lock"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Catch async and lock misuse before it becomes runtime flakiness."
+
+[[lint]]
+name = "clippy::readonly_write_lock"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Catch async and lock misuse before it becomes runtime flakiness."
+
+[[lint]]
+name = "clippy::mem_forget"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Keep unsafe and memory-sensitive shapes explicit and reviewable."
+
+[[lint]]
+name = "clippy::forget_non_drop"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Keep unsafe and memory-sensitive shapes explicit and reviewable."
+
+[[lint]]
+name = "clippy::drop_non_drop"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Keep unsafe and memory-sensitive shapes explicit and reviewable."
+
+[[lint]]
+name = "clippy::undocumented_unsafe_blocks"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Keep unsafe and memory-sensitive shapes explicit and reviewable."
+
+[[lint]]
+name = "clippy::multiple_unsafe_ops_per_block"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Keep unsafe and memory-sensitive shapes explicit and reviewable."
+
+[[lint]]
+name = "clippy::repr_packed_without_abi"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Keep unsafe and memory-sensitive shapes explicit and reviewable."
+
+[[lint]]
+name = "clippy::float_cmp"
+level = "deny"
+status = "active"
+class = "numeric-correctness"
+reason = "Surface numeric conversions, comparisons, and arithmetic that need reviewed intent."
+
+[[lint]]
+name = "clippy::float_cmp_const"
+level = "deny"
+status = "active"
+class = "numeric-correctness"
+reason = "Surface numeric conversions, comparisons, and arithmetic that need reviewed intent."
+
+[[lint]]
+name = "clippy::float_equality_without_abs"
+level = "deny"
+status = "active"
+class = "numeric-correctness"
+reason = "Surface numeric conversions, comparisons, and arithmetic that need reviewed intent."
+
+[[lint]]
+name = "clippy::lossy_float_literal"
+level = "deny"
+status = "active"
+class = "numeric-correctness"
+reason = "Surface numeric conversions, comparisons, and arithmetic that need reviewed intent."
+
+[[lint]]
+name = "clippy::cast_sign_loss"
+level = "deny"
+status = "active"
+class = "numeric-correctness"
+reason = "Surface numeric conversions, comparisons, and arithmetic that need reviewed intent."
+
+[[lint]]
+name = "clippy::cast_possible_wrap"
+level = "warn"
+status = "active"
+class = "numeric-correctness"
+reason = "Surface numeric conversions, comparisons, and arithmetic that need reviewed intent."
+
+[[lint]]
+name = "clippy::cast_possible_truncation"
+level = "warn"
+status = "active"
+class = "numeric-correctness"
+reason = "Surface numeric conversions, comparisons, and arithmetic that need reviewed intent."
+
+[[lint]]
+name = "clippy::cast_precision_loss"
+level = "warn"
+status = "active"
+class = "numeric-correctness"
+reason = "Surface numeric conversions, comparisons, and arithmetic that need reviewed intent."
+
+[[lint]]
+name = "clippy::invalid_upcast_comparisons"
+level = "deny"
+status = "active"
+class = "numeric-correctness"
+reason = "Surface numeric conversions, comparisons, and arithmetic that need reviewed intent."
+
+[[lint]]
+name = "clippy::cast_abs_to_unsigned"
+level = "deny"
+status = "active"
+class = "numeric-correctness"
+reason = "Surface numeric conversions, comparisons, and arithmetic that need reviewed intent."
+
+[[lint]]
+name = "clippy::cast_enum_truncation"
+level = "deny"
+status = "active"
+class = "numeric-correctness"
+reason = "Surface numeric conversions, comparisons, and arithmetic that need reviewed intent."
+
+[[lint]]
+name = "clippy::cast_nan_to_int"
+level = "deny"
+status = "active"
+class = "numeric-correctness"
+reason = "Surface numeric conversions, comparisons, and arithmetic that need reviewed intent."
+
+[[lint]]
+name = "clippy::manual_midpoint"
+level = "warn"
+status = "active"
+class = "numeric-correctness"
+reason = "Surface numeric conversions, comparisons, and arithmetic that need reviewed intent."
+
+[[lint]]
+name = "clippy::manual_is_multiple_of"
+level = "warn"
+status = "active"
+class = "numeric-correctness"
+reason = "Surface numeric conversions, comparisons, and arithmetic that need reviewed intent."
+
+[[lint]]
+name = "clippy::manual_div_ceil"
+level = "warn"
+status = "active"
+class = "numeric-correctness"
+reason = "Surface numeric conversions, comparisons, and arithmetic that need reviewed intent."
+
+[[lint]]
+name = "clippy::arithmetic_side_effects"
+level = "warn"
+status = "active"
+class = "numeric-correctness"
+reason = "Surface numeric conversions, comparisons, and arithmetic that need reviewed intent."
+
+[[lint]]
+name = "clippy::suspicious_open_options"
+level = "deny"
+status = "active"
+class = "filesystem-process"
+reason = "Avoid filesystem, path, and process-control footguns outside reviewed boundaries."
+
+[[lint]]
+name = "clippy::nonsensical_open_options"
+level = "deny"
+status = "active"
+class = "filesystem-process"
+reason = "Avoid filesystem, path, and process-control footguns outside reviewed boundaries."
+
+[[lint]]
+name = "clippy::ineffective_open_options"
+level = "deny"
+status = "active"
+class = "filesystem-process"
+reason = "Avoid filesystem, path, and process-control footguns outside reviewed boundaries."
+
+[[lint]]
+name = "clippy::path_buf_push_overwrite"
+level = "deny"
+status = "active"
+class = "filesystem-process"
+reason = "Avoid filesystem, path, and process-control footguns outside reviewed boundaries."
+
+[[lint]]
+name = "clippy::join_absolute_paths"
+level = "deny"
+status = "active"
+class = "filesystem-process"
+reason = "Avoid filesystem, path, and process-control footguns outside reviewed boundaries."
+
+[[lint]]
+name = "clippy::read_line_without_trim"
+level = "warn"
+status = "active"
+class = "filesystem-process"
+reason = "Avoid filesystem, path, and process-control footguns outside reviewed boundaries."
+
+[[lint]]
+name = "clippy::exit"
+level = "deny"
+status = "active"
+class = "filesystem-process"
+reason = "Avoid filesystem, path, and process-control footguns outside reviewed boundaries."
+
+[[lint]]
+name = "clippy::iter_not_returning_iterator"
+level = "deny"
+status = "active"
+class = "api-contract"
+reason = "Keep public APIs and trait implementations semantically correct and reviewable."
+
+[[lint]]
+name = "clippy::expl_impl_clone_on_copy"
+level = "deny"
+status = "active"
+class = "api-contract"
+reason = "Keep public APIs and trait implementations semantically correct and reviewable."
+
+[[lint]]
+name = "clippy::infallible_try_from"
+level = "deny"
+status = "active"
+class = "api-contract"
+reason = "Keep public APIs and trait implementations semantically correct and reviewable."
+
+[[lint]]
+name = "clippy::fallible_impl_from"
+level = "deny"
+status = "active"
+class = "api-contract"
+reason = "Keep public APIs and trait implementations semantically correct and reviewable."
+
+[[lint]]
+name = "clippy::error_impl_error"
+level = "deny"
+status = "active"
+class = "api-contract"
+reason = "Keep public APIs and trait implementations semantically correct and reviewable."
+
+[[lint]]
+name = "clippy::result_unit_err"
+level = "warn"
+status = "active"
+class = "api-contract"
+reason = "Keep public APIs and trait implementations semantically correct and reviewable."
+
+[[lint]]
+name = "clippy::result_large_err"
+level = "warn"
+status = "active"
+class = "api-contract"
+reason = "Keep public APIs and trait implementations semantically correct and reviewable."
+
+[[lint]]
+name = "clippy::format_in_format_args"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer, lower-noise idioms that make reviews easier."
+
+[[lint]]
+name = "clippy::to_string_in_format_args"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer, lower-noise idioms that make reviews easier."
+
+[[lint]]
+name = "clippy::unused_format_specs"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer, lower-noise idioms that make reviews easier."
+
+[[lint]]
+name = "clippy::unnecessary_debug_formatting"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer, lower-noise idioms that make reviews easier."
+
+[[lint]]
+name = "clippy::uninlined_format_args"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer, lower-noise idioms that make reviews easier."
+
+[[lint]]
+name = "clippy::manual_let_else"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer, lower-noise idioms that make reviews easier."
+
+[[lint]]
+name = "clippy::manual_ok_or"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer, lower-noise idioms that make reviews easier."
+
+[[lint]]
+name = "clippy::manual_strip"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer, lower-noise idioms that make reviews easier."
+
+[[lint]]
+name = "clippy::manual_split_once"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer, lower-noise idioms that make reviews easier."
+
+[[lint]]
+name = "clippy::manual_is_variant_and"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer, lower-noise idioms that make reviews easier."
+
+[[lint]]
+name = "clippy::filter_map_next"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer, lower-noise idioms that make reviews easier."
+
+[[lint]]
+name = "clippy::flat_map_option"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer, lower-noise idioms that make reviews easier."
+
+[[lint]]
+name = "clippy::match_result_ok"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer, lower-noise idioms that make reviews easier."
+
+[[lint]]
+name = "clippy::cloned_instead_of_copied"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer, lower-noise idioms that make reviews easier."
+
+[[lint]]
+name = "clippy::iter_cloned_collect"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer, lower-noise idioms that make reviews easier."
+
+[[lint]]
+name = "clippy::iter_overeager_cloned"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer, lower-noise idioms that make reviews easier."
+
+[[lint]]
+name = "clippy::needless_collect"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer, lower-noise idioms that make reviews easier."
+
+[[lint]]
+name = "clippy::redundant_closure"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer, lower-noise idioms that make reviews easier."
+
+[[lint]]
+name = "clippy::redundant_closure_for_method_calls"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer, lower-noise idioms that make reviews easier."
+
+[[lint]]
+name = "clippy::missing_panics_doc"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer, lower-noise idioms that make reviews easier."
+
+[[lint]]
+name = "clippy::missing_errors_doc"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer, lower-noise idioms that make reviews easier."
+
+[[lint]]
+name = "clippy::allow_attributes"
+level = "deny"
+status = "active"
+class = "suppression-governance"
+reason = "Require explicit, reasoned suppressions instead of silent broad allowances."
+
+[[lint]]
+name = "clippy::allow_attributes_without_reason"
+level = "deny"
+status = "active"
+class = "suppression-governance"
+reason = "Require explicit, reasoned suppressions instead of silent broad allowances."
+
+[[lint]]
+name = "clippy::blanket_clippy_restriction_lints"
+level = "deny"
+status = "active"
+class = "suppression-governance"
+reason = "Require explicit, reasoned suppressions instead of silent broad allowances."
+
+[[lint]]
+name = "clippy::ignore_without_reason"
+level = "deny"
+status = "active"
+class = "suppression-governance"
+reason = "Require explicit, reasoned suppressions instead of silent broad allowances."
+
+[[lint]]
+name = "clippy::should_panic_without_expect"
+level = "deny"
+status = "active"
+class = "suppression-governance"
+reason = "Require explicit, reasoned suppressions instead of silent broad allowances."
+
+[[lint]]
+name = "clippy::same_length_and_capacity"
+level = "deny"
+status = "planned"
+activate_when_msrv = "1.94"
+class = "unsafe-memory"
+reason = "Catch raw-parts reconstruction mistakes."
+
+[[lint]]
+name = "clippy::manual_ilog2"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.94"
+class = "numeric-correctness"
+reason = "Prefer the standard integer log helper."
+
+[[lint]]
+name = "clippy::decimal_bitwise_operands"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.94"
+class = "numeric-correctness"
+reason = "Make bit masks visually inspectable."
+
+[[lint]]
+name = "clippy::needless_type_cast"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.94"
+class = "numeric-correctness"
+reason = "Avoid stale numeric type drift."
+
+[[lint]]
+name = "clippy::disallowed_fields"
+level = "deny"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "architecture"
+reason = "Allow architecture policy to ban direct field access across protected seams."
+
+[[lint]]
+name = "clippy::manual_checked_ops"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "numeric-correctness"
+reason = "Prefer checked arithmetic over manual divide-by-zero guards."
+
+[[lint]]
+name = "clippy::manual_take"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "ownership"
+reason = "Use standard ownership helper instead of local reimplementation."
+
+[[lint]]
+name = "clippy::manual_pop_if"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "collections"
+reason = "Use collection APIs that encode predicate-and-pop intent directly."
+
+[[lint]]
+name = "clippy::duration_suboptimal_units"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "time"
+reason = "Make durations legible without mental unit conversion."
+
+[[lint]]
+name = "clippy::unnecessary_trailing_comma"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "reviewability"
+reason = "Keep generated and hand-written format macro calls clean."

--- a/policy/no-panic-allowlist.toml
+++ b/policy/no-panic-allowlist.toml
@@ -1,0 +1,5 @@
+schema_version = "0.3"
+
+# Panic-family exceptions are intentionally empty for this first policy ratchet.
+# Future exceptions must use path + family + selector identity with owner,
+# classification, explanation, advisory last_seen, and optional expires.

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -1,0 +1,5 @@
+schema_version = "1.0"
+
+# Non-Rust file policy will be populated as the file-policy checker lands.
+# Entries must use path or glob plus kind, owner, reason, surface,
+# classification, covered_by, and optional expires.

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adze"
 version = "0.8.0-dev"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.93"
 authors = ["Steven Zimmerman, CPA"]
 description = "Define tree-sitter grammars alongside Rust logic with AST-first parsing"
 license = "Apache-2.0 OR MIT"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.92.0"
+channel = "1.93"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/tablegen/Cargo.toml
+++ b/tablegen/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adze-tablegen"
 version = "0.8.0-dev"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.93"
 description = "Table generation and compression for pure-Rust Tree-sitter"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/effortlessmetrics/adze"

--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adze-tool"
 version = "0.8.0-dev"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.93"
 authors = ["Steven Zimmerman, CPA"]
 description = "Build-time code generation tool for Adze grammar definitions"
 license = "Apache-2.0 OR MIT"

--- a/tools/ts-bridge/Cargo.toml
+++ b/tools/ts-bridge/Cargo.toml
@@ -3,7 +3,7 @@ name = "ts-bridge"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
 edition = "2024"
-rust-version = "1.92.0"
+rust-version = "1.93"
 
 [lib]
 crate-type = ["rlib", "cdylib"]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -16,5 +16,6 @@ walkdir = "2.5.0"
 glob = "0.3.3"
 chrono = "0.4.44"
 serde.workspace = true
+toml.workspace = true
 adze-tool = { version = "0.8.0-dev", path = "../tool" }
 tempfile.workspace = true

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -10,6 +10,7 @@ mod fixtures;
 mod golden;
 mod grammar_json;
 mod lint;
+mod policy;
 mod profile;
 mod test_grammars;
 mod test_local_grammars;
@@ -169,6 +170,14 @@ enum Commands {
         #[arg(last = true)]
         clippy_args: Vec<String>,
     },
+    /// Check the governed Clippy policy ledger and workspace lint inheritance
+    CheckLintPolicy,
+    /// Validate the semantic no-panic allowlist schema
+    CheckNoPanicFamily,
+    /// Validate the non-Rust file policy allowlist schema
+    CheckFilePolicy,
+    /// Print a summary of configured policy ledgers
+    PolicyReport,
     /// Generate arithmetic expression fixtures for benchmarking
     GenerateFixtures {
         /// Output directory for fixtures
@@ -361,6 +370,18 @@ fn main() -> Result<()> {
             clippy_args,
         } => {
             lint::lint(&sh, fix, changed_only, since, fast, clippy_args)?;
+        }
+        Commands::CheckLintPolicy => {
+            policy::check_lint_policy()?;
+        }
+        Commands::CheckNoPanicFamily => {
+            policy::check_no_panic_family()?;
+        }
+        Commands::CheckFilePolicy => {
+            policy::check_file_policy()?;
+        }
+        Commands::PolicyReport => {
+            policy::policy_report()?;
         }
         Commands::GenerateFixtures { output, force } => {
             fixtures::generate_fixtures(&sh, &output, force)?;

--- a/xtask/src/policy.rs
+++ b/xtask/src/policy.rs
@@ -1,0 +1,560 @@
+use anyhow::{Context, Result, bail};
+use chrono::NaiveDate;
+use serde::Deserialize;
+use std::{collections::BTreeMap, env, fs, path::Path, process::Command};
+
+type LintMap = BTreeMap<String, String>;
+
+const CLIPPY_TEST_CARVEOUTS: &[&str] = &[
+    "allow-unwrap-in-tests",
+    "allow-expect-in-tests",
+    "allow-panic-in-tests",
+    "allow-indexing-slicing-in-tests",
+    "allow-dbg-in-tests",
+];
+
+#[derive(Debug, Deserialize)]
+struct ClippyPolicyLedger {
+    schema: u64,
+    msrv: String,
+    policy: ClippyPolicy,
+    #[serde(default)]
+    lint: Vec<LintEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClippyPolicy {
+    panic_free_tests: bool,
+    allow_test_carveouts: bool,
+    suppression_style: String,
+    blanket_categories: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct LintEntry {
+    name: String,
+    level: String,
+    status: String,
+    #[serde(default)]
+    activate_when_msrv: Option<String>,
+    class: String,
+    reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClippyDebtLedger {
+    schema: u64,
+    #[serde(default)]
+    debt: Vec<DebtEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DebtEntry {
+    lint: String,
+    path: String,
+    owner: String,
+    reason: String,
+    expires: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct NoPanicAllowlist {
+    schema_version: String,
+    #[serde(default)]
+    allow: Vec<NoPanicAllow>,
+}
+
+#[derive(Debug, Deserialize)]
+struct NoPanicAllow {
+    path: String,
+    family: String,
+    classification: String,
+    owner: String,
+    explanation: String,
+    #[serde(default)]
+    expires: Option<String>,
+    selector: PanicSelector,
+    #[serde(default)]
+    last_seen: Option<LastSeen>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PanicSelector {
+    kind: String,
+    container: String,
+    callee: String,
+    #[serde(default)]
+    receiver_fingerprint: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LastSeen {
+    line: u64,
+    column: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct NonRustAllowlist {
+    schema_version: String,
+    #[serde(default)]
+    allow: Vec<NonRustAllow>,
+}
+
+#[derive(Debug, Deserialize)]
+struct NonRustAllow {
+    #[serde(default)]
+    path: Option<String>,
+    #[serde(default)]
+    glob: Option<String>,
+    kind: String,
+    owner: String,
+    reason: String,
+    surface: String,
+    classification: String,
+    #[serde(default)]
+    covered_by: Vec<String>,
+    #[serde(default)]
+    expires: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CargoManifest {
+    workspace: Workspace,
+}
+
+#[derive(Debug, Deserialize)]
+struct Workspace {
+    package: WorkspacePackage,
+    #[serde(default)]
+    lints: WorkspaceLints,
+}
+
+#[derive(Debug, Deserialize)]
+struct WorkspacePackage {
+    #[serde(rename = "rust-version")]
+    rust_version: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct WorkspaceLints {
+    #[serde(default)]
+    rust: LintMap,
+    #[serde(default)]
+    clippy: LintMap,
+}
+
+#[derive(Debug, Deserialize)]
+struct CargoMetadata {
+    packages: Vec<MetadataPackage>,
+    workspace_members: Vec<String>,
+    workspace_root: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct MetadataPackage {
+    id: String,
+    manifest_path: String,
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct PackageManifest {
+    #[serde(default)]
+    lints: Option<PackageLints>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PackageLints {
+    #[serde(default)]
+    workspace: bool,
+}
+
+pub fn check_lint_policy() -> Result<()> {
+    let root = repo_root()?;
+    let cargo = read_toml::<CargoManifest>(&root.join("Cargo.toml"))?;
+    let ledger = read_toml::<ClippyPolicyLedger>(&root.join("policy/clippy-lints.toml"))?;
+    let debt = read_toml::<ClippyDebtLedger>(&root.join("policy/clippy-debt.toml"))?;
+
+    ensure_ledger_header(&ledger)?;
+    ensure_msrv_matches(&cargo, &ledger)?;
+    ensure_lints_match_manifest(&cargo.workspace.lints, &ledger)?;
+    ensure_planned_lints_not_active(&cargo.workspace.lints, &ledger)?;
+    ensure_workspace_lint_inheritance(&root)?;
+    ensure_no_test_carveouts(&root.join("clippy.toml"))?;
+    ensure_debt_is_reviewable(&debt)?;
+
+    println!(
+        "✓ lint policy ok: {} active lints, {} planned lints, {} debt entries",
+        active_lints(&ledger).count(),
+        planned_lints(&ledger).count(),
+        debt.debt.len()
+    );
+    Ok(())
+}
+
+pub fn check_no_panic_family() -> Result<()> {
+    let root = repo_root()?;
+    let allowlist = read_toml::<NoPanicAllowlist>(&root.join("policy/no-panic-allowlist.toml"))?;
+    ensure_no_panic_allowlist(&allowlist)?;
+    println!(
+        "✓ no-panic allowlist ok: {} semantic exceptions",
+        allowlist.allow.len()
+    );
+    Ok(())
+}
+
+pub fn check_file_policy() -> Result<()> {
+    let root = repo_root()?;
+    let allowlist = read_toml::<NonRustAllowlist>(&root.join("policy/non-rust-allowlist.toml"))?;
+    ensure_non_rust_allowlist(&allowlist)?;
+    println!(
+        "✓ non-rust allowlist ok: {} policy exceptions",
+        allowlist.allow.len()
+    );
+    Ok(())
+}
+
+pub fn policy_report() -> Result<()> {
+    let root = repo_root()?;
+    let ledger = read_toml::<ClippyPolicyLedger>(&root.join("policy/clippy-lints.toml"))?;
+    let debt = read_toml::<ClippyDebtLedger>(&root.join("policy/clippy-debt.toml"))?;
+    let no_panic = read_toml::<NoPanicAllowlist>(&root.join("policy/no-panic-allowlist.toml"))?;
+    let non_rust = read_toml::<NonRustAllowlist>(&root.join("policy/non-rust-allowlist.toml"))?;
+
+    println!("policy report");
+    println!("  clippy schema: {}", ledger.schema);
+    println!("  clippy msrv: {}", ledger.msrv);
+    println!("  active lints: {}", active_lints(&ledger).count());
+    println!("  planned lints: {}", planned_lints(&ledger).count());
+    println!("  clippy debt entries: {}", debt.debt.len());
+    println!("  no-panic exceptions: {}", no_panic.allow.len());
+    println!("  non-rust exceptions: {}", non_rust.allow.len());
+    Ok(())
+}
+
+fn ensure_no_panic_allowlist(allowlist: &NoPanicAllowlist) -> Result<()> {
+    if allowlist.schema_version != "0.3" {
+        bail!("policy/no-panic-allowlist.toml schema_version must be 0.3");
+    }
+    for entry in &allowlist.allow {
+        require_non_empty(&entry.path, "allow.path")?;
+        require_non_empty(&entry.family, "allow.family")?;
+        require_non_empty(&entry.classification, "allow.classification")?;
+        require_non_empty(&entry.owner, "allow.owner")?;
+        require_non_empty(&entry.explanation, "allow.explanation")?;
+        require_non_empty(&entry.selector.kind, "allow.selector.kind")?;
+        require_non_empty(&entry.selector.container, "allow.selector.container")?;
+        require_non_empty(&entry.selector.callee, "allow.selector.callee")?;
+        if let Some(receiver) = &entry.selector.receiver_fingerprint {
+            require_non_empty(receiver, "allow.selector.receiver_fingerprint")?;
+        }
+        if let Some(last_seen) = &entry.last_seen {
+            if last_seen.line == 0 || last_seen.column == 0 {
+                bail!("allow.last_seen line and column must be one-based");
+            }
+        }
+        ensure_optional_expiry(entry.expires.as_deref(), &entry.path)?;
+    }
+    Ok(())
+}
+
+fn ensure_non_rust_allowlist(allowlist: &NonRustAllowlist) -> Result<()> {
+    if allowlist.schema_version != "1.0" {
+        bail!("policy/non-rust-allowlist.toml schema_version must be 1.0");
+    }
+    for entry in &allowlist.allow {
+        if entry.path.is_none() == entry.glob.is_none() {
+            bail!("non-rust allow entries must set exactly one of path or glob");
+        }
+        if let Some(path) = &entry.path {
+            require_non_empty(path, "allow.path")?;
+        }
+        if let Some(glob) = &entry.glob {
+            require_non_empty(glob, "allow.glob")?;
+        }
+        require_non_empty(&entry.kind, "allow.kind")?;
+        require_non_empty(&entry.owner, "allow.owner")?;
+        require_non_empty(&entry.reason, "allow.reason")?;
+        require_non_empty(&entry.surface, "allow.surface")?;
+        require_non_empty(&entry.classification, "allow.classification")?;
+        if matches!(
+            entry.classification.as_str(),
+            "production" | "test" | "tooling"
+        ) && entry.covered_by.is_empty()
+        {
+            bail!(
+                "non-rust allow entry for {} must include covered_by",
+                entry.owner
+            );
+        }
+        ensure_optional_expiry(
+            entry.expires.as_deref(),
+            entry
+                .path
+                .as_deref()
+                .or(entry.glob.as_deref())
+                .unwrap_or("<unknown>"),
+        )?;
+    }
+    Ok(())
+}
+
+fn ensure_optional_expiry(expires: Option<&str>, label: &str) -> Result<()> {
+    if let Some(expires) = expires {
+        let today = chrono::Utc::now().date_naive();
+        let expires_date = NaiveDate::parse_from_str(expires, "%Y-%m-%d")
+            .with_context(|| format!("{label} has invalid expires date"))?;
+        if expires_date < today {
+            bail!("{label} expired on {expires}");
+        }
+    }
+    Ok(())
+}
+
+fn ensure_ledger_header(ledger: &ClippyPolicyLedger) -> Result<()> {
+    if ledger.schema != 1 {
+        bail!("policy/clippy-lints.toml schema must be 1");
+    }
+    if !ledger.policy.panic_free_tests {
+        bail!("policy/clippy-lints.toml must keep panic_free_tests = true");
+    }
+    if ledger.policy.allow_test_carveouts {
+        bail!("policy/clippy-lints.toml must keep allow_test_carveouts = false");
+    }
+    if ledger.policy.suppression_style != "expect-with-reason" {
+        bail!("policy/clippy-lints.toml must use suppression_style = \"expect-with-reason\"");
+    }
+    if ledger.policy.blanket_categories {
+        bail!("policy/clippy-lints.toml must keep blanket_categories = false");
+    }
+    for lint in &ledger.lint {
+        require_non_empty(&lint.name, "lint.name")?;
+        require_non_empty(&lint.level, "lint.level")?;
+        require_non_empty(&lint.status, "lint.status")?;
+        require_non_empty(&lint.class, "lint.class")?;
+        require_non_empty(&lint.reason, "lint.reason")?;
+        if lint.status != "active" && lint.status != "planned" {
+            bail!("lint {} has unsupported status {}", lint.name, lint.status);
+        }
+        if lint.status == "planned" && lint.activate_when_msrv.is_none() {
+            bail!("planned lint {} is missing activate_when_msrv", lint.name);
+        }
+    }
+    Ok(())
+}
+
+fn ensure_msrv_matches(cargo: &CargoManifest, ledger: &ClippyPolicyLedger) -> Result<()> {
+    if cargo.workspace.package.rust_version != ledger.msrv {
+        bail!(
+            "workspace.package.rust-version {} does not match policy msrv {}",
+            cargo.workspace.package.rust_version,
+            ledger.msrv
+        );
+    }
+    Ok(())
+}
+
+fn ensure_lints_match_manifest(lints: &WorkspaceLints, ledger: &ClippyPolicyLedger) -> Result<()> {
+    let manifest_lints = flatten_lints(lints);
+    for lint in active_lints(ledger) {
+        let actual = manifest_lints.get(&lint.name).ok_or_else(|| {
+            anyhow::anyhow!("active lint {} is missing from root Cargo.toml", lint.name)
+        })?;
+        if actual != &lint.level {
+            bail!(
+                "active lint {} is {} in policy but {} in Cargo.toml",
+                lint.name,
+                lint.level,
+                actual
+            );
+        }
+    }
+    for (name, level) in manifest_lints {
+        let Some(policy_lint) = ledger.lint.iter().find(|lint| lint.name == name) else {
+            bail!("Cargo.toml lint {name} = {level} is missing from policy/clippy-lints.toml");
+        };
+        if policy_lint.status != "active" {
+            bail!(
+                "Cargo.toml lint {name} is marked {} in policy",
+                policy_lint.status
+            );
+        }
+    }
+    Ok(())
+}
+
+fn ensure_planned_lints_not_active(
+    lints: &WorkspaceLints,
+    ledger: &ClippyPolicyLedger,
+) -> Result<()> {
+    let manifest_lints = flatten_lints(lints);
+    for lint in planned_lints(ledger) {
+        if manifest_lints.contains_key(&lint.name) {
+            bail!(
+                "planned lint {} must not be active before MSRV {}",
+                lint.name,
+                lint.activate_when_msrv.as_deref().unwrap_or("<missing>")
+            );
+        }
+    }
+    Ok(())
+}
+
+fn ensure_workspace_lint_inheritance(root: &Path) -> Result<()> {
+    let metadata = cargo_metadata(root)?;
+    let enforce = env::var_os("ADZE_ENFORCE_LINT_INHERITANCE").is_some();
+    let mut missing = Vec::new();
+    for package in metadata.packages {
+        if !metadata
+            .workspace_members
+            .iter()
+            .any(|id| id == &package.id)
+        {
+            continue;
+        }
+        let manifest_path = Path::new(&package.manifest_path);
+        let manifest = read_toml::<PackageManifest>(manifest_path)?;
+        if !manifest.lints.map(|lints| lints.workspace).unwrap_or(false) {
+            let relative_path = manifest_path
+                .strip_prefix(&metadata.workspace_root)
+                .unwrap_or(manifest_path);
+            missing.push(format!("{} ({})", package.name, relative_path.display()));
+        }
+    }
+    if !missing.is_empty() {
+        if enforce {
+            bail!(
+                "{} workspace members are missing [lints] workspace = true: {}",
+                missing.len(),
+                missing.join(", ")
+            );
+        }
+        println!(
+            "⚠️  lint inheritance is advisory in this PR: {} workspace members still need [lints] workspace = true",
+            missing.len()
+        );
+    }
+    Ok(())
+}
+
+fn ensure_no_test_carveouts(path: &Path) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+    let contents =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
+    for (line_number, line) in contents.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        for carveout in CLIPPY_TEST_CARVEOUTS {
+            if trimmed.starts_with(carveout) {
+                bail!(
+                    "clippy.toml must not set {carveout} (line {})",
+                    line_number + 1
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn ensure_debt_is_reviewable(ledger: &ClippyDebtLedger) -> Result<()> {
+    if ledger.schema != 1 {
+        bail!("policy/clippy-debt.toml schema must be 1");
+    }
+    let today = chrono::Utc::now().date_naive();
+    for entry in &ledger.debt {
+        require_non_empty(&entry.lint, "debt.lint")?;
+        require_non_empty(&entry.path, "debt.path")?;
+        require_non_empty(&entry.owner, "debt.owner")?;
+        require_non_empty(&entry.reason, "debt.reason")?;
+        require_non_empty(&entry.expires, "debt.expires")?;
+        let expires = NaiveDate::parse_from_str(&entry.expires, "%Y-%m-%d")
+            .with_context(|| format!("debt {} has invalid expires date", entry.lint))?;
+        if expires < today {
+            bail!(
+                "debt {} for {} expired on {}",
+                entry.lint,
+                entry.path,
+                entry.expires
+            );
+        }
+    }
+    Ok(())
+}
+
+fn flatten_lints(lints: &WorkspaceLints) -> LintMap {
+    let mut out = LintMap::new();
+    out.extend(
+        lints
+            .rust
+            .iter()
+            .map(|(name, level)| (name.clone(), level.clone())),
+    );
+    out.extend(
+        lints
+            .clippy
+            .iter()
+            .map(|(name, level)| (format!("clippy::{name}"), level.clone())),
+    );
+    out
+}
+
+fn active_lints(ledger: &ClippyPolicyLedger) -> impl Iterator<Item = &LintEntry> {
+    ledger.lint.iter().filter(|lint| lint.status == "active")
+}
+
+fn planned_lints(ledger: &ClippyPolicyLedger) -> impl Iterator<Item = &LintEntry> {
+    ledger.lint.iter().filter(|lint| lint.status == "planned")
+}
+
+fn require_non_empty(value: &str, field: &str) -> Result<()> {
+    if value.trim().is_empty() {
+        bail!("{field} must not be empty");
+    }
+    Ok(())
+}
+
+fn repo_root() -> Result<std::path::PathBuf> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .context("failed to run git rev-parse --show-toplevel")?;
+    if !output.status.success() {
+        bail!(
+            "git rev-parse --show-toplevel failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(std::path::PathBuf::from(
+        String::from_utf8(output.stdout)
+            .context("git returned a non-utf8 repo root")?
+            .trim(),
+    ))
+}
+
+fn cargo_metadata(root: &Path) -> Result<CargoMetadata> {
+    let output = Command::new("cargo")
+        .args(["metadata", "--no-deps", "--format-version", "1"])
+        .current_dir(root)
+        .output()
+        .context("failed to run cargo metadata")?;
+    if !output.status.success() {
+        bail!(
+            "cargo metadata failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    serde_json::from_slice(&output.stdout).context("failed to parse cargo metadata")
+}
+
+fn read_toml<T>(path: &Path) -> Result<T>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let contents =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
+    toml::from_str(&contents).with_context(|| format!("failed to parse {}", path.display()))
+}


### PR DESCRIPTION
### Motivation

- Establish a single, governed Clippy baseline (panic-free, suppression governance, AST/slice safety, silent-failure prevention, and good-taste reviews) and record planned Rust 1.94/1.95 flips so linting is an infrastructure surface, not a per-crate vibes file. 
- Provide machine-readable policy and allowlist artifacts and automated checks so exceptions are explicit, expiring, and reviewable rather than hidden in local configs or test carveouts.

### Description

- Ratchets the workspace/toolchain MSRV to `1.93` and adds a shared workspace lint surface under `[workspace.lints.rust]` and `[workspace.lints.clippy]` in `Cargo.toml` and `rust-toolchain.toml`. 
- Adds machine-readable policy ledgers and allowlists: `policy/clippy-lints.toml`, `policy/clippy-debt.toml`, `policy/no-panic-allowlist.toml`, and `policy/non-rust-allowlist.toml`, plus a repo-local `clippy.toml` and `docs/CLIPPY_POLICY.md` documenting the model and suppression style. 
- Implements xtask policy checks by adding `xtask/src/policy.rs` with `check_lint_policy`, `check_no_panic_family`, `check_file_policy`, and `policy_report`, wires them into `xtask/src/main.rs`, and exposes the checks in `justfile` so CI can run the policy gate before clippy. 
- Adds narrow, reasoned site suppression (`#[expect(clippy::panic, reason = "...")]`) for the existing parser-backend documented panic contract and updates a conditional `allow(missing_docs)` to include a reason. 
- Updates core crates and workspace members to inherit or explicitly set the new MSRV and adds a `toml` workspace dependency for `xtask` policy parsing.

### Testing

- Ran `cargo +1.93.0 fmt --all -- --check` and it succeeded. 
- Ran `cargo +1.93.0 xtask check-lint-policy` and it succeeded (the run reports that lint inheritance is currently advisory for workspace members; enforcement is gated by `ADZE_ENFORCE_LINT_INHERITANCE`).
- Ran `cargo +1.93.0 xtask check-no-panic-family`, `cargo +1.93.0 xtask check-file-policy`, and `cargo +1.93.0 xtask policy-report`, and all checks succeeded. 
- Ran `cargo +1.93.0 clippy -p adze -p adze-glr-core -p adze-ir -p adze-tablegen --lib -- -D warnings` and fixed/verified necessary narrow suppressions so the check passed. 
- Ran core crate tests `cargo +1.93.0 test -p adze -p adze-glr-core -p adze-ir -p adze-tablegen --lib -- --test-threads=2` and `cargo +1.93.0 test -p adze-glr-core --features serialization --doc -- --test-threads=2`, and they passed. 

Note: `just ci-supported` was not executed here because `just` is not installed in the execution environment; the underlying `cargo`/`xtask` commands used by that recipe were run directly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb0855588c833384e22ae937396536)