### PR TITLE
docs: add correctness push plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Support tiers, proof commands, and CI lanes are tracked in [`docs/status/SUPPORT
 |---------|--------|-------------|
 | **Typed extraction** | ✅ Stable | Grammar *is* your AST — parse directly into your Rust types |
 | **Pure Rust** | ✅ Stable | Default backend is 100% Rust; no C toolchain needed |
-| **GLR parsing** | ✅ Stable | Handles ambiguous grammars (C++, JavaScript, etc.) |
+| **GLR conflict routing** | 🚧 Stabilizing | Core GLR routing exists; full ambiguous typed extraction proof is still being expanded |
 | **Operator precedence** | ✅ Stable | `#[prec_left]`, `#[prec_right]` for disambiguation |
 | **WASM support** | 📎 Advisory | Compile parsers to WebAssembly with `features = ["wasm"]` |
 | **Tree-sitter interop** | 📎 Advisory | Import existing Tree-sitter grammars via `ts-bridge` |
@@ -105,6 +105,8 @@ Support tiers, proof commands, and CI lanes are tracked in [`docs/status/SUPPORT
 | WASM                        | Advisory                    | Compile/proof surface is being expanded; runtime/browser execution is not yet the main contract. |
 | Grammar crates              | Advisory                    | Valuable smoke coverage; not all grammar crates are production-ready.                            |
 | Benchmarks                  | Advisory                    | Benchmarks are signal, not support proof.                                                        |
+
+Rule for documentation and CI promotion: no Stable feature claim without a named proof command in [`docs/status/SUPPORT_TIERS.md`](./docs/status/SUPPORT_TIERS.md).
 
 Adze is a good fit if you are building a parser or DSL in Rust, you control the grammar, and you want the result as plain Rust types integrated into a normal Cargo build. It is not yet a drop-in replacement for mature parser generators, and surfaces outside the core lane should be treated as developing.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,6 +61,8 @@ Welcome to the Adze documentation. Adze (formerly `rust-sitter`) is a Rust-nativ
 ## Project Status
 
 - [**Roadmap**](../ROADMAP.md) - Milestones for 0.8.0, 0.9.0, and 1.0.
+- [**Correctness Push Plan**](./status/CORRECTNESS_PUSH.md) - Current merge/proof sequence for parser, GLR, tablegen ABI, CLI, and product-proof convergence.
+- [**Support Tiers**](./status/SUPPORT_TIERS.md) - Feature claims mapped to proof commands and CI lanes.
 - [**Friction Log**](./status/FRICTION_LOG.md) - Current developer pain points we are burning down.
 - [**Now / Next / Later**](./status/NOW_NEXT_LATER.md) - Rolling execution plan.
 - [**Known Red**](./status/KNOWN_RED.md) - Exclusions from the supported CI lane.

--- a/docs/status/CORRECTNESS_PUSH.md
+++ b/docs/status/CORRECTNESS_PUSH.md
@@ -1,0 +1,100 @@
+# Correctness Push Plan
+
+**Last updated:** 2026-05-06
+**Scope:** current parser/runtime, GLR, tablegen ABI, CLI, and product-proof convergence.
+
+This is the execution playbook for moving Adze from "bounded core lane is green" to "the product claims are behavior-proven." It is intentionally narrower than a roadmap: finish the active correctness queue first, then open focused follow-up work for gaps that should not be hidden inside broad implementation PRs.
+
+## Baseline
+
+- Required fast gate stays `just ci-supported`.
+- `ci-supported` covers the seven core crates: `adze`, `adze-macro`, `adze-tool`, `adze-common`, `adze-ir`, `adze-glr-core`, and `adze-tablegen`.
+- The broader product lane is advisory until each canary proves real behavior instead of only compile/no-run smoke.
+- README-stable claims must map to a proof command in `docs/status/SUPPORT_TIERS.md`.
+- Runtime2 remains an experimental proving ground unless a later promotion plan gives it required behavior tests and a public support contract.
+
+## Live-State Refresh
+
+Before merging any queued PR, refresh the real GitHub state:
+
+```bash
+gh pr list --state open --limit 50 \
+  --json number,title,mergeable,isDraft,headRefName,baseRefName,updatedAt,url
+```
+
+If GitHub API access is rate-limited, do not guess mergeability. Continue with local rebases and tests, but report that live PR count could not be refreshed.
+
+## Merge Queue
+
+Use the queue below as the current seed order. Re-check live state before each merge because PRs may have landed, closed, or changed base.
+
+| Order | PR | Direction | Required proof beyond `just ci-supported` |
+|---:|---|---|---|
+| 1 | #300 | Rebase, test, merge | `cargo test -p adze-tablegen language_gen::tests::test_count_symbols_uses_parse_table_count_with_externals -- --exact`; `cargo clippy -p adze-tablegen -- -D warnings` |
+| 2 | #306 | Rebase after #300, test, merge | `cargo test -p adze-tablegen --test primary_state_comprehensive lang_gen_primary_state_count_equals_state_count -- --exact`; `cargo test -p adze-tablegen --test primary_state_comprehensive` |
+| 3 | #303 | Rebase, test, merge | `cargo check -p adze-tool`; clean downstream/repro build if available |
+| 4 | #332 | Merge after ABI tests | `cargo test -p adze-glr-core --lib test_ts_lexer_layout_matches_tree_sitter_abi -- --nocapture`; `cargo test -p adze-glr-core --lib test_grammar_lexer_uses_tree_sitter_callback_abi -- --nocapture` |
+| 5 | #335 | Merge after timeout tests | `cargo test -p adze --lib unified_parser::tests:: -- --nocapture` |
+| 6 | #348 | Merge after CLI tests | `cargo test -p adze-cli -- --nocapture` |
+| 7 | #386 | Manually resolve conflicts, then merge | `cargo test -p adze-tablegen compression -- --nocapture`; `cargo test -p adze-tablegen validation -- --nocapture`; `cargo test -p adze-tablegen --all-features --no-run` |
+| 8 | #387 | Manually resolve conflicts, then merge | `cargo test -p adze-glr-core conflict -- --nocapture`; `cargo test -p adze-glr-core ambiguity -- --nocapture`; `cargo test -p adze-glr-core --all-features --no-run` |
+| 9 | #376 | Merge only if strict canary proves real parser output | `cargo test -p adze-golden-tests -- --nocapture`; `cargo test -p adze-golden-tests --features javascript-grammar javascript_canary_expression_golden -- --nocapture` |
+| 10 | #398 | Merge after correctness PRs | `cargo metadata --format-version 1`; `cargo tree -i criterion`; `cargo tree -i bincode`; benchmark no-run checks; `cargo test -p adze-ir serde -- --nocapture` |
+| Last | #321 | Rebase or close if superseded | Keep separate from correctness merges |
+
+For every PR:
+
+```bash
+git checkout main
+git pull --ff-only
+gh pr checkout <PR>
+git fetch origin main
+git rebase origin/main
+cargo fmt --all -- --check
+just ci-supported
+```
+
+Do not merge #386 or #387 without resolving conflicts manually. Do not weaken #376's canary to make it pass. Do not let #398 change production parse-table format semantics; postcard should remain dev/test-only unless a separate format migration is explicitly designed.
+
+## Post-Queue Issues
+
+After the PR queue is empty, open focused issues instead of broad catch-all implementation PRs:
+
+- GLR product proof: conflict-preserving end-to-end typed extraction.
+- Tablegen ABI completeness: conflict encoding/routing, field maps, symbol/state invariants.
+- Product-proof behavior lane: replace compile-only canaries with one real behavior per major surface.
+- Parse diagnostics: spans, expected token sets, line/column mapping, excerpts.
+- CLI clean-room quickstart and parse command truthfulness.
+- README/support-tier reconciliation: no Stable claim without a named proof command.
+- Benchmark truthfulness: real parser work vs infrastructure-only measurements.
+
+## Green Ladder
+
+Rung 0 is the current required gate:
+
+```bash
+just ci-supported
+```
+
+Rung 1 is advisory product behavior. Convert `scripts/ci-product.sh` from compile-only smoke to bounded behavior smokes, but keep it non-blocking until stable.
+
+Rung 2 is a stable product lane. Promote only README-stable claims:
+
+```bash
+just ci-supported
+just ci-product-stable
+```
+
+The stable product lane should cover a clean-room README quickstart, typed extraction exact-value test, operator precedence test, GLR ambiguity canary, serialization canary, and one structured parse-error diagnostic test.
+
+Rung 3 remains scheduled/manual: full workspace all-features, fuzzing, Miri, sanitizers, benchmarks, grammar corpus, runtime2, and browser WASM execution.
+
+## Reporting Format
+
+After each merge or failed merge attempt, report:
+
+- PR handled.
+- Proof commands run.
+- Current open PR count, or why it could not be refreshed.
+- Red checks.
+- Next blocking PR.

--- a/docs/status/KNOWN_RED.md
+++ b/docs/status/KNOWN_RED.md
@@ -1,6 +1,6 @@
 # Known red
 
-**Last updated:** 2026-04-29
+**Last updated:** 2026-05-06
 
 This file tracks intentional exclusions from the supported lane:
 
@@ -11,7 +11,7 @@ Rule: if something is excluded from the supported lane, it must be listed here w
 - why
 - how it becomes supported (or why it won't)
 
-Support tiers and proof commands for major surfaces are tracked in [`docs/status/SUPPORT_TIERS.md`](./SUPPORT_TIERS.md).
+Support tiers and proof commands for major surfaces are tracked in [`docs/status/SUPPORT_TIERS.md`](./SUPPORT_TIERS.md). The active correctness merge/proof sequence is tracked in [`docs/status/CORRECTNESS_PUSH.md`](./CORRECTNESS_PUSH.md).
 
 ---
 
@@ -89,6 +89,7 @@ Current canaries:
 
 Notes:
 - This lane intentionally does not provide full behavior proof; it is bounded canary signal only.
+- The next promotion step is to replace each compile-only canary with one real behavior proof while keeping the lane advisory until it is reliable.
 - If one canary is red, the advisory job can fail while remaining non-blocking due to workflow `continue-on-error: true`.
 
 ## Known warnings (non-blocking)
@@ -104,6 +105,7 @@ To add a crate/workflow to the supported lane, it must be:
 - reproducible on a normal dev machine
 - stable across the supported toolchain/MSRV
 - bounded in time/resources
+- behavior-proven, not just compile-proven
 - documented (how to run it locally; common failure modes)
 
 When you add something to `ci-supported`, update this file in the same PR.

--- a/docs/status/NOW_NEXT_LATER.md
+++ b/docs/status/NOW_NEXT_LATER.md
@@ -1,9 +1,9 @@
 # Now / Next / Later
 
-**Last updated:** 2026-04-11
-**Status:** **Post-release hardening on `main`** — `adze` 0.8.0 is live on crates.io, the supported gate remains green, there is no open PR stack, and the remaining work is the residual advisory/broad CI tail on current `main`.
+**Last updated:** 2026-05-06
+**Status:** **Correctness push in progress** — `adze` 0.8.0 is live on crates.io and the supported gate remains bounded, but the live GitHub PR queue must be treated as the execution baseline before any merge. The current push is tracked in [`CORRECTNESS_PUSH.md`](./CORRECTNESS_PUSH.md).
 
-Adze status and rolling execution plan. For recurring pain points, see [`docs/status/FRICTION_LOG.md`](./FRICTION_LOG.md). For API stability guarantees per crate, see [`docs/status/API_STABILITY.md`](./API_STABILITY.md). For the (substantially complete) post-PR264 follow-up plan, see [`plans/POST-PR264-CI-FOLLOWUPS.md`](../../plans/POST-PR264-CI-FOLLOWUPS.md).
+Adze status and rolling execution plan. For recurring pain points, see [`docs/status/FRICTION_LOG.md`](./FRICTION_LOG.md). For API stability guarantees per crate, see [`docs/status/API_STABILITY.md`](./API_STABILITY.md). For support-tier proof commands, see [`docs/status/SUPPORT_TIERS.md`](./SUPPORT_TIERS.md).
 
 ---
 
@@ -18,24 +18,29 @@ Adze status and rolling execution plan. For recurring pain points, see [`docs/st
 - [x] A safety archive of the pre-cleanup dirty checkout was preserved outside `/tmp`.
 - [x] Issue #268 worktree cleanup documentation and validation is now documented and backed by a helper script.
 
-### ✅ Immediate close-out state
+### ✅ Prior close-out state
 - [x] PR `#280` (workflow hardening) merged on 2026-04-06.
 - [x] PR `#281` (roadmap/execution-state refresh) merged.
 - [x] `main` is aligned with `origin/main` and is now the source of truth for the remaining hardening work.
-- [x] GitHub currently shows no open PRs; any remaining hardening should restart from fresh branches off current `main`.
 - [x] A restore audit on 2026-04-11 confirmed that the proof surfaces trimmed during publication are already present again on `main`.
 
 ---
 
 ## Now
 
-### 🧪 Broad CI truthfulness and hardening
-- [ ] Finish the workflow/toolchain tail on current `main`: sanitizers, minimal-versions, supply-chain checks, cross-compilation, and the long-running Miri lane.
-- [ ] Clear the remaining `adze` broad-surface failures on current `main`: matrix smoke, coverage, strict-invariants release mode, feature-matrix `serialization` / `all-features` / `glr`, and the matching cross-platform test lanes.
-- [ ] Clear the remaining GLR tail on current `main`: `adze-glr-core / all-features` and deterministic codegen.
-- [ ] Keep `KNOWN_RED.md` aligned with the real advisory-lane state whenever a lane stops being intentionally red.
+### Correctness merge queue
+- [ ] Refresh live PR state before each merge with `gh pr list --state open --limit 50 --json number,title,mergeable,isDraft,headRefName,baseRefName,updatedAt,url`.
+- [ ] Land mergeable parser/tablegen/runtime/CLI correctness PRs in the order documented in [`CORRECTNESS_PUSH.md`](./CORRECTNESS_PUSH.md).
+- [ ] Manually resolve conflict PRs instead of taking either side wholesale.
+- [ ] Report proof commands, open PR count, red checks, and the next blocker after each merge.
 
-### 📦 Close remaining operational issues
+### Product proof alignment
+- [ ] Keep `just ci-supported` as the fast required gate.
+- [ ] Convert `scripts/ci-product.sh` from compile-only advisory smoke to one behavior proof per major product surface.
+- [ ] Keep README feature claims aligned with [`SUPPORT_TIERS.md`](./SUPPORT_TIERS.md): no Stable claim without a named proof command.
+- [ ] Open focused follow-up issues after the queue is empty for GLR product proof, tablegen ABI completeness, parse diagnostics, CLI clean-room quickstart, and benchmark truthfulness.
+
+### Operational tail
 - [ ] [Issue #269](https://github.com/EffortlessMetrics/adze/issues/269): Windows pure-rust benchmark-compilation tail is gated but still open; decide whether to trim further or close as acceptable.
 - [ ] [Issue #268](https://github.com/EffortlessMetrics/adze/issues/268): Worktree cleanup script exists (`scripts/cleanup-worktrees.sh`); contributor documentation still needs finishing.
 - [ ] Investigate the current rustdoc-only `Documentation` lane failure separately from reader-facing markdown/status drift.
@@ -44,10 +49,10 @@ Adze status and rolling execution plan. For recurring pain points, see [`docs/st
 
 ## Next
 
-### 📚 Documentation polish
-- [ ] Continue tightening tutorial/reference accuracy around the actual 0.8.x release surface.
-- [ ] Add contributor-facing guidance for temporary worktree lifecycle and closeout hygiene ([issue #268](https://github.com/EffortlessMetrics/adze/issues/268)).
-- [ ] Keep roadmap/status docs aligned with the real repo state after each meaningful convergence wave, but only after the corresponding code/CI family lands on `main`.
+### Behavior-proof product lane
+- [ ] Add a stable product lane only after advisory behavior smokes pass consistently.
+- [ ] Promote only README-stable claims into `ci-product-stable`.
+- [ ] Keep broad workspace, fuzzing, Miri, sanitizers, browser WASM, grammar corpus, runtime2, and benchmarks scheduled/manual unless explicitly promoted.
 
 ---
 

--- a/docs/status/SUPPORT_TIERS.md
+++ b/docs/status/SUPPORT_TIERS.md
@@ -1,11 +1,12 @@
 # Support Tiers and Proof Surface
 
-**Last updated:** 2026-04-26
+**Last updated:** 2026-05-06
 **Source of truth for:** README feature claims, `docs/status/KNOWN_RED.md`, and CI expectations.
 
-This document maps major Adze surfaces to four tiers:
+This document maps major Adze surfaces to five tiers:
 
 - **Stable** — part of the required support contract (`just ci-supported` / `CI / ci-supported`).
+- **Stabilizing** — implemented and tested, but missing one or more product-level proofs before it should be marketed as a stable user contract.
 - **Experimental** — implemented, but not part of the required merge gate; behavior may change.
 - **Advisory** — useful signal exists (optional CI lane, smoke, benchmark, etc.) but is non-blocking.
 - **Intentionally excluded** — tracked in `KNOWN_RED`; not currently a merge requirement.
@@ -16,15 +17,18 @@ This document maps major Adze surfaces to four tiers:
 |---|---|---|---|---|
 | Typed extraction | **Stable** | `cargo test -p adze --lib --tests --bins` (via `just ci-supported`) | `CI / ci-supported` | Core user contract via `adze` runtime tests in supported lane. |
 | Pure-Rust parser | **Stable** | `just ci-supported` | `CI / ci-supported` | Supported gate exercises pure-Rust core crates as the required contract. |
-| GLR parsing | **Stable** | `cargo test -p adze-glr-core --lib --tests --bins` (via `just ci-supported`) | `CI / ci-supported` | GLR generation/runtime core is in required gate. |
-| Serialization | **Stable** | `cargo test -p adze-glr-core --features serialization --doc` (via `just ci-supported`) | `CI / ci-supported` | Supported proof is currently `adze-glr-core` serialization doctests, not a full workspace serialization matrix. |
+| Operator precedence | **Stable** | `cargo test -p adze --lib --tests --bins`; `cargo test -p adze-glr-core --lib --tests --bins` (via `just ci-supported`) | `CI / ci-supported` | Stable for proven expression grammar shapes. |
+| GLR conflict routing | **Stabilizing** | `cargo test -p adze-glr-core conflict ambiguity -- --nocapture`; target: `cargo test -p adze --features "pure-rust,glr,runtime-e2e" glr_ -- --nocapture` | `CI / ci-supported` plus future product lane | GLR core is in the required gate, but full product proof still needs conflict-preserving end-to-end typed extraction and ambiguity metadata/selection coverage. |
+| Tablegen `TSLanguage` ABI | **Stabilizing** | `cargo test -p adze-tablegen --all-features`; target: `cargo test -p adze --features "pure-rust,glr,ts-compat" --test ts_compat_equiv -- --nocapture` | `CI / ci-supported` plus future product lane | Symbol/state invariants are core-gated; conflict encoding/routing and real field maps need stronger ABI proof before broader Tree-sitter compatibility is claimed. |
+| Structured parse errors | **Stabilizing** | `cargo test -p adze --features "pure-rust,glr" parse_error -- --nocapture` | Future product lane | Error paths exist, but the stable contract needs spans, expected sets, line/column, excerpts, and no-panic coverage across LR and GLR. |
+| Serialization | **Stable for core table serialization** | `cargo test -p adze-glr-core --features serialization --doc` (via `just ci-supported`) | `CI / ci-supported` | Supported proof is currently `adze-glr-core` serialization doctests, not a full workspace serialization matrix or generated-AST persistence contract. |
 | External scanners | **Experimental** | `cargo test -p adze --features external_scanners` | `CI / feature-matrix`, `CI / miri` (non-blocking/optional) | Not in required gate; coverage exists but is broad-lane signal. |
 | Incremental parsing | **Experimental** | `cargo test --workspace --features incremental_glr` | `CI / feature-matrix-extras` (non-blocking/optional) | Exists and tested in broad CI; still outside supported merge contract. |
 | Tree-sitter interop | **Advisory** | `./scripts/smoke-link.sh ts-bridge` | `smoke-ts-bridge / smoke`, `ts-bridge-smoke` | Interop/bridge proof is smoke-level and optional; not part of required lane. |
 | WASM | **Advisory** | `cargo check --target wasm32-unknown-unknown -p adze` (and core crates) | `CI / wasm-check`, `microcrate-ci / wasm-check` | Compile-check signal exists, but WASM is not in required branch-protection gate. |
-| CLI (`cli/`) | **Intentionally excluded** | `cargo check -p adze-cli` | No required lane | Tooling/prototype surface; excluded from supported lane per `KNOWN_RED`. |
-| runtime2 (`runtime2/`) | **Intentionally excluded** | `cargo check -p adze-runtime2` | No required lane | Alternate runtime path still converging; excluded from supported lane. |
-| Grammars (`grammars/*`) | **Intentionally excluded** | `cargo test -p adze-grammar-python` (and peers) | No required lane | Valuable examples/integration surfaces, but not yet a stable supported contract. |
+| CLI (`cli/`) | **Advisory** | `cargo test -p adze-cli -- --nocapture` | Product-proof advisory lane target | CLI is outside `ci-supported`; supported commands must be behavior-tested and unsupported modes must fail explicitly before promotion. |
+| runtime2 (`runtime2/`) | **Intentionally excluded** | `cargo test --manifest-path runtime2/Cargo.toml language_smoke_exposes_metadata_queries -- --nocapture` | Product-proof advisory lane target | Experimental proving ground; not the public-primary runtime contract. |
+| Grammars (`grammars/*`) | **Advisory** | `cargo test -p adze-python -- --nocapture` and peer grammar smokes | Product-proof advisory lane target | Valuable examples/integration surfaces, but not yet a stable published support contract. |
 | Golden tests | **Advisory** | `cd golden-tests && cargo test --features <lang>-grammar -- --nocapture` | `golden-tests / golden-tests`, `pure-rust-ci / golden-tests` | High-value parity signal, but intentionally non-blocking for merges. |
 | Benchmarks | **Advisory** | `cargo bench -p adze --bench glr_parser_bench --no-run` | `CI / benchmarks`, `benchmarks / benchmark`, `performance` | Performance signal only; never treated as merge-blocking proof of correctness. |
 
@@ -33,3 +37,4 @@ This document maps major Adze surfaces to four tiers:
 - If you change support scope, update this file and `docs/status/KNOWN_RED.md` in the same PR.
 - If README capability wording changes, ensure each claim maps to a row here.
 - If a surface lacks a repeatable proof command and lane, it must not be labeled **Stable**.
+- Use `docs/status/CORRECTNESS_PUSH.md` for the current merge/proof sequence.


### PR DESCRIPTION
## Summary
- add a current correctness push playbook for the PR queue and post-queue product proof work
- align support tiers and README wording so GLR product behavior is marked stabilizing, not broadly stable
- refresh known-red and now/next/later docs around behavior proof and live PR-state refresh

## Verification
- git diff --check