### PR TITLE
tablegen: preserve fallback multi-action cells

### DIFF
--- a/tablegen/src/abi_builder.rs
+++ b/tablegen/src/abi_builder.rs
@@ -652,9 +652,6 @@ impl<'a> AbiLanguageBuilder<'a> {
                 // We need to know the count before we start pushing
                 let mut entries = Vec::new();
 
-                // Check if this state has a default reduce action
-                let mut default_reduce = None;
-                let mut has_non_reduce = false;
                 let mut non_error_actions = Vec::new();
 
                 for symbol_idx in 0..self.parse_table.symbol_count {
@@ -677,62 +674,35 @@ impl<'a> AbiLanguageBuilder<'a> {
                             .any(|e| e.symbol_id == symbol_id)
                         || symbol_id == self.parse_table.eof_symbol;
 
-                    let action = if is_terminal {
+                    let mut record_action = |symbol_idx: usize, action: &Action| match action {
+                        Action::Error => {}
+                        _ => {
+                            non_error_actions.push((symbol_idx, action.clone()));
+                        }
+                    };
+
+                    if is_terminal {
                         if state_idx < self.parse_table.action_table.len()
                             && symbol_idx < self.parse_table.action_table[state_idx].len()
                         {
                             let actions = &self.parse_table.action_table[state_idx][symbol_idx];
-                            if actions.is_empty() {
-                                Action::Error
-                            } else {
-                                actions[0].clone()
+                            for action in actions {
+                                record_action(symbol_idx, action);
                             }
-                        } else {
-                            Action::Error
                         }
                     } else if state_idx < self.parse_table.goto_table.len()
                         && symbol_idx < self.parse_table.goto_table[state_idx].len()
                     {
                         let goto_state = self.parse_table.goto_table[state_idx][symbol_idx];
                         if goto_state.0 > 0 {
-                            Action::Shift(goto_state)
-                        } else {
-                            Action::Error
-                        }
-                    } else {
-                        Action::Error
-                    };
-
-                    match action {
-                        Action::Error => continue,
-                        Action::Reduce(prod_id) => {
-                            non_error_actions.push((symbol_idx, action.clone()));
-                            if let Some(default_prod) = &default_reduce {
-                                if default_prod != &prod_id {
-                                    has_non_reduce = true;
-                                }
-                            } else {
-                                default_reduce = Some(prod_id);
-                            }
-                        }
-                        _ => {
-                            has_non_reduce = true;
-                            non_error_actions.push((symbol_idx, action.clone()));
+                            record_action(symbol_idx, &Action::Shift(goto_state));
                         }
                     }
                 }
 
-                if let Some(prod_id) = default_reduce
-                    && !has_non_reduce
-                    && !non_error_actions.is_empty()
-                {
-                    let reduce_action = 0x8000u16 | (prod_id.0 + 1);
-                    entries.push((0x8000u16, reduce_action));
-                } else {
-                    for (symbol_idx, action) in non_error_actions {
-                        if let Ok(encoded) = self.encode_action(&action) {
-                            entries.push((symbol_idx as u16, encoded));
-                        }
+                for (symbol_idx, action) in non_error_actions {
+                    if let Ok(encoded) = self.encode_action(&action) {
+                        entries.push((symbol_idx as u16, encoded));
                     }
                 }
 
@@ -749,11 +719,6 @@ impl<'a> AbiLanguageBuilder<'a> {
                         }
                     }
                 }
-
-                // Push field_count then entries
-                let field_count = entries.len() as u16;
-                table_data.push(quote! { #field_count });
-                current_offset += 1;
 
                 for (sym, val) in entries {
                     table_data.push(quote! { #sym });
@@ -1296,6 +1261,10 @@ mod tests {
     use super::*;
     use adze_ir::*;
 
+    fn token_stream_u16(token: &TokenStream) -> u16 {
+        token.to_string().trim_end_matches("u16").parse().unwrap()
+    }
+
     #[test]
     fn test_deterministic_symbol_ordering() {
         let mut grammar = Grammar::new("test".to_string());
@@ -1612,6 +1581,63 @@ mod tests {
         // Error
         let enc = builder.encode_action(&Action::Error).unwrap();
         assert_eq!(enc, 0, "Error → 0");
+    }
+
+    #[test]
+    fn test_fallback_parse_table_preserves_multi_action_cell() {
+        let mut table = crate::empty_table!(states: 2, terms: 1, nonterms: 1);
+        let start = table.start_symbol;
+        let t = SymbolId(1);
+
+        for row in &mut table.goto_table {
+            row.fill(StateId(0));
+        }
+        table.action_table[0][1] = vec![
+            Action::Error,
+            Action::Shift(StateId(1)),
+            Action::Reduce(RuleId(0)),
+        ];
+
+        let mut grammar = Grammar::new("fallback_conflict".to_string());
+        grammar.rule_names.insert(start, "start".to_string());
+        grammar.tokens.insert(
+            t,
+            Token {
+                name: "t".to_string(),
+                pattern: TokenPattern::String("t".to_string()),
+                fragile: false,
+            },
+        );
+        grammar.add_rule(Rule {
+            lhs: start,
+            rhs: vec![Symbol::Terminal(t)],
+            precedence: None,
+            associativity: None,
+            fields: vec![],
+            production_id: ProductionId(0),
+        });
+
+        let builder = AbiLanguageBuilder::new(&grammar, &table);
+        let (table_data, table_map) = builder.generate_parse_tables();
+        let values: Vec<u16> = table_data.iter().map(token_stream_u16).collect();
+        let offsets: Vec<u32> = table_map
+            .iter()
+            .map(|token| token.to_string().trim_end_matches("u32").parse().unwrap())
+            .collect();
+
+        assert_eq!(offsets[0], 0, "state 0 starts at the first pair");
+        assert_eq!(offsets[1], 4, "state 1 starts after both state 0 pairs");
+        assert_eq!(values.len(), 4, "state 0 must emit two direct pairs");
+        assert_eq!(values[0], 1, "first entry symbol");
+        assert_eq!(
+            values[1],
+            builder.encode_action(&Action::Shift(StateId(1))).unwrap()
+        );
+        assert_eq!(values[2], 1, "second entry symbol");
+        assert_eq!(
+            values[3],
+            builder.encode_action(&Action::Reduce(RuleId(0))).unwrap()
+        );
     }
 
     /// Production LHS index entries must all reference non-terminal columns.


### PR DESCRIPTION
## Summary
- preserve every non-error top-level terminal action when the ABI builder emits fallback small tables
- emit fallback small-table rows as direct `(symbol, value)` pairs matching the runtime parsers and compressed ABI path
- remove fallback default-reduce sentinel emission because the active pure parser does not consume it
- add a regression test for a fallback shift/reduce cell so uncompressed table emission does not erase conflicts

## Proof
- `cargo fmt -p adze-tablegen --check`
- `cargo test -p adze-tablegen --lib abi_builder::tests::test_fallback_parse_table_preserves_multi_action_cell -- --exact --nocapture`
- `cargo test -p adze-tablegen --test compression_roundtrip_proptest small_action_multi_action_cell_stores_all -- --exact --nocapture`
- `cargo test -p adze-tablegen --test compress_api_comprehensive cat_multi_action_cell -- --exact --nocapture`
- `cargo test -p adze-tablegen --test schema_encoding_tests -- --nocapture`
- `cargo test -p adze-tablegen --lib`
- `cargo clippy -p adze-tablegen -- -D warnings`

## Notes
This intentionally does not change `Action::Fork` schema encoding; Fork remains runtime-only in the current tablegen schema.