### PR TITLE
test: avoid duplicate reduce conflict proptest case

### DIFF
--- a/glr-core/tests/advanced_conflict_proptest.rs
+++ b/glr-core/tests/advanced_conflict_proptest.rs
@@ -454,6 +454,7 @@ proptest! {
 
     #[test]
     fn single_rr_conflict_counted(r1 in arb_rule_id(), r2 in arb_rule_id()) {
+        prop_assume!(r1 != r2);
         let table = make_test_table(vec![vec![vec![Action::Reduce(r1), Action::Reduce(r2)]]]);
         let summary = count_conflicts(&table);
         prop_assert_eq!(summary.shift_reduce, 0);


### PR DESCRIPTION
## Summary
- exclude identical reduce actions from the reduce/reduce conflict proptest
- align the property with the canonical conflict predicate, which flattens and dedupes effective actions before counting conflicts

## Proof
- `cargo fmt -p adze-glr-core --check`
- `cargo test -p adze-glr-core --test advanced_conflict_proptest single_rr_conflict_counted -- --exact --nocapture`
- `cargo test -p adze-glr-core --test advanced_conflict_proptest -- --nocapture`
- `cargo test -p adze-glr-core conflict -- --nocapture`

## Context
This unblocks #472, where hosted `ci-supported` found the generated case `r1 == r2`; duplicate reduce actions are deterministic after canonical deduplication, so they are not a reduce/reduce conflict.