### PR TITLE
runtime: report unexpected token start position

### DIFF
--- a/runtime/src/error_reporting.rs
+++ b/runtime/src/error_reporting.rs
@@ -138,8 +138,15 @@ impl ErrorReportingExt for GLRParser {
         let mut reporter = ErrorReporter::new(String::new());
 
         for (symbol_id, token_text) in tokens {
-            reporter.record_token(&token_text, 0);
             let expected_before_token = expected_token_names(self);
+            if !expected_before_token.is_empty() && !self.expected_symbols().contains(&symbol_id) {
+                let mut error = reporter.error_at_current(self, Some(token_text));
+                if error.expected.is_empty() {
+                    error.expected = expected_before_token;
+                }
+                errors.push(error);
+                return Err(errors);
+            }
 
             // Try to process the token
             let initial_stack_count = self.stack_count();
@@ -154,6 +161,8 @@ impl ErrorReportingExt for GLRParser {
                 errors.push(error);
                 return Err(errors);
             }
+
+            reporter.record_token(&token_text, 0);
         }
 
         let expected_before_eof = expected_token_names(self);

--- a/runtime/tests/error_display_tests.rs
+++ b/runtime/tests/error_display_tests.rs
@@ -1267,6 +1267,9 @@ fn reporting_parse_with_errors_preserves_expected_tokens_after_bad_input() {
         .expect_err("invalid token should fail to parse");
 
     assert_eq!(errors.len(), 1);
+    assert_eq!(errors[0].line, 1);
+    assert_eq!(errors[0].column, 1);
+    assert_eq!(errors[0].unexpected_token.as_deref(), Some("@"));
     assert!(
         errors[0].expected.iter().any(|token| token == "num"),
         "expected token set should survive parse failure: {:?}",


### PR DESCRIPTION
## Summary
- make `parse_with_errors` reject unexpected symbols before advancing the reporter position
- keep accepted-token position tracking unchanged
- extend the existing expected-token regression to assert the diagnostic starts at line 1, column 1 and preserves the unexpected token text

## Proof
- `cargo fmt -p adze --check`
- `cargo test -p adze --test error_display_tests reporting_parse_with_errors_preserves_expected_tokens_after_bad_input --features "pure-rust,glr" -- --exact --nocapture`
- `cargo test -p adze-linecol-core`
- `cargo test -p adze-error-location-core`
- `cargo clippy -p adze --features "pure-rust,glr" -- -D warnings`

## Local note
- `cargo test -p adze parse_error --features "pure-rust,glr" -- --nocapture` ran the parse-error tests but the local Windows host failed while launching an unrelated external-scanner test binary with `os error 740` (elevation required). This PR keeps the proof focused on the exact regression plus the location crates.