### PR TITLE
bdd-grid: generalize progress report heading

### DIFF
--- a/crates/bdd-governance-core/src/lib.rs
+++ b/crates/bdd-governance-core/src/lib.rs
@@ -171,7 +171,7 @@ mod tests {
         assert!(
             matrix
                 .report("Core")
-                .contains("=== BDD GLR Conflict Preservation Test Summary ===")
+                .contains("=== BDD Scenario Progress Summary ===")
         );
         assert!(matrix.status_line().starts_with("core:"));
     }

--- a/crates/bdd-governance-core/tests/comprehensive.rs
+++ b/crates/bdd-governance-core/tests/comprehensive.rs
@@ -45,7 +45,7 @@ fn matrix_standard_is_core_phase() {
 fn matrix_report_contains_summary_header() {
     let matrix = BddGovernanceMatrix::standard(ParserFeatureProfile::current());
     let report = matrix.report("Core");
-    assert!(report.contains("BDD GLR Conflict Preservation Test Summary"));
+    assert!(report.contains("BDD Scenario Progress Summary"));
 }
 
 #[test]

--- a/crates/bdd-grid-core/src/lib.rs
+++ b/crates/bdd-grid-core/src/lib.rs
@@ -216,7 +216,7 @@ pub fn bdd_progress_report(
     let mut out = String::new();
 
     let (implemented, total) = bdd_progress(phase, scenarios);
-    out.push_str("\n=== BDD GLR Conflict Preservation Test Summary ===\n");
+    out.push_str("=== BDD Scenario Progress Summary ===\n");
     out.push_str(phase_title);
     out.push('\n');
     out.push('\n');
@@ -246,6 +246,9 @@ pub fn bdd_progress_report(
         "{}: {}/{} scenarios complete",
         phase_title, implemented, total
     );
+    if let Some(reference) = scenarios.first().map(|scenario| scenario.reference) {
+        let _ = write!(out, "\nReference: {reference}");
+    }
     if implemented < total {
         out.push_str("\nNext: Implement remaining deferred scenarios.");
     }
@@ -294,6 +297,19 @@ mod tests {
     fn progress_report_for_valid_grid_has_no_validation_warning() {
         let report = bdd_progress_report(BddPhase::Core, GLR_CONFLICT_PRESERVATION_GRID, "Core");
         assert!(!report.contains("Grid validation found"));
+    }
+
+    #[test]
+    fn progress_report_uses_generic_heading_and_reference() {
+        let report = bdd_progress_report(BddPhase::Core, GLR_CONFLICT_PRESERVATION_GRID, "Core");
+        assert!(report.starts_with("=== BDD Scenario Progress Summary ==="));
+        assert!(report.contains("Reference: docs/archive/plans/BDD_GLR_CONFLICT_PRESERVATION.md"));
+    }
+
+    #[test]
+    fn progress_report_omits_reference_for_empty_grid() {
+        let report = bdd_progress_report(BddPhase::Core, &[], "Core");
+        assert!(!report.contains("Reference:"));
     }
 
     #[test]


### PR DESCRIPTION
Replacement for #321, whose source branch is dirty and not maintainer-editable.

Carries the BDD report cleanup on top of current main after #320:
- generic `=== BDD Scenario Progress Summary ===` heading
- no leading blank line before the heading
- reference footer when the scenario grid is non-empty
- no reference footer for empty grids

Local proof:
- cargo fmt -p adze-bdd-grid-core --check
- cargo test -p adze-bdd-grid-core -- --nocapture
- cargo clippy -p adze-bdd-grid-core --all-targets -- -D warnings