### PR TITLE
runtime: name expected parse tokens

### DIFF
--- a/runtime/src/error_reporting.rs
+++ b/runtime/src/error_reporting.rs
@@ -173,11 +173,7 @@ impl ErrorReportingExt for GLRParser {
 }
 
 fn expected_token_names(parser: &GLRParser) -> Vec<String> {
-    parser
-        .expected_symbols()
-        .into_iter()
-        .map(|symbol| format!("{symbol:?}"))
-        .collect()
+    parser.expected_symbol_names()
 }
 
 #[cfg(test)]

--- a/runtime/src/glr_parser.rs
+++ b/runtime/src/glr_parser.rs
@@ -2231,6 +2231,32 @@ impl GLRParser {
         symbols
     }
 
+    /// Return the grammar name for a symbol when one is available.
+    pub fn symbol_name(&self, symbol: SymbolId) -> Option<&str> {
+        self.grammar
+            .tokens
+            .get(&symbol)
+            .map(|token| token.name.as_str())
+            .or_else(|| self.grammar.rule_names.get(&symbol).map(String::as_str))
+    }
+
+    /// Get display names for symbols expected at the current parse state.
+    pub fn expected_symbol_names(&self) -> Vec<String> {
+        let mut symbols = self
+            .expected_symbols()
+            .into_iter()
+            .map(|symbol| {
+                self.symbol_name(symbol)
+                    .map(str::to_string)
+                    .unwrap_or_else(|| format!("{symbol:?}"))
+            })
+            .collect::<Vec<_>>();
+
+        symbols.sort();
+        symbols.dedup();
+        symbols
+    }
+
     /// Perform all possible reductions on a stack until no more are possible
     ///
     /// # Errors

--- a/runtime/tests/error_display_tests.rs
+++ b/runtime/tests/error_display_tests.rs
@@ -1252,8 +1252,8 @@ fn reporting_error_reporter_populates_expected_tokens() {
 
     assert_eq!(error.unexpected_token.as_deref(), Some("@"));
     assert!(
-        error.expected.iter().any(|token| token == "SymbolId(1)"),
-        "expected token set should include the one-token grammar's number symbol: {:?}",
+        error.expected.iter().any(|token| token == "num"),
+        "expected token set should include the one-token grammar's token name: {:?}",
         error.expected
     );
 }
@@ -1268,10 +1268,7 @@ fn reporting_parse_with_errors_preserves_expected_tokens_after_bad_input() {
 
     assert_eq!(errors.len(), 1);
     assert!(
-        errors[0]
-            .expected
-            .iter()
-            .any(|token| token == "SymbolId(1)"),
+        errors[0].expected.iter().any(|token| token == "num"),
         "expected token set should survive parse failure: {:?}",
         errors[0].expected
     );


### PR DESCRIPTION
## Summary

Partial progress on #463, following #471.

- Add `GLRParser::symbol_name()` and `GLRParser::expected_symbol_names()`.
- Use grammar token/rule names in GLR error reporter expected sets, with `SymbolId(..)` fallback for unnamed symbols.
- Keep expected sets deterministic by sorting and deduping display names.

## Proof

- `cargo fmt -p adze --check`
- `git diff --check`
- `cargo test -p adze --test error_display_tests reporting_error_reporter_populates_expected_tokens --features "pure-rust,glr" -- --exact --nocapture`
- `cargo test -p adze --test error_display_tests reporting_parse_with_errors_preserves_expected_tokens_after_bad_input --features "pure-rust,glr" -- --exact --nocapture`
- `cargo test -p adze --test error_display_tests --features "pure-rust,glr"`
- `cargo test -p adze --test parse_error_v3 --features "pure-rust,glr"`
- `cargo clippy -p adze --features "pure-rust,glr" --tests -- -D warnings`

Refs #463.