### PR TITLE
runtime: improve parse diagnostics

### DIFF
--- a/runtime/src/error_reporting.rs
+++ b/runtime/src/error_reporting.rs
@@ -103,10 +103,8 @@ impl ErrorReporter {
     }
 
     /// Get expected tokens from parser state
-    fn get_expected_tokens(&self, _parser: &GLRParser) -> Vec<String> {
-        // In a real implementation, this would examine the parse table
-        // to determine valid tokens at the current state
-        vec![] // Placeholder
+    fn get_expected_tokens(&self, parser: &GLRParser) -> Vec<String> {
+        expected_token_names(parser)
     }
 
     /// Get context around the error
@@ -141,6 +139,7 @@ impl ErrorReportingExt for GLRParser {
 
         for (symbol_id, token_text) in tokens {
             reporter.record_token(&token_text, 0);
+            let expected_before_token = expected_token_names(self);
 
             // Try to process the token
             let initial_stack_count = self.stack_count();
@@ -148,20 +147,37 @@ impl ErrorReportingExt for GLRParser {
 
             // Check if all stacks died (parse error)
             if self.stack_count() == 0 && initial_stack_count > 0 {
-                errors.push(reporter.error_at_current(self, Some(token_text.clone())));
+                let mut error = reporter.error_at_current(self, Some(token_text.clone()));
+                if error.expected.is_empty() {
+                    error.expected = expected_before_token;
+                }
+                errors.push(error);
                 return Err(errors);
             }
         }
 
+        let expected_before_eof = expected_token_names(self);
         self.process_eof(0); // No byte tracking in error reporter
 
         if let Some(tree) = self.get_best_parse() {
             Ok(Arc::try_unwrap(tree).unwrap_or_else(|arc| (*arc).clone()))
         } else {
-            errors.push(reporter.error_at_current(self, None));
+            let mut error = reporter.error_at_current(self, None);
+            if error.expected.is_empty() {
+                error.expected = expected_before_eof;
+            }
+            errors.push(error);
             Err(errors)
         }
     }
+}
+
+fn expected_token_names(parser: &GLRParser) -> Vec<String> {
+    parser
+        .expected_symbols()
+        .into_iter()
+        .map(|symbol| format!("{symbol:?}"))
+        .collect()
 }
 
 #[cfg(test)]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1181,6 +1181,158 @@ pub mod errors {
         pub end: usize,
     }
 
