### PR TITLE
Add governed Clippy policy gate, MSRV→1.93, and policy-ledger artifacts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,8 +449,11 @@ dependencies = [
  "adze",
  "adze-javascript",
  "adze-python",
+ "adze-tool",
  "anyhow",
+ "serde_json",
  "sha2",
+ "tempfile",
 ]
 
 [[package]]
@@ -3129,6 +3132,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.1.0",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
@@ -3149,6 +3167,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -3950,6 +3977,7 @@ dependencies = [
  "serde_json",
  "similar",
  "tempfile",
+ "toml 0.9.12+spec-1.1.0",
  "walkdir",
  "xshell",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,14 +99,134 @@ homepage = "https://github.com/effortlessmetrics/adze"
 license = "Apache-2.0 OR MIT"
 publish = false
 repository = "https://github.com/effortlessmetrics/adze"
-rust-version = "1.92.0"
+rust-version = "1.93"
 
 
 [workspace.lints.rust]
+unsafe_code = "forbid"
 unsafe_op_in_unsafe_fn = "deny"
 unused_must_use = "deny"
+unexpected_cfgs = "warn"
+const_item_interior_mutations = "deny"
+function_casts_as_integer = "deny"
 missing_docs = "warn"
 unused_extern_crates = "deny"
+
+[workspace.lints.clippy]
+# Panic-free production and tests
+dbg_macro = "deny"
+todo = "deny"
+unimplemented = "deny"
+panic = "deny"
+unreachable = "deny"
+unwrap_used = "deny"
+expect_used = "deny"
+get_unwrap = "deny"
+unwrap_in_result = "deny"
+panic_in_result_fn = "deny"
+string_slice = "deny"
+indexing_slicing = "deny"
+out_of_bounds_indexing = "deny"
+unchecked_time_subtraction = "deny"
+
+# AST / parser / UTF-8 / slice safety
+char_indices_as_byte_indices = "deny"
+sliced_string_as_bytes = "deny"
+index_refutable_slice = "deny"
+
+# Silent failure
+let_underscore_future = "deny"
+let_underscore_must_use = "deny"
+let_underscore_lock = "deny"
+unused_result_ok = "deny"
+map_err_ignore = "deny"
+assertions_on_result_states = "deny"
+lines_filter_map_ok = "deny"
+
+# Async / concurrency
+await_holding_lock = "deny"
+await_holding_refcell_ref = "deny"
+await_holding_invalid_type = "deny"
+future_not_send = "warn"
+large_futures = "warn"
+arc_with_non_send_sync = "deny"
+rc_mutex = "deny"
+mut_mutex_lock = "deny"
+readonly_write_lock = "deny"
+
+# Unsafe / memory
+mem_forget = "deny"
+forget_non_drop = "deny"
+drop_non_drop = "deny"
+undocumented_unsafe_blocks = "deny"
+multiple_unsafe_ops_per_block = "deny"
+repr_packed_without_abi = "deny"
+
+# Numeric correctness
+float_cmp = "deny"
+float_cmp_const = "deny"
+float_equality_without_abs = "deny"
+lossy_float_literal = "deny"
+cast_sign_loss = "deny"
+cast_possible_wrap = "warn"
+cast_possible_truncation = "warn"
+cast_precision_loss = "warn"
+invalid_upcast_comparisons = "deny"
+cast_abs_to_unsigned = "deny"
+cast_enum_truncation = "deny"
+cast_nan_to_int = "deny"
+manual_midpoint = "warn"
+manual_is_multiple_of = "warn"
+manual_div_ceil = "warn"
+arithmetic_side_effects = "warn"
+
+# File/process/path footguns
+suspicious_open_options = "deny"
+nonsensical_open_options = "deny"
+ineffective_open_options = "deny"
+path_buf_push_overwrite = "deny"
+join_absolute_paths = "deny"
+read_line_without_trim = "warn"
+exit = "deny"
+
+# API / trait correctness
+iter_not_returning_iterator = "deny"
+expl_impl_clone_on_copy = "deny"
+infallible_try_from = "deny"
+fallible_impl_from = "deny"
+error_impl_error = "deny"
+result_unit_err = "warn"
+result_large_err = "warn"
+
+# Good taste that pays rent
+format_in_format_args = "deny"
+to_string_in_format_args = "deny"
+unused_format_specs = "deny"
+unnecessary_debug_formatting = "warn"
+uninlined_format_args = "warn"
+manual_let_else = "warn"
+manual_ok_or = "warn"
+manual_strip = "warn"
+manual_split_once = "warn"
+manual_is_variant_and = "warn"
+filter_map_next = "warn"
+flat_map_option = "warn"
+match_result_ok = "deny"
+cloned_instead_of_copied = "warn"
+iter_cloned_collect = "warn"
+iter_overeager_cloned = "warn"
+needless_collect = "warn"
+redundant_closure = "warn"
+redundant_closure_for_method_calls = "warn"
+missing_panics_doc = "deny"
+missing_errors_doc = "warn"
+
+# Suppression governance
+allow_attributes = "deny"
+allow_attributes_without_reason = "deny"
+blanket_clippy_restriction_lints = "deny"
+ignore_without_reason = "deny"
+should_panic_without_expect = "deny"
 
 [workspace.dependencies]
 tree-sitter = "=0.26.7"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,7 @@
+# Adze keeps test carveouts disabled: no allow-unwrap-in-tests, allow-expect-in-tests,
+# allow-panic-in-tests, allow-indexing-slicing-in-tests, or allow-dbg-in-tests.
+# Repo-specific disallowed-methods/types/macros should be added here with policy
+# entries instead of weakening the workspace lint baseline.
+disallowed-methods = []
+disallowed-types = []
+disallowed-macros = []

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adze-common"
 version = "0.8.0-dev"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.93"
 authors = ["Steven Zimmerman, CPA"]
 description = "Shared grammar expansion logic for the Adze macro and tool crates"
 license = "Apache-2.0 OR MIT"

--- a/crates/ts-c-harness/Cargo.toml
+++ b/crates/ts-c-harness/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adze-ts-c-harness"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.92.0"
+rust-version = "1.93"
 license = "Apache-2.0 OR MIT"
 description = "Internal Tree-sitter C FFI parity test harness."
 repository = "https://github.com/EffortlessMetrics/adze"

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -1,0 +1,75 @@
+# Clippy Policy
+
+Adze treats Clippy as a governed engineering surface. The root `Cargo.toml`
+contains the active workspace lint baseline, `policy/clippy-lints.toml` is the
+machine-readable ledger for active and planned lint levels, and `cargo xtask
+check-lint-policy` keeps those surfaces coherent.
+
+## Goals
+
+The standard policy is intentionally workspace-wide:
+
+- panic-free production and test code;
+- AST/parser/UTF-8/slice safety by default;
+- no silently swallowed futures, locks, `Result`s, or errors;
+- explicit suppression governance;
+- reviewability lints that reduce allocation and control-flow noise; and
+- planned Rust 1.94 / 1.95 lint flips tracked before an MSRV bump.
+
+## Active policy surfaces
+
+- `Cargo.toml` owns the active `[workspace.lints.rust]` and
+  `[workspace.lints.clippy]` levels.
+- `clippy.toml` is reserved for repo-specific `disallowed-*` policy and must
+  not contain test carveouts.
+- `policy/clippy-lints.toml` mirrors active lints and records planned flips.
+- `policy/clippy-debt.toml` records temporary exceptions with an owner, reason,
+  path, lint, and expiry.
+
+## Suppressions
+
+Prefer code changes over suppressions. If a suppression is unavoidable, use a
+narrow `#[expect(..., reason = "...")]` at the smallest useful scope so the
+compiler and Clippy can prove the exception is still needed.
+
+Do not add broad `#[allow(...)]` attributes or Clippy test carveouts. Existing
+legacy suppressions should be migrated in follow-up cleanup PRs and represented
+as temporary debt while they are still present.
+
+## Panic-family exceptions
+
+The standard exception shape is semantic TOML in
+`policy/no-panic-allowlist.toml`. Identity is:
+
+```text
+path + family + selector
+```
+
+`last_seen` line and column values are advisory hints only; they are not the
+stable identity of an exception.
+
+## Non-Rust file exceptions
+
+Rust is the default implementation language for repo tooling. Non-Rust
+programming, fixture, CI, or config surfaces belong in
+`policy/non-rust-allowlist.toml` with the owner, reason, surface,
+classification, and CI coverage that justify the exception.
+
+## Upgrade ledger
+
+Rust 1.94 and 1.95 lints are tracked as `status = "planned"` entries in
+`policy/clippy-lints.toml`. Planned lints must not be activated before their
+`activate_when_msrv` unless the ledger and MSRV are updated together.
+
+## Gate
+
+Run:
+
+```bash
+cargo xtask check-lint-policy
+```
+
+The gate verifies the MSRV ledger, root lint levels, planned lint flips,
+`clippy.toml` carveouts, and debt metadata. As the rollout advances, follow-up
+PRs should tighten inheritance and suppression checks after the current debt is
+explicitly categorized.

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -3,7 +3,7 @@ name = "adze-fuzz"
 version = "0.0.0"
 publish = false
 edition = "2024"
-rust-version = "1.92.0"
+rust-version = "1.93"
 
 [package.metadata]
 cargo-fuzz = true

--- a/glr-core/Cargo.toml
+++ b/glr-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adze-glr-core"
 version = "0.8.0-dev"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.93"
 description = "GLR parser generation algorithms for pure-Rust Tree-sitter"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/effortlessmetrics/adze"

--- a/ir/Cargo.toml
+++ b/ir/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adze-ir"
 version = "0.8.0-dev"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.93"
 description = "Grammar Intermediate Representation for pure-Rust Tree-sitter"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/effortlessmetrics/adze"

--- a/justfile
+++ b/justfile
@@ -73,6 +73,7 @@ ci-supported:
     export CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-2}"
     export RUST_TEST_THREADS="${RUST_TEST_THREADS:-2}"
     cargo fmt --all -- --check
