### PR TITLE
fix: unblock baseline CI checks

### DIFF
--- a/golden-tests/src/lib.rs
+++ b/golden-tests/src/lib.rs
@@ -622,9 +622,8 @@ mod tests {
         let result = build_parser_from_json(grammar_json, options)
             .with_context(|| "Failed to build parser from JSON fixture")?;
 
-        let actual_pretty = serde_json::to_string_pretty(&serde_json::from_str::<
-            serde_json::Value,
-        >(&result.node_types_json)?)?;
+        let actual_value = serde_json::from_str::<serde_json::Value>(&result.node_types_json)?;
+        let actual_pretty = serde_json::to_string_pretty(&actual_value)?;
         if std::env::var("UPDATE_GOLDEN").is_ok() {
             if let Some(parent) = expected_path.parent() {
                 fs::create_dir_all(parent)?;
@@ -639,8 +638,9 @@ mod tests {
                 expected_path.display()
             )
         })?;
+        let expected_value = serde_json::from_str::<serde_json::Value>(&expected_pretty)?;
 
-        if actual_pretty != expected_pretty {
+        if actual_value != expected_value {
             let actual_path = expected_path.with_extension("actual.json");
             fs::write(&actual_path, actual_pretty)?;
             anyhow::bail!(

--- a/runtime/tests/glr_incremental_comprehensive.rs
+++ b/runtime/tests/glr_incremental_comprehensive.rs
@@ -702,10 +702,10 @@ mod tests {
             get_reuse_count() > 0,
             "compatible incremental edit should reuse at least one subtree"
         );
-        assert!(get_reuse_count() <= new_toks.len());
         let status = p.last_parse_status();
         assert!(!status.full_reparse_fallback);
         assert!(status.reused_node_count > 0);
+        assert!(status.reused_node_count <= new_toks.len());
         assert_eq!(status.invalidated_ranges, vec![start..end]);
     }
 

--- a/runtime2/src/builder.rs
+++ b/runtime2/src/builder.rs
@@ -9,7 +9,7 @@ use crate::tree::{Tree, TreeNode};
 
 #[cfg(feature = "glr")]
 use adze_glr_core::ForestView as CoreForestView;
-#[cfg(feature = "glr-core")]
+#[cfg(feature = "glr")]
 use rustc_hash::FxHashSet;
 
 /// Converts a GLR parse forest into a Tree-sitter compatible tree.

--- a/runtime2/src/tree.rs
+++ b/runtime2/src/tree.rs
@@ -150,6 +150,15 @@ impl TreeNode {
     }
 }
 
+impl Drop for TreeNode {
+    fn drop(&mut self) {
+        let mut pending = std::mem::take(&mut self.children);
+        while let Some(mut node) = pending.pop() {
+            pending.extend(std::mem::take(&mut node.children));
+        }
+    }
+}
+
 impl Tree {
     /// Create a new tree from a root node
     #[allow(dead_code)]
@@ -196,8 +205,8 @@ impl Tree {
         end_byte: usize,
         children: Vec<Tree>,
     ) -> Self {
-        fn tree_to_node(t: Tree) -> TreeNode {
-            let child_nodes = t.root.children.into_iter().collect();
+        fn tree_to_node(mut t: Tree) -> TreeNode {
+            let child_nodes = std::mem::take(&mut t.root.children);
             TreeNode {
                 symbol: t.root.symbol,
                 start_byte: t.root.start_byte,


### PR DESCRIPTION
## Summary

Fixes current broad-CI baseline blockers that were preventing tablegen correctness PRs from merging:

- imports runtime2 `FxHashSet` under the same `glr` feature gate that uses it
- drops deep runtime2 `TreeNode` children iteratively so deep right-recursive trees do not overflow the stack on drop
- compares the minimal JSON `node_types` golden test as parsed JSON instead of raw platform-newline text, fixing Windows golden failures without changing the golden artifact
- makes the incremental GLR reuse-count test bound parser-local reuse status instead of a global atomic that can be incremented by concurrent coverage tests

This is intentionally separate from the tablegen correctness PR queue so #300 can merge against a green baseline instead of carrying unrelated runtime2/golden/coverage fixes.

## Proof

- `git diff --check`
- `cargo fmt -p adze-runtime --check`
- `cargo clippy -p adze-runtime --all-targets -- -D warnings`
- `cargo test -p adze-runtime --test builder_tests forest_to_tree_handles_deep_right_recursive_input -- --exact --nocapture`
- `cargo test -p adze-runtime --lib --tests -- --test-threads=2`
- `cargo fmt -p adze-golden-tests --check`
- `cargo test -p adze-golden-tests tests::minimal_json_grammar_node_types_golden -- --exact --nocapture`
- `cargo test -p adze-golden-tests --lib -- --test-threads=2`
- `cargo fmt -p adze --check`
- `cargo test -p adze --features pure-rust,glr,incremental_glr,external_scanners,serialization,ts-compat --test glr_incremental_comprehensive tests::test_reuse_counter_on_incremental -- --exact --nocapture`
- `cargo test -p adze --features pure-rust,glr,incremental_glr,external_scanners,serialization,ts-compat --test glr_incremental_comprehensive -- --test-threads=2`

Note: `cargo fmt --all -- --check` is not runnable in this Windows shell due local OS error 206 path-length failure; package-scoped fmt passes.