### PR TITLE
runtime: include source excerpt in reported parse errors

### DIFF
--- a/runtime/src/error_reporting.rs
+++ b/runtime/src/error_reporting.rs
@@ -135,7 +135,11 @@ impl ErrorReportingExt for GLRParser {
         tokens: Vec<(SymbolId, String)>,
     ) -> Result<Subtree, Vec<ParseError>> {
         let mut errors = Vec::new();
-        let mut reporter = ErrorReporter::new(String::new());
+        let source = tokens
+            .iter()
+            .map(|(_, token_text)| token_text.as_str())
+            .collect::<String>();
+        let mut reporter = ErrorReporter::new(source);
 
         for (symbol_id, token_text) in tokens {
             let expected_before_token = expected_token_names(self);

--- a/runtime/tests/error_display_tests.rs
+++ b/runtime/tests/error_display_tests.rs
@@ -1277,6 +1277,26 @@ fn reporting_parse_with_errors_preserves_expected_tokens_after_bad_input() {
     );
 }
 
+#[test]
+fn reporting_parse_with_errors_includes_source_excerpt_after_bad_input() {
+    let mut parser = make_dummy_parser();
+
+    let errors = parser
+        .parse_with_errors(vec![(adze_ir::SymbolId(2), "@".to_string())])
+        .expect_err("invalid token should fail to parse");
+
+    assert!(
+        errors[0].context.contains("@"),
+        "source excerpt should include the unexpected input: {:?}",
+        errors[0].context
+    );
+    assert!(
+        errors[0].context.contains("^"),
+        "source excerpt should include a caret marker: {:?}",
+        errors[0].context
+    );
+}
+
 // ============================================================================
 // Helper: create a minimal GLRParser for ErrorReporter tests
 // ============================================================================


### PR DESCRIPTION
## Summary
- seed `ErrorReporter` with the token stream text in `parse_with_errors` so parser-generated errors can include source context
- add a regression that invalid input reports both the source excerpt and caret marker alongside the existing expected-token diagnostics

## Verification
- `cargo fmt -p adze --check`
- `cargo test -p adze --test error_display_tests reporting_parse_with_errors_includes_source_excerpt_after_bad_input --features "pure-rust,glr" -- --exact --nocapture`
- `cargo test -p adze --test error_display_tests reporting_parse_with_errors_preserves_expected_tokens_after_bad_input --features "pure-rust,glr" -- --exact --nocapture`
- `cargo test -p adze-linecol-core`
- `cargo test -p adze-error-location-core`
- `cargo clippy -p adze --features "pure-rust,glr" -- -D warnings`
- `git diff --check`

## Notes
- This is a small slice of #463; it does not claim to finish the whole parse-diagnostics issue.