### PR TITLE
tool: remove stale version text from CLI limits

### DIFF
--- a/tool/src/cli/parse.rs
+++ b/tool/src/cli/parse.rs
@@ -28,7 +28,7 @@ pub fn parse_file(
     // Check if a crate path was provided
     if let Some(crate_path) = parser_path {
         // MVP: Provide honest feedback about the current limitations
-        eprintln!("adze CLI v0.6.0 - Parse Command");
+        eprintln!("adze CLI {} - Parse Command", env!("CARGO_PKG_VERSION"));
         eprintln!("========================================");
         eprintln!();
         eprintln!("STATUS: The dynamic parser loading feature is not yet implemented.");
@@ -70,7 +70,7 @@ pub fn parse_file(
         );
         eprintln!("   ```");
         eprintln!();
-        eprintln!("COMING SOON (v0.6.x):");
+        eprintln!("PLANNED:");
         eprintln!("  - Dynamic parser loading via --parser flag");
         eprintln!("  - Tree-sitter compatible CLI functionality");
         eprintln!();
@@ -104,7 +104,7 @@ pub fn parse_file(
     eprintln!("  ```");
     eprintln!();
     eprintln!("Note: Full CLI functionality including dynamic parser loading");
-    eprintln!("      is planned for v0.6.x releases.");
+    eprintln!("      is planned but not available in this release.");
 
     // Return error to indicate no parser was specified
     std::process::exit(64) // EX_USAGE - command line usage error

--- a/tool/src/cli/test.rs
+++ b/tool/src/cli/test.rs
@@ -15,7 +15,7 @@ pub fn run_tests(
     let corpus = corpus_path.unwrap_or(Path::new("corpus"));
 
     if parser_path.is_some() {
-        eprintln!("adze CLI v0.6.0 - Test Command");
+        eprintln!("adze CLI {} - Test Command", env!("CARGO_PKG_VERSION"));
         eprintln!("=====================================");
         eprintln!();
         eprintln!("STATUS: Corpus testing with external parsers is not yet implemented.");
@@ -48,7 +48,7 @@ pub fn run_tests(
         eprintln!("   cargo insta review  # to update snapshots");
         eprintln!("   ```");
         eprintln!();
-        eprintln!("COMING SOON (v0.6.x):");
+        eprintln!("PLANNED:");
         eprintln!("  - Tree-sitter compatible corpus testing");
         eprintln!("  - Automatic test generation from corpus files");
         eprintln!();

--- a/tool/tests/cli_test.rs
+++ b/tool/tests/cli_test.rs
@@ -133,7 +133,14 @@ fn test_parse_with_parser_shows_limitations() {
         stderr.contains("not yet implemented") || stderr.contains("CURRENT LIMITATIONS"),
         "Should mention current limitations"
     );
-    assert!(stderr.contains("v0.6"), "Should mention version");
+    assert!(
+        stderr.contains(env!("CARGO_PKG_VERSION")),
+        "Should mention the current adze-tool version"
+    );
+    assert!(
+        !stderr.contains("v0.6"),
+        "Should not advertise stale v0.6 release text"
+    );
     assert!(
         stderr.contains("dynamic"),
         "Should mention dynamic loading limitation"


### PR DESCRIPTION
## Summary
- Replace stale `v0.6` limitation text in `adze-gen parse` and `adze-gen test` with the current crate version or version-neutral planned wording.
- Strengthen the parser limitation canary to reject stale `v0.6` copy while preserving the explicit unsupported dynamic parser loading behavior.

## Proof
- `cargo test -p adze-tool --test cli_test test_parse_with_parser_shows_limitations -- --exact --nocapture`
- `cargo test -p adze-tool --test cli_test test_test_command_rejects_corpus_without_parser -- --exact --nocapture`
- `cargo test -p adze-tool --test cli_test -- --nocapture`
- `cargo fmt -p adze-tool --check`
- `cargo clippy -p adze-tool --test cli_test -- -D warnings`
- `git diff --check origin/main...HEAD`

Note: local `just ci-supported` is still blocked in this Windows shell by the missing `cygpath` shebang translation; hosted `ci-supported` remains the required merge proof.