+    /// One-indexed source position for a parse diagnostic.
+    ///
+    /// The column is byte-oriented so it matches the parser's byte offsets.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct SourcePosition {
+        /// Byte offset in the original source.
+        pub byte: usize,
+        /// One-indexed line number.
+        pub line: usize,
+        /// One-indexed byte column within the line.
+        pub column: usize,
+    }
+
+    impl SourcePosition {
+        /// Compute a source position from a byte offset.
+        #[must_use]
+        pub fn from_byte_offset(source: &[u8], byte: usize) -> Self {
+            let byte = byte.min(source.len());
+            let line_col = crate::linecol::LineCol::at_position(source, byte);
+            Self {
+                byte,
+                line: line_col.line + 1,
+                column: line_col.column(byte) + 1,
+            }
+        }
+    }
+
+    impl std::fmt::Display for SourcePosition {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{}:{}", self.line, self.column)
+        }
+    }
+
+    /// One-indexed source range for a parse diagnostic.
+    ///
+    /// The end position is exclusive, matching [`ParseError::end`].
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct SourceSpan {
+        /// Inclusive start position.
+        pub start: SourcePosition,
+        /// Exclusive end position.
+        pub end: SourcePosition,
+    }
+
+    impl ParseError {
+        /// Return the byte span covered by this parse error.
+        #[must_use]
+        pub fn byte_span(&self) -> std::ops::Range<usize> {
+            self.start..self.end
+        }
+
+        /// Compute a line/column span for this error in `source`.
+        ///
+        /// Out-of-range byte offsets are clamped to the end of `source` so
+        /// diagnostics remain printable for malformed parser output.
+        #[must_use]
+        pub fn source_span(&self, source: &[u8]) -> SourceSpan {
+            SourceSpan {
+                start: SourcePosition::from_byte_offset(source, self.start),
+                end: SourcePosition::from_byte_offset(source, self.end),
+            }
+        }
+
+        /// Return a formatter that includes line/column and source context.
+        #[must_use]
+        pub fn display_with_source<'a>(&'a self, source: &'a str) -> ParseErrorWithSource<'a> {
+            ParseErrorWithSource {
+                error: self,
+                source,
+            }
+        }
+    }
+
+    impl std::fmt::Display for ParseErrorReason {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                ParseErrorReason::UnexpectedToken(token) => {
+                    write!(f, "unexpected token {token:?}")
+                }
+                ParseErrorReason::FailedNode(errors) if errors.is_empty() => {
+                    write!(f, "failed to parse node")
+                }
+                ParseErrorReason::FailedNode(errors) => {
+                    write!(
+                        f,
+                        "failed to parse node with {} nested errors",
+                        errors.len()
+                    )
+                }
+                ParseErrorReason::MissingToken(token) => write!(f, "missing token {token:?}"),
+            }
+        }
+    }
+
+    impl std::fmt::Display for ParseError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{} at bytes {}..{}", self.reason, self.start, self.end)
+        }
+    }
+
+    impl std::error::Error for ParseError {}
+
+    /// Display helper returned by [`ParseError::display_with_source`].
+    pub struct ParseErrorWithSource<'a> {
+        error: &'a ParseError,
+        source: &'a str,
+    }
+
+    impl std::fmt::Display for ParseErrorWithSource<'_> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let span = self.error.source_span(self.source.as_bytes());
+            write!(
+                f,
+                "{} at {} (bytes {}..{})",
+                self.error.reason, span.start, self.error.start, self.error.end
+            )?;
+
+            if let Some(line) = source_line(self.source, span.start.byte) {
+                let marker_width = if span.start.line == span.end.line {
+                    span.end.column.saturating_sub(span.start.column).max(1)
+                } else {
+                    1
+                };
+                let marker =
+                    " ".repeat(span.start.column.saturating_sub(1)) + &"^".repeat(marker_width);
+                write!(f, "\n{line}\n{marker}")?;
+            }
+
+            Ok(())
+        }
+    }
+
+    fn source_line(source: &str, byte_offset: usize) -> Option<&str> {
+        if source.is_empty() {
+            return None;
+        }
+
+        let bytes = source.as_bytes();
+        let offset = byte_offset.min(bytes.len());
+        let mut start = offset;
+        while start > 0 && bytes[start - 1] != b'\n' && bytes[start - 1] != b'\r' {
+            start -= 1;
+        }
+
+        let mut end = offset;
+        while end < bytes.len() && bytes[end] != b'\n' && bytes[end] != b'\r' {
+            end += 1;
+        }
+
+        source.get(start..end)
+    }
+
     /// Given the root node of a Tree Sitter parsing result, accumulates all
     /// errors that were emitted.
     #[cfg(not(feature = "pure-rust"))]

--- a/runtime/tests/error_display_tests.rs
+++ b/runtime/tests/error_display_tests.rs
@@ -7,7 +7,7 @@ use adze::error_recovery::{
     ErrorNode, ErrorRecoveryConfig, ErrorRecoveryConfigBuilder, ErrorRecoveryState,
     RecoveryStrategy,
 };
-use adze::error_reporting::{ErrorReporter, ParseError as ReportingParseError};
+use adze::error_reporting::{ErrorReporter, ErrorReportingExt, ParseError as ReportingParseError};
 use adze::errors::{ParseError, ParseErrorReason};
 use adze::glr_validation::{ErrorKind, ErrorLocation, RelatedInfo, ValidationError};
 use adze::{SpanError, SpanErrorReason};
