### PR TITLE
ci(codecov): add conservative Codecov config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,23 +7,20 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 2%
+        threshold: 5%
         informational: true
         flags:
-          - rust
+          - rust-core
 
     patch:
       default:
-        target: 60%
-        threshold: 10%
+        target: 70%
+        threshold: 20%
         informational: true
         flags:
-          - rust
+          - rust-core
 
-comment:
-  layout: "reach,diff,flags,tree"
-  behavior: default
-  require_changes: true
+comment: false
 
 github_checks:
   annotations: false
@@ -32,6 +29,5 @@ ignore:
   - "target/**"
   - "runtime/fuzz/**"
   - "tools/ts-bridge/**"
-  - "book/book/**"
-  - "docs/archive/**"
-  - "benchmarks/results/**"
+  - "crates/ts-c-harness/**"
+  - "example/**"


### PR DESCRIPTION
## Summary

Adds step 2 of the Adze Codecov rollout: conservative, quiet codecov configuration with advisory-only thresholds.

## CI economics

- **File touched**: `codecov.yml` (existing, updated)
- **Default PR impact**: Zero. Comments disabled, annotations disabled, thresholds informational.
- **Rollback path**: Revert `codecov.yml` to prior version; Codecov will use defaults.

## Configuration changes

- **Project threshold**: 5% (was 2%) — informational only
- **Patch threshold**: 70% target, 20% threshold (was 60% target, 10% threshold) — informational only
- **Comments**: `false` (was layout + behavior settings) — rely on dashboard instead
- **Annotations**: `false` (unchanged) — reduce PR noise
- **Flag**: `rust-core` (was `rust`) — for coverage lane distinction
- **Ignore paths**: Aligned with workspace exclusions (target/, runtime/fuzz/, tools/ts-bridge/, crates/ts-c-harness/, example/)

## Claim boundary

Coverage is **execution-surface evidence only**. It does not prove:
- Parser correctness
- GLR correctness
- Mutation adequacy
- Fuzz robustness
- Miri/sanitizer proof
- Release packaging
- Public API stability

## Validation

- [x] YAML parses correctly
- [x] Thresholds are informational (not blocking PRs)
- [x] Comments disabled
- [x] Annotations disabled
- [x] Paths match workspace exclusions
- [x] Flag aligns with coverage lane identity

## Follow-up

- This is designed to work with the advisory Coverage workflow (PR 1)
- PR 3 will add the Codecov badge to README
- PRs 4–6 will register the lane in policy surfaces (after policy PRs land)


---
_Generated by [Claude Code](https://claude.ai/code/session_016XoCKRUEJu64bKGxFEV2YJ)_