+    cargo xtask check-lint-policy
     cargo clippy {{supported_crates}} --all-targets -- -D warnings
     cargo test {{supported_crates}} --lib --tests --bins -- --test-threads="$RUST_TEST_THREADS"
     cargo test -p adze-glr-core --features serialization --doc -- --test-threads="$RUST_TEST_THREADS"

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adze-macro"
 version = "0.8.0-dev"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.93"
 authors = ["Steven Zimmerman, CPA"]
 description = "Procedural macros for defining tree-sitter grammars alongside Rust logic"
 license = "Apache-2.0 OR MIT"

--- a/policy/clippy-debt.toml
+++ b/policy/clippy-debt.toml
@@ -1,0 +1,11 @@
+schema = 1
+
+# Temporary lint exceptions belong here instead of weakening workspace policy.
+# Each entry must include lint, path, owner, reason, and expires.
+#
+# [[debt]]
+# lint = "clippy::indexing_slicing"
+# path = "crates/example/src/parser/table.rs"
+# owner = "parser"
+# reason = "Generated table access; replace with checked table abstraction."
+# expires = "2026-07-01"

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -1,0 +1,811 @@
+schema = 1
+msrv = "1.93"
+
+[policy]
+panic_free_tests = true
+allow_test_carveouts = false
+suppression_style = "expect-with-reason"
+blanket_categories = false
+
+# Active lint levels mirror the root Cargo.toml workspace lint policy.
+
+[[lint]]
+name = "unsafe_code"
+level = "forbid"
+status = "active"
+class = "unsafe-memory"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "unsafe_op_in_unsafe_fn"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "unused_must_use"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "unexpected_cfgs"
+level = "warn"
+status = "active"
+class = "configuration"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "const_item_interior_mutations"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "function_casts_as_integer"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "missing_docs"
+level = "warn"
+status = "active"
+class = "api-contract"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "unused_extern_crates"
+level = "deny"
+status = "active"
+class = "dependency-hygiene"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::dbg_macro"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::todo"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::unimplemented"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::panic"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::unreachable"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::unwrap_used"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::expect_used"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::get_unwrap"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::unwrap_in_result"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::panic_in_result_fn"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::string_slice"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::indexing_slicing"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::out_of_bounds_indexing"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::unchecked_time_subtraction"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::char_indices_as_byte_indices"
+level = "deny"
+status = "active"
+class = "parser-safety"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::sliced_string_as_bytes"
+level = "deny"
+status = "active"
+class = "parser-safety"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::index_refutable_slice"
+level = "deny"
+status = "active"
+class = "parser-safety"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::let_underscore_future"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::let_underscore_must_use"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::let_underscore_lock"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::unused_result_ok"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::map_err_ignore"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::assertions_on_result_states"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::lines_filter_map_ok"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::await_holding_lock"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::await_holding_refcell_ref"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::await_holding_invalid_type"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::future_not_send"
+level = "warn"
+status = "active"
+class = "concurrency"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::large_futures"
+level = "warn"
+status = "active"
+class = "concurrency"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::arc_with_non_send_sync"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::rc_mutex"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::mut_mutex_lock"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::readonly_write_lock"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::mem_forget"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::forget_non_drop"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::drop_non_drop"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::undocumented_unsafe_blocks"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::multiple_unsafe_ops_per_block"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::repr_packed_without_abi"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::float_cmp"
+level = "deny"
+status = "active"
+class = "numeric-correctness"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::float_cmp_const"
+level = "deny"
+status = "active"
+class = "numeric-correctness"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::float_equality_without_abs"
+level = "deny"
+status = "active"
+class = "numeric-correctness"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::lossy_float_literal"
+level = "deny"
+status = "active"
+class = "numeric-correctness"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::cast_sign_loss"
+level = "deny"
+status = "active"
+class = "numeric-correctness"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::cast_possible_wrap"
+level = "warn"
+status = "active"
+class = "numeric-correctness"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::cast_possible_truncation"
+level = "warn"
+status = "active"
+class = "numeric-correctness"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::cast_precision_loss"
+level = "warn"
+status = "active"
+class = "numeric-correctness"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::invalid_upcast_comparisons"
+level = "deny"
+status = "active"
+class = "numeric-correctness"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::cast_abs_to_unsigned"
+level = "deny"
+status = "active"
+class = "numeric-correctness"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::cast_enum_truncation"
+level = "deny"
+status = "active"
+class = "numeric-correctness"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::cast_nan_to_int"
+level = "deny"
+status = "active"
+class = "numeric-correctness"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::manual_midpoint"
+level = "warn"
+status = "active"
+class = "numeric-correctness"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::manual_is_multiple_of"
+level = "warn"
+status = "active"
+class = "numeric-correctness"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::manual_div_ceil"
+level = "warn"
+status = "active"
+class = "numeric-correctness"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::arithmetic_side_effects"
+level = "warn"
+status = "active"
+class = "numeric-correctness"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::suspicious_open_options"
+level = "deny"
+status = "active"
+class = "filesystem-process"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::nonsensical_open_options"
+level = "deny"
+status = "active"
+class = "filesystem-process"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::ineffective_open_options"
+level = "deny"
+status = "active"
+class = "filesystem-process"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::path_buf_push_overwrite"
+level = "deny"
+status = "active"
+class = "filesystem-process"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::join_absolute_paths"
+level = "deny"
+status = "active"
+class = "filesystem-process"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::read_line_without_trim"
+level = "warn"
+status = "active"
+class = "filesystem-process"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::exit"
+level = "deny"
+status = "active"
+class = "filesystem-process"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::iter_not_returning_iterator"
+level = "deny"
+status = "active"
+class = "api-contract"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::expl_impl_clone_on_copy"
+level = "deny"
+status = "active"
+class = "api-contract"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::infallible_try_from"
+level = "deny"
+status = "active"
+class = "api-contract"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::fallible_impl_from"
+level = "deny"
+status = "active"
+class = "api-contract"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::error_impl_error"
+level = "deny"
+status = "active"
+class = "api-contract"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::result_unit_err"
+level = "warn"
+status = "active"
+class = "api-contract"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::result_large_err"
+level = "warn"
+status = "active"
+class = "api-contract"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::format_in_format_args"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::to_string_in_format_args"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::unused_format_specs"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::unnecessary_debug_formatting"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::uninlined_format_args"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::manual_let_else"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::manual_ok_or"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::manual_strip"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::manual_split_once"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::manual_is_variant_and"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::filter_map_next"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::flat_map_option"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::match_result_ok"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::cloned_instead_of_copied"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::iter_cloned_collect"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::iter_overeager_cloned"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::needless_collect"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::redundant_closure"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::redundant_closure_for_method_calls"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::missing_panics_doc"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::missing_errors_doc"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::allow_attributes"
+level = "deny"
+status = "active"
+class = "suppression-governance"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::allow_attributes_without_reason"
+level = "deny"
+status = "active"
+class = "suppression-governance"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::blanket_clippy_restriction_lints"
+level = "deny"
+status = "active"
+class = "suppression-governance"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::ignore_without_reason"
+level = "deny"
+status = "active"
+class = "suppression-governance"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::should_panic_without_expect"
+level = "deny"
+status = "active"
+class = "suppression-governance"
+reason = "Part of the Adze workspace lint baseline for panic-free, parser-safe, suppression-governed Rust."
+
+[[lint]]
+name = "clippy::same_length_and_capacity"
+level = "deny"
+status = "planned"
+activate_when_msrv = "1.94"
+class = "unsafe-memory"
+reason = "Catch raw-parts reconstruction mistakes."
+
+[[lint]]
+name = "clippy::manual_ilog2"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.94"
+class = "numeric-correctness"
+reason = "Prefer the standard integer log helper."
+
+[[lint]]
+name = "clippy::decimal_bitwise_operands"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.94"
+class = "numeric-correctness"
+reason = "Make bit masks visually inspectable."
+
+[[lint]]
+name = "clippy::needless_type_cast"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.94"
+class = "numeric-correctness"
+reason = "Avoid stale numeric type drift."
+
+[[lint]]
+name = "clippy::disallowed_fields"
+level = "deny"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "architecture"
+reason = "Allow architecture policy to ban direct field access across protected seams."
+
+[[lint]]
+name = "clippy::manual_checked_ops"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "numeric-correctness"
+reason = "Prefer checked arithmetic over manual divide-by-zero guards."
+
+[[lint]]
+name = "clippy::manual_take"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "ownership"
+reason = "Use standard ownership helper instead of local reimplementation."
+
+[[lint]]
+name = "clippy::manual_pop_if"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "collection-api"
+reason = "Use collection APIs that encode predicate-and-pop intent directly."
+
+[[lint]]
+name = "clippy::duration_suboptimal_units"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "time"
+reason = "Make durations legible without mental unit conversion."
+
+[[lint]]
+name = "clippy::unnecessary_trailing_comma"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "formatting"
+reason = "Keep generated and hand-written format macro calls clean."