@@ -26,6 +26,91 @@ fn parse_error_includes_byte_positions() {
     let dbg = format!("{:?}", err);
     assert!(dbg.contains("10"), "Debug should include start byte: {dbg}");
     assert!(dbg.contains("11"), "Debug should include end byte: {dbg}");
+}
+
+#[test]
+fn parse_error_display_includes_reason_and_byte_span() {
+    let err = ParseError {
+        reason: ParseErrorReason::UnexpectedToken("@".to_string()),
+        start: 10,
+        end: 11,
+    };
+    let display = format!("{err}");
+    assert!(
+        display.contains("unexpected token \"@\""),
+        "Display should include reason: {display}"
+    );
+    assert!(
+        display.contains("bytes 10..11"),
+        "Display should include byte span: {display}"
+    );
+}
+
+#[test]
+fn parse_error_source_span_is_one_indexed() {
+    let source = "let x\n  @bad";
+    let err = ParseError {
+        reason: ParseErrorReason::UnexpectedToken("@".to_string()),
+        start: 8,
+        end: 9,
+    };
+
+    let span = err.source_span(source.as_bytes());
+
+    assert_eq!(span.start.line, 2);
+    assert_eq!(span.start.column, 3);
+    assert_eq!(span.end.line, 2);
+    assert_eq!(span.end.column, 4);
+}
+
+#[test]
+fn parse_error_display_with_source_includes_line_column_and_excerpt() {
+    let source = "let x\n  @bad";
+    let err = ParseError {
+        reason: ParseErrorReason::UnexpectedToken("@".to_string()),
+        start: 8,
+        end: 9,
+    };
+
+    let display = format!("{}", err.display_with_source(source));
+
+    assert!(
+        display.contains("at 2:3"),
+        "Display should include line:column: {display}"
+    );
+    assert!(
+        display.contains("bytes 8..9"),
+        "Display should include byte span: {display}"
+    );
+    assert!(
+        display.contains("  @bad"),
+        "Display should include source excerpt: {display}"
+    );
+    assert!(
+        display.contains("  ^"),
+        "Display should include caret marker: {display}"
+    );
+}
+
+#[test]
+fn parse_error_display_with_source_marks_zero_width_spans() {
+    let source = "abc";
+    let err = ParseError {
+        reason: ParseErrorReason::MissingToken(";".to_string()),
+        start: 3,
+        end: 3,
+    };
+
+    let display = format!("{}", err.display_with_source(source));
+
+    assert!(
+        display.contains("missing token \";\""),
+        "Display should include missing token reason: {display}"
+    );
+    assert!(
+        display.contains("   ^"),
+        "Display should mark the insertion point: {display}"
+    );
 }
 
 #[test]
@@ -1155,6 +1240,40 @@ fn error_recovery_config_builder_produces_informative_config() {
     assert!(
         dbg.contains("5"),
         "Debug should show max_consecutive_errors"
+    );
+}
+
+#[test]
+fn reporting_error_reporter_populates_expected_tokens() {
+    let parser = make_dummy_parser();
+    let reporter = ErrorReporter::new(String::new());
+
+    let error = reporter.error_at_current(&parser, Some("@".to_string()));
+
+    assert_eq!(error.unexpected_token.as_deref(), Some("@"));
+    assert!(
+        error.expected.iter().any(|token| token == "SymbolId(1)"),
+        "expected token set should include the one-token grammar's number symbol: {:?}",
+        error.expected
+    );
+}
+
+#[test]
+fn reporting_parse_with_errors_preserves_expected_tokens_after_bad_input() {
+    let mut parser = make_dummy_parser();
+
+    let errors = parser
+        .parse_with_errors(vec![(adze_ir::SymbolId(2), "@".to_string())])
+        .expect_err("invalid token should fail to parse");
+
+    assert_eq!(errors.len(), 1);
+    assert!(
+        errors[0]
+            .expected
+            .iter()
+            .any(|token| token == "SymbolId(1)"),
+        "expected token set should survive parse failure: {:?}",
+        errors[0].expected
     );
 }
 


### PR DESCRIPTION
## Summary

Partial progress on #463.

- Add `Display`/`Error` support for `adze::errors::ParseError` and `Display` for `ParseErrorReason`.
- Add source-aware parse diagnostics: byte span helper, one-indexed line/column span helper, and `display_with_source()` with an excerpt/caret marker.
- Replace the GLR error reporter expected-token placeholder with `GLRParser::expected_symbols()` and preserve the pre-failure expected set when token processing or EOF finalization loses active expected symbols.

## Proof

- `cargo fmt -p adze --check`
- `git diff --check`
- `cargo test -p adze --test error_display_tests --features "pure-rust,glr"`
- `cargo test -p adze --test parse_error_v3 --features "pure-rust,glr"`
- `cargo test -p adze-linecol-core`
- `cargo test -p adze-error-location-core`
- `cargo clippy -p adze --features "pure-rust,glr" --tests -- -D warnings`

Attempted broader issue command:

- `cargo test -p adze parse_error --features "pure-rust,glr" -- --nocapture`

That command ran the matching parse-error tests successfully but exited nonzero when Cargo attempted to execute unrelated `external_scanner_valid_symbols_dispatch_test` and Windows returned `os error 740` (`The requested operation requires elevation`).

Refs #463.