### PR TITLE
runtime: prove generated ambiguous GLR routing

### DIFF
--- a/runtime/src/__private.rs
+++ b/runtime/src/__private.rs
@@ -490,30 +490,36 @@ fn parse_with_true_glr_runtime<T: Extract<T>>(
 ) -> core::result::Result<T, Vec<crate::errors::ParseError>> {
     let source = input.as_bytes();
     let grammar = crate::decoder::decode_grammar(language);
-    let mut lexer = match crate::glr_lexer::GLRLexer::new(&grammar, input.to_string()) {
-        Ok(lexer) => lexer,
-        Err(message) => {
+    let mut parser = crate::glr_parser::GLRParser::new(parse_table, grammar.clone());
+
+    if let Some(lex_fn) = language.lex_fn {
+        for token in lex_with_language_fn(language, lex_fn, source)? {
+            parser.process_token(token.symbol_id, &token.text, token.byte_offset);
+        }
+    } else {
+        let mut lexer = match crate::glr_lexer::GLRLexer::new(&grammar, input.to_string()) {
+            Ok(lexer) => lexer,
+            Err(message) => {
+                return Err(vec![crate::errors::ParseError {
+                    reason: crate::errors::ParseErrorReason::UnexpectedToken(message),
+                    start: 0,
+                    end: source.len(),
+                }]);
+            }
+        };
+
+        while let Some(token) = lexer.next_token() {
+            parser.process_token(token.symbol_id, &token.text, token.byte_offset);
+        }
+        if let Some((start, end)) = lexer.invalid_span() {
             return Err(vec![crate::errors::ParseError {
-                reason: crate::errors::ParseErrorReason::UnexpectedToken(message),
-                start: 0,
-                end: source.len(),
+                reason: crate::errors::ParseErrorReason::UnexpectedToken(
+                    "unexpected token while lexing".to_string(),
+                ),
+                start,
+                end,
             }]);
         }
-    };
-
-    let mut parser = crate::glr_parser::GLRParser::new(parse_table, grammar);
-
-    while let Some(token) = lexer.next_token() {
-        parser.process_token(token.symbol_id, &token.text, token.byte_offset);
-    }
-    if let Some((start, end)) = lexer.invalid_span() {
-        return Err(vec![crate::errors::ParseError {
-            reason: crate::errors::ParseErrorReason::UnexpectedToken(
-                "unexpected token while lexing".to_string(),
-            ),
-            start,
-            end,
-        }]);
     }
 
     parser.process_eof(source.len());
@@ -555,6 +561,144 @@ fn parse_with_true_glr_runtime<T: Extract<T>>(
         0,
         None,
     ))
+}
+
+#[cfg(all(feature = "glr", feature = "pure-rust"))]
+fn lex_with_language_fn(
+    language: &'static crate::pure_parser::TSLanguage,
+    lex_fn: unsafe extern "C" fn(*mut core::ffi::c_void, crate::pure_parser::TSLexState) -> bool,
+    source: &[u8],
+) -> core::result::Result<Vec<crate::glr_lexer::TokenWithPosition>, Vec<crate::errors::ParseError>>
+{
+    use crate::lex::TsLexer;
+    use adze_ir::SymbolId;
+    use core::ffi::c_void;
+
+    #[repr(C)]
+    struct Backing<'a> {
+        input: &'a [u8],
+        pos: usize,
+        mark: usize,
+    }
+
+    unsafe extern "C" fn lookahead(lex: *mut TsLexer) -> u32 {
+        unsafe {
+            if lex.is_null() || (*lex).data.is_null() {
+                return 0;
+            }
+            let backing = &*((*lex).data as *const Backing);
+            if backing.pos < backing.input.len() {
+                backing.input[backing.pos] as u32
+            } else {
+                0
+            }
+        }
+    }
+
+    unsafe extern "C" fn advance(lex: *mut TsLexer, _skip: bool) {
+        unsafe {
+            if lex.is_null() || (*lex).data.is_null() {
+                return;
+            }
+            let backing = &mut *((*lex).data as *mut Backing);
+            if backing.pos < backing.input.len() {
+                backing.pos += 1;
+            }
+        }
+    }
+
+    unsafe extern "C" fn mark_end(lex: *mut TsLexer) {
+        unsafe {
+            if lex.is_null() || (*lex).data.is_null() {
+                return;
+            }
+            let backing = &mut *((*lex).data as *mut Backing);
+            backing.mark = backing.pos;
+        }
+    }
+
+    fn is_extra_symbol(language: &crate::pure_parser::TSLanguage, symbol: u16) -> bool {
+        if symbol >= language.symbol_count as u16 || language.symbol_metadata.is_null() {
+            return false;
+        }
+        // SAFETY: `symbol < symbol_count` and generated languages expose a
+        // `symbol_metadata` array with `symbol_count` entries.
+        unsafe { (*language.symbol_metadata.add(symbol as usize) & 0x04) != 0 }
+    }
+
+    let mut tokens = Vec::new();
+    let mut position = 0usize;
+    let lex_mode = if !language.lex_modes.is_null() {
+        // SAFETY: generated languages provide one lex mode per state. State 0 is
+        // the conservative default for the current generated lexers.
+        unsafe { *language.lex_modes }
+    } else {
+        crate::pure_parser::TSLexState {
+            lex_state: 0,
+            external_lex_state: 0,
+        }
+    };
+
+    while position < source.len() {
+        while position < source.len() && matches!(source[position], b' ' | b'\t' | b'\n' | b'\r') {
+            position += 1;
+        }
+        if position >= source.len() {
+            break;
+        }
+
+        let start = position;
+        let mut backing = Backing {
+            input: source,
+            pos: position,
+            mark: position,
+        };
+        let mut ts_lexer = TsLexer {
+            lookahead,
+            advance,
+            mark_end,
+            result_symbol: u16::MAX,
+            data: &mut backing as *mut _ as *mut c_void,
+        };
+
+        // SAFETY: `lex_fn` is the generated language lexer. `ts_lexer` uses the
+        // same `TsLexer` ABI layout that generated lexers expect.
+        let ok = unsafe { lex_fn(&mut ts_lexer as *mut _ as *mut c_void, lex_mode) };
+        let end = if backing.mark > start {
+            backing.mark
+        } else {
+            backing.pos
+        };
+
+        if !ok || ts_lexer.result_symbol == u16::MAX || end <= start {
+            let invalid_end = source[start..]
+                .iter()
+                .position(|byte| byte.is_ascii_whitespace())
+                .map(|offset| start + offset.max(1))
+                .unwrap_or_else(|| (start + 1).min(source.len()));
+            return Err(vec![crate::errors::ParseError {
+                reason: crate::errors::ParseErrorReason::UnexpectedToken(
+                    "unexpected token while lexing".to_string(),
+                ),
+                start,
+                end: invalid_end,
+            }]);
+        }
+
+        if !is_extra_symbol(language, ts_lexer.result_symbol) {
+            let text = String::from_utf8_lossy(&source[start..end]).into_owned();
+            tokens.push(crate::glr_lexer::TokenWithPosition {
+                symbol_id: SymbolId(ts_lexer.result_symbol),
+                text,
+                byte_offset: start,
+                byte_length: end - start,
+            });
+        }
+
+        position = end;
+    }
+
+    Ok(tokens)
 }
 
 #[cfg(all(feature = "glr", feature = "pure-rust"))]

--- a/runtime/src/decoder.rs
+++ b/runtime/src/decoder.rs
@@ -682,10 +682,11 @@ fn decode_rules(lang: &TSLanguage) -> Vec<ParseRule> {
 /// Decode a ParseTable from a TSLanguage struct
 pub fn decode_parse_table(lang: &'static TSLanguage) -> ParseTable {
     let mut action_table = Vec::new();
-    let goto_table = Vec::new();
     let mut symbol_metadata = Vec::new();
     let mut symbol_to_index = BTreeMap::new();
     let symbol_count = lang.symbol_count as usize;
+    let tcols = (lang.token_count + lang.external_token_count) as usize;
+    let mut goto_table = vec![vec![StateId(0); symbol_count]; lang.state_count as usize];
     let mut extras_set: BTreeSet<SymbolId> = BTreeSet::new();
 
     // Build the column -> symbol mapping first. If `public_symbol_map` is present, it
@@ -821,7 +822,7 @@ pub fn decode_parse_table(lang: &'static TSLanguage) -> ParseTable {
     for state in 0..lang.large_state_count as usize {
         let mut state_actions = Vec::new();
 
-        for symbol in 0..lang.symbol_count as usize {
+        for symbol in 0..symbol_count {
             let table_offset = state * lang.symbol_count as usize + symbol;
             // SAFETY: `lang.parse_table` is a flat 2D array of size
             // `state_count * symbol_count`. `table_offset = state * symbol_count + symbol`
@@ -829,11 +830,16 @@ pub fn decode_parse_table(lang: &'static TSLanguage) -> ParseTable {
             // `symbol < symbol_count`. `lang.parse_actions` is indexed by `action_idx`
             // which is read from the parse table (trusted TSLanguage data).
             // TODO(safety): No bounds check on `action_idx` against parse_actions array size.
-            let action = unsafe {
-                let action_idx = *lang.parse_table.add(table_offset);
+            let table_value = unsafe { *lang.parse_table.add(table_offset) };
 
-                if action_idx != 0 {
-                    let raw = &*lang.parse_actions.add(action_idx as usize);
+            let action_cell = if symbol >= tcols {
+                if table_value != 0 {
+                    goto_table[state][symbol] = StateId(table_value);
+                }
+                vec![]
+            } else if table_value != 0 {
+                let action = unsafe {
+                    let raw = &*lang.parse_actions.add(table_value as usize);
                     if raw.extra != 0
                         && raw.action_type == TSActionTag::Shift as u8
                         && let Some(&sym) = index_to_symbol.get(symbol)
@@ -841,14 +847,14 @@ pub fn decode_parse_table(lang: &'static TSLanguage) -> ParseTable {
                         extras_set.insert(sym);
                     }
                     decode_action(raw, &rules, &rid_by_pair)
+                };
+                if matches!(action, Action::Error) {
+                    vec![]
                 } else {
-                    Action::Error
+                    vec![action]
                 }
-            };
-            let action_cell = if matches!(action, Action::Error) {
-                vec![]
             } else {
-                vec![action]
+                vec![]
             };
             state_actions.push(action_cell);
         }
@@ -861,41 +867,35 @@ pub fn decode_parse_table(lang: &'static TSLanguage) -> ParseTable {
         for state in lang.large_state_count as usize..lang.state_count as usize {
             let mut state_actions = vec![vec![]; lang.symbol_count as usize];
 
-            // Get the offset into small_parse_table from the map
+            // Get this state's direct-pair range from the map.
             let map_index = state - lang.large_state_count as usize;
             // SAFETY: `lang.small_parse_table_map` is non-null (branch guard).
             // `map_index = state - large_state_count` where `state` ranges from
             // `large_state_count..state_count`, so `map_index < state_count - large_state_count`.
             // TSLanguage contract guarantees the map array covers all small states.
-            let offset = unsafe { *lang.small_parse_table_map.add(map_index) } as usize;
+            // The map has a sentinel final offset after the last small state.
+            let start_offset = unsafe { *lang.small_parse_table_map.add(map_index) } as usize;
+            let end_offset = unsafe { *lang.small_parse_table_map.add(map_index + 1) } as usize;
 
-            // SAFETY: `lang.small_parse_table` is non-null (branch guard).
-            // `offset` comes from `small_parse_table_map` which is trusted TSLanguage data.
-            // TODO(safety): No independent validation that `offset` is within the
-            // small_parse_table allocation. Corrupted TSLanguage data could cause OOB reads.
-            let mut ptr = unsafe { lang.small_parse_table.add(offset) };
+            // Read direct (symbol, action_index) pairs. This matches the pure parser
+            // and parser_v4 small-table readers and preserves duplicate symbols for
+            // GLR multi-action cells.
+            let mut offset = start_offset;
+            while offset + 1 < end_offset {
+                // SAFETY: `offset` is bounded by the trusted start/end offsets from
+                // `small_parse_table_map`. Malformed TSLanguage data could still point
+                // outside the allocation; callers should validate generated ABI data.
+                let symbol = unsafe { *lang.small_parse_table.add(offset) } as usize;
+                let action_index = unsafe { *lang.small_parse_table.add(offset + 1) } as usize;
+                offset += 2;
 
-            // SAFETY: `ptr` points within the small_parse_table array (see above).
-            // Each subsequent `ptr.add(1)` advances to the next entry. The total number
-            // of reads is `1 + 2 * field_count`, which must fit within the allocation.
-            // TODO(safety): `field_count` is read from the table itself with no upper-bound
-            // validation against the total allocation size.
-            let field_count = unsafe { *ptr } as usize;
-            ptr = unsafe { ptr.add(1) };
+                if symbol >= symbol_count || action_index == 0 {
+                    continue;
+                }
 
-            // Read field_count pairs of (symbol, action_index)
-            for _ in 0..field_count {
-                // SAFETY: `ptr` is advanced sequentially within small_parse_table.
-                // Each iteration reads two entries. Validity depends on `field_count`
-                // being correct per TSLanguage contract (see TODO above).
-                let symbol = unsafe { *ptr } as usize;
-                ptr = unsafe { ptr.add(1) };
-
-                let action_index = unsafe { *ptr } as usize;
-                ptr = unsafe { ptr.add(1) };
-
-                // Decode the action
-                if action_index != 0 && symbol < lang.symbol_count as usize {
+                if symbol >= tcols {
+                    goto_table[state][symbol] = StateId(action_index as u16);
+                } else {
                     let action = if action_index == 0xFFFF {
                         Action::Accept
                     } else if action_index & 0x8000 != 0 {
@@ -957,7 +957,6 @@ pub fn decode_parse_table(lang: &'static TSLanguage) -> ParseTable {
     // No separate map needed
 
     // Build nonterminal_to_index for goto lookups
-    let tcols = (lang.token_count + lang.external_token_count) as usize;
     let mut nonterminal_to_index = BTreeMap::new();
     for (col, sym) in index_to_symbol.iter().enumerate() {
         if col >= tcols {

--- a/runtime/src/glr_parser.rs
+++ b/runtime/src/glr_parser.rs
@@ -335,6 +335,29 @@ pub struct GLRParser {
     telemetry: TelemetryCounters,
 }
 
+type SubtreeSelectionKey = Vec<(usize, usize, u16, u16, usize)>;
+
+fn subtree_selection_key(node: &Subtree) -> SubtreeSelectionKey {
+    let mut key = Vec::new();
+    append_subtree_selection_key(node, &mut key);
+    key
+}
+
+fn append_subtree_selection_key(node: &Subtree, key: &mut SubtreeSelectionKey) {
+    key.push((
+        node.node.byte_range.start,
+        node.node.byte_range.end,
+        node.node.symbol_id.0,
+        u16::from(node.node.is_error),
+        node.children.len(),
+    ));
+
+    for edge in &node.children {
+        key.push((usize::MAX, usize::MAX, edge.field_id, 0, 0));
+        append_subtree_selection_key(&edge.subtree, key);
+    }
+}
+
 /// Dummy telemetry type when feature is disabled
 #[cfg(not(feature = "glr_telemetry"))]
 #[allow(dead_code)]
@@ -2064,6 +2087,7 @@ impl GLRParser {
             );
 
             let mut best_stack_idx = complete_stacks[0];
+            let mut best_tree_key = subtree_selection_key(&self.stacks[best_stack_idx].nodes[0]);
             for &stack_idx in &complete_stacks[1..] {
                 match compare_versions(
                     &self.stacks[best_stack_idx].version,
@@ -2076,6 +2100,20 @@ impl GLRParser {
                             best_stack_idx
                         );
                         best_stack_idx = stack_idx;
+                        best_tree_key =
+                            subtree_selection_key(&self.stacks[best_stack_idx].nodes[0]);
+                    }
+                    CompareResult::Tie => {
+                        let tree_key = subtree_selection_key(&self.stacks[stack_idx].nodes[0]);
+                        if tree_key < best_tree_key {
+                            debug_glr!(
+                                "finish: Stack {} wins stable structural tie-break over stack {}",
+                                stack_idx,
+                                best_stack_idx
+                            );
+                            best_stack_idx = stack_idx;
+                            best_tree_key = tree_key;
+                        }
                     }
                     _ => {
                         debug_glr!(

--- a/runtime/tests/test_e2e_ambiguous_grammar_glr.rs
+++ b/runtime/tests/test_e2e_ambiguous_grammar_glr.rs
@@ -18,6 +18,7 @@
 use adze::decoder;
 use adze::pure_parser::TSLanguage;
 use adze_glr_core::Action;
+use adze_glr_core::conflict_inspection::cell_has_conflict;
 
 /// Helper: Count multi-action cells (GLR conflicts) in a parse table
 fn count_multi_action_cells(lang: &'static TSLanguage) -> usize {
@@ -26,7 +27,7 @@ fn count_multi_action_cells(lang: &'static TSLanguage) -> usize {
     let mut conflict_count = 0;
     for state_actions in &parse_table.action_table {
         for action_cell in state_actions {
-            if action_cell.len() > 1 {
+            if cell_has_conflict(action_cell) {
                 conflict_count += 1;
             }
         }
@@ -47,7 +48,6 @@ fn contains_shift_reduce(cell: &[Action]) -> bool {
 //==============================================================================
 
 #[test]
-#[ignore = "KNOWN BUG: GLR conflict generation - enum variant inlining not generating conflicts yet"]
 fn test_ambiguous_grammar_conflict_generation() {
     eprintln!("\n=== E2E TEST: Ambiguous Grammar Conflict Generation ===\n");
 
@@ -83,7 +83,7 @@ fn test_ambiguous_grammar_conflict_generation() {
     let mut has_binary_conflict = false;
     for (state_idx, state_actions) in parse_table.action_table.iter().enumerate() {
         for (symbol_idx, cell) in state_actions.iter().enumerate() {
-            if cell.len() > 1 && contains_shift_reduce(cell) {
+            if cell_has_conflict(cell) && contains_shift_reduce(cell) {
                 has_binary_conflict = true;
 
                 let symbol_name = if symbol_idx < parse_table.symbol_metadata.len() {
@@ -119,7 +119,6 @@ fn test_ambiguous_grammar_conflict_generation() {
 //==============================================================================
 
 #[test]
-#[ignore = "KNOWN BUG: GLR conflict generation - depends on conflict generation which is not yet working"]
 fn test_ambiguous_grammar_glr_parsing() {
     eprintln!("\n=== E2E TEST: Ambiguous Grammar GLR Parsing ===\n");
 
@@ -147,6 +146,26 @@ fn test_ambiguous_grammar_glr_parsing() {
 
     let expr = result.unwrap();
     eprintln!("  Parsed AST: {:?}", expr);
+
+    let repeated = grammar::parse(input).expect("second parse should succeed");
+    assert_eq!(
+        expr, repeated,
+        "ambiguous typed extraction must be deterministic"
+    );
+    assert_eq!(
+        expr,
+        Expr::Binary(
+            Box::new(Expr::Number(1)),
+            "+".to_string(),
+            Box::new(Expr::Binary(
+                Box::new(Expr::Number(2)),
+                "+".to_string(),
+                Box::new(Expr::Number(3)),
+            )),
+        ),
+        "current deterministic selection should remain stable"
+    );
+    eprintln!("  ✅ Deterministic typed extraction validated");
 
     // Contract Assertion 2: Valid AST structure
     assert!(
@@ -256,7 +275,6 @@ fn test_glr_backward_compatibility() {
 //==============================================================================
 
 #[test]
-#[ignore = "KNOWN BUG: GLR conflict generation - ambiguous grammar not generating conflicts yet"]
 fn test_ambiguous_vs_arithmetic_comparison() {
     eprintln!("\n=== E2E TEST: Ambiguous vs Arithmetic Comparison ===\n");
 
@@ -316,7 +334,9 @@ fn test_contract_documentation() {
     eprintln!("  4. ✓ Backward compatibility with precedence grammars");
     eprintln!();
     eprintln!("To run validation:");
-    eprintln!("  cargo test -p adze --features glr --test test_e2e_ambiguous_grammar_glr");
+    eprintln!(
+        "  cargo test -p adze --features \"pure-rust,glr,runtime-e2e\" --test test_e2e_ambiguous_grammar_glr"
+    );
     eprintln!();
     eprintln!("Expected Results:");
     eprintln!("  - test_ambiguous_grammar_conflict_generation: PASS");
@@ -324,5 +344,5 @@ fn test_contract_documentation() {
     eprintln!("  - test_glr_backward_compatibility: PASS");
     eprintln!("  - test_ambiguous_vs_arithmetic_comparison: PASS");
     eprintln!();
-    eprintln!("See: docs/specs/E2E_AMBIGUOUS_GRAMMAR_GLR_VALIDATION.md");
+    eprintln!("See: docs/status/SUPPORT_TIERS.md");
 }


### PR DESCRIPTION
## Summary
- decode generated small-table direct pairs as actions for terminal columns and gotos for nonterminal columns, preserving conflict cells while giving true GLR reductions their goto transitions
- route true GLR typed parsing through generated `lex_fn` when available, so generated token IDs are used instead of fallback grammar-pattern lexing
- add stable structural tie-break selection for equivalent complete GLR parses, then promote the generated ambiguous-expression E2E canaries from ignored to active behavior proof

## Proof
- `cargo fmt -p adze --check`
- `cargo test -p adze --features "pure-rust,glr,runtime-e2e" --test test_e2e_ambiguous_grammar_glr -- --nocapture`
- `cargo test -p adze --features "pure-rust,glr,runtime-e2e" --test typed_ast_contract typed_ast_contract_left_associative_addition -- --exact --nocapture`
- `cargo clippy -p adze --features "pure-rust,glr,runtime-e2e" -- -D warnings`

## Notes
This proves one generated ambiguous grammar end to end: conflict-preserving decode, true GLR routing, generated lexer tokenization, and deterministic typed extraction. It does not claim reduce/reduce, nested fork, or ambiguity metadata coverage.