--- a/policy/no-panic-allowlist.toml
+++ b/policy/no-panic-allowlist.toml
@@ -1,0 +1,22 @@
+schema_version = "0.3"
+
+# Semantic panic-family exceptions use path + family + selector as identity.
+# last_seen line/column values are advisory drift hints only.
+#
+# [[allow]]
+# path = "crates/example/src/parser.rs"
+# family = "unwrap"
+# classification = "test_only"
+# owner = "parser"
+# explanation = "Fixture setup path; covered by follow-up panic-free test helper migration."
+# expires = "2026-07-01"
+#
+# [allow.selector]
+# kind = "method_call"
+# container = "parses_fixture_with_boundary_case"
+# callee = "unwrap"
+# receiver_fingerprint = "std::fs::read_to_string(path)"
+#
+# [allow.last_seen]
+# line = 42
+# column = 17

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -1,0 +1,19 @@
+schema_version = "1.0"
+
+[[allow]]
+glob = ".github/workflows/*.yml"
+kind = "ci_declarative"
+owner = "release/ci"
+reason = "GitHub Actions workflow definitions are platform-required YAML."
+surface = "ci"
+classification = "config"
+covered_by = ["cargo xtask check-lint-policy"]
+
+[[allow]]
+glob = "xtask/fixtures/**"
+kind = "fixture_input"
+owner = "analysis-fixtures"
+reason = "Fixture workspaces intentionally contain analyzed source files."
+surface = "fixtures"
+classification = "test"
+covered_by = ["cargo xtask test-pure-rust"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adze"
 version = "0.8.0-dev"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.93"
 authors = ["Steven Zimmerman, CPA"]
 description = "Define tree-sitter grammars alongside Rust logic with AST-first parsing"
 license = "Apache-2.0 OR MIT"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.92.0"
+channel = "1.93"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/tablegen/Cargo.toml
+++ b/tablegen/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adze-tablegen"
 version = "0.8.0-dev"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.93"
 description = "Table generation and compression for pure-Rust Tree-sitter"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/effortlessmetrics/adze"

--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adze-tool"
 version = "0.8.0-dev"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.93"
 authors = ["Steven Zimmerman, CPA"]
 description = "Build-time code generation tool for Adze grammar definitions"
 license = "Apache-2.0 OR MIT"

--- a/tools/ts-bridge/Cargo.toml
+++ b/tools/ts-bridge/Cargo.toml
@@ -3,7 +3,7 @@ name = "ts-bridge"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
 edition = "2024"
-rust-version = "1.92.0"
+rust-version = "1.93"
 
 [lib]
 crate-type = ["rlib", "cdylib"]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -16,5 +16,6 @@ walkdir = "2.5.0"
 glob = "0.3.3"
 chrono = "0.4.44"
 serde.workspace = true
+toml = "0.9.8"
 adze-tool = { version = "0.8.0-dev", path = "../tool" }
 tempfile.workspace = true

--- a/xtask/src/lint_policy.rs
+++ b/xtask/src/lint_policy.rs
@@ -1,0 +1,298 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result, bail, ensure};
+use chrono::{NaiveDate, Utc};
+use serde::Deserialize;
+use toml::Value;
+
+const ROOT_MANIFEST: &str = "Cargo.toml";
+const POLICY_LEDGER: &str = "policy/clippy-lints.toml";
+const DEBT_LEDGER: &str = "policy/clippy-debt.toml";
+const CLIPPY_CONFIG: &str = "clippy.toml";
+
+const TEST_CARVEOUTS: &[&str] = &[
+    "allow-unwrap-in-tests",
+    "allow-expect-in-tests",
+    "allow-panic-in-tests",
+    "allow-indexing-slicing-in-tests",
+    "allow-dbg-in-tests",
+];
+
+#[derive(Debug, Deserialize)]
+struct LintPolicyLedger {
+    schema: u64,
+    msrv: String,
+    policy: PolicyFlags,
+    #[serde(default)]
+    lint: Vec<LintEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PolicyFlags {
+    panic_free_tests: bool,
+    allow_test_carveouts: bool,
+    suppression_style: String,
+    blanket_categories: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct LintEntry {
+    name: String,
+    level: String,
+    status: String,
+    #[serde(default)]
+    activate_when_msrv: Option<String>,
+    class: String,
+    reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DebtLedger {
+    schema: u64,
+    #[serde(default)]
+    debt: Vec<DebtEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DebtEntry {
+    lint: String,
+    path: String,
+    owner: String,
+    reason: String,
+    expires: String,
+}
+
+pub fn check_lint_policy() -> Result<()> {
+    let root = repo_root()?;
+    let manifest = read_toml(root.join(ROOT_MANIFEST))?;
+    let ledger: LintPolicyLedger = read_toml(root.join(POLICY_LEDGER))?;
+    let debt: DebtLedger = read_toml(root.join(DEBT_LEDGER))?;
+
+    check_ledger_shape(&ledger)?;
+    check_msrv(&manifest, &ledger)?;
+    check_root_lints(&manifest, &ledger)?;
+    check_clippy_toml(&root)?;
+    check_debt(&debt)?;
+
+    println!(
+        "✓ lint policy ok: {} active lint(s), {} planned lint(s), {} debt entry/entries",
+        ledger
+            .lint
+            .iter()
+            .filter(|lint| lint.status == "active")
+            .count(),
+        ledger
+            .lint
+            .iter()
+            .filter(|lint| lint.status == "planned")
+            .count(),
+        debt.debt.len()
+    );
+    Ok(())
+}
+
+fn repo_root() -> Result<std::path::PathBuf> {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .context("failed to run git rev-parse --show-toplevel")?;
+    ensure!(
+        output.status.success(),
+        "git rev-parse --show-toplevel failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(std::path::PathBuf::from(
+        String::from_utf8_lossy(&output.stdout).trim(),
+    ))
+}
+
+fn read_toml<T>(path: impl AsRef<Path>) -> Result<T>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let path = path.as_ref();
+    let text =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
+    toml::from_str(&text).with_context(|| format!("failed to parse {}", path.display()))
+}
+
+fn check_ledger_shape(ledger: &LintPolicyLedger) -> Result<()> {
+    ensure!(
+        ledger.schema == 1,
+        "policy/clippy-lints.toml schema must be 1"
+    );
+    ensure!(ledger.msrv == "1.93", "lint policy MSRV must be 1.93");
+    ensure!(
+        ledger.policy.panic_free_tests,
+        "panic_free_tests must be true"
+    );
+    ensure!(
+        !ledger.policy.allow_test_carveouts,
+        "allow_test_carveouts must be false"
+    );
+    ensure!(
+        ledger.policy.suppression_style == "expect-with-reason",
+        "suppression_style must be expect-with-reason"
+    );
+    ensure!(
+        !ledger.policy.blanket_categories,
+        "blanket_categories must be false"
+    );
+
+    let mut seen = BTreeSet::new();
+    for lint in &ledger.lint {
+        ensure!(!lint.name.trim().is_empty(), "lint entry has empty name");
+        ensure!(
+            matches!(lint.level.as_str(), "forbid" | "deny" | "warn"),
+            "{} has unsupported level {}",
+            lint.name,
+            lint.level
+        );
+        ensure!(
+            matches!(lint.status.as_str(), "active" | "planned"),
+            "{} has unsupported status {}",
+            lint.name,
+            lint.status
+        );
+        ensure!(
+            !lint.class.trim().is_empty(),
+            "{} is missing class",
+            lint.name
+        );
+        ensure!(
+            !lint.reason.trim().is_empty(),
+            "{} is missing reason",
+            lint.name
+        );
+        ensure!(
+            seen.insert(&lint.name),
+            "duplicate lint entry {}",
+            lint.name
+        );
+        if lint.status == "planned" {
+            ensure!(
+                lint.activate_when_msrv.is_some(),
+                "planned lint {} must have activate_when_msrv",
+                lint.name
+            );
+        }
+    }
+    Ok(())
+}
+
+fn check_msrv(manifest: &Value, ledger: &LintPolicyLedger) -> Result<()> {
+    let manifest_msrv = manifest
+        .get("workspace")
+        .and_then(|workspace| workspace.get("package"))
+        .and_then(|package| package.get("rust-version"))
+        .and_then(Value::as_str)
+        .context("Cargo.toml must define workspace.package.rust-version")?;
+    ensure!(
+        manifest_msrv == ledger.msrv,
+        "workspace.package.rust-version ({manifest_msrv}) must match policy MSRV ({})",
+        ledger.msrv
+    );
+    Ok(())
+}
+
+fn check_root_lints(manifest: &Value, ledger: &LintPolicyLedger) -> Result<()> {
+    let root_lints = collect_root_lints(manifest)?;
+    let mut missing = Vec::new();
+    let mut mismatched = Vec::new();
+
+    for lint in ledger.lint.iter().filter(|lint| lint.status == "active") {
+        match root_lints.get(&lint.name) {
+            Some(level) if level == &lint.level => {}
+            Some(level) => mismatched.push(format!(
+                "{}: Cargo.toml has {}, policy has {}",
+                lint.name, level, lint.level
+            )),
+            None => missing.push(lint.name.clone()),
+        }
+    }
+
+    if !missing.is_empty() || !mismatched.is_empty() {
+        bail!(
+            "active lint policy mismatch\nmissing: {:?}\nmismatched: {:?}",
+            missing,
+            mismatched
+        );
+    }
+
+    for lint in ledger.lint.iter().filter(|lint| lint.status == "planned") {
+        if root_lints.contains_key(&lint.name) {
+            bail!(
+                "planned lint {} is active before MSRV {}",
+                lint.name,
+                lint.activate_when_msrv.as_deref().unwrap_or("<unknown>")
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn collect_root_lints(manifest: &Value) -> Result<BTreeMap<String, String>> {
+    let mut out = BTreeMap::new();
+    let lints = manifest
+        .get("workspace")
+        .and_then(|workspace| workspace.get("lints"))
+        .context("Cargo.toml must define workspace.lints")?;
+
+    for namespace in ["rust", "clippy"] {
+        let table = lints
+            .get(namespace)
+            .and_then(Value::as_table)
+            .with_context(|| format!("Cargo.toml must define workspace.lints.{namespace}"))?;
+        for (name, value) in table {
+            let level = value.as_str().with_context(|| {
+                format!("workspace lint {namespace}::{name} must be a string level")
+            })?;
+            let key = if namespace == "clippy" {
+                format!("clippy::{name}")
+            } else {
+                name.to_string()
+            };
+            out.insert(key, level.to_string());
+        }
+    }
+    Ok(out)
+}
+
+fn check_clippy_toml(root: &Path) -> Result<()> {
+    let path = root.join(CLIPPY_CONFIG);
+    let text =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    let config: Value =
+        toml::from_str(&text).with_context(|| format!("failed to parse {}", path.display()))?;
+
+    for carveout in TEST_CARVEOUTS {
+        if config.get(*carveout).is_some() {
+            bail!("clippy.toml must not set test carveout {carveout}");
+        }
+    }
+    Ok(())
+}
+
+fn check_debt(debt: &DebtLedger) -> Result<()> {
+    ensure!(debt.schema == 1, "policy/clippy-debt.toml schema must be 1");
+    let today = Utc::now().date_naive();
+    for entry in &debt.debt {
+        ensure!(!entry.lint.trim().is_empty(), "debt entry missing lint");
+        ensure!(!entry.path.trim().is_empty(), "debt entry missing path");
+        ensure!(!entry.owner.trim().is_empty(), "debt entry missing owner");
+        ensure!(!entry.reason.trim().is_empty(), "debt entry missing reason");
+        let expires = NaiveDate::parse_from_str(&entry.expires, "%Y-%m-%d")
+            .with_context(|| format!("debt entry {} has invalid expires", entry.lint))?;
+        ensure!(
+            expires >= today,
+            "debt entry {} for {} expired on {}",
+            entry.lint,
+            entry.path,
+            entry.expires
+        );
+    }
+    Ok(())
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -10,6 +10,7 @@ mod fixtures;
 mod golden;
 mod grammar_json;
 mod lint;
+mod lint_policy;
 mod profile;
 mod test_grammars;
 mod test_local_grammars;
@@ -169,6 +170,8 @@ enum Commands {
         #[arg(last = true)]
         clippy_args: Vec<String>,
     },
+    /// Verify root lint policy, Clippy config, and policy debt ledgers
+    CheckLintPolicy,
     /// Generate arithmetic expression fixtures for benchmarking
     GenerateFixtures {
         /// Output directory for fixtures
@@ -361,6 +364,9 @@ fn main() -> Result<()> {
             clippy_args,
         } => {
             lint::lint(&sh, fix, changed_only, since, fast, clippy_args)?;
+        }
+        Commands::CheckLintPolicy => {
+            lint_policy::check_lint_policy()?;
         }
         Commands::GenerateFixtures { output, force } => {
             fixtures::generate_fixtures(&sh, &output, force)?;


### PR DESCRIPTION
### Motivation
- Establish a workspace-wide, enforceable Clippy baseline (panic-free, parser/UTF-8/slice safe, suppression-governed) and track planned Rust 1.94/1.95 flips as policy, not ad-hoc manifest copies.
- Provide machine-readable policy and debt ledgers plus semantic allowlists so `xtask`/CI can validate that lint levels, MSRV, suppressions, and exceptions remain coherent and reviewable.

### Description
- Bumped toolchain and workspace MSRV to `1.93` (`rust-toolchain.toml` and `workspace.package.rust-version`) and updated crate `rust-version` fields that did not inherit workspace defaults. 
- Added a strict workspace lint block under `[workspace.lints.clippy]` and `unsafe_code =

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb0855588c833384e22ae937396536)