### PR TITLE
policy(ci): register coverage lane

### DIFF
--- a/policy/ci-lane-whitelist.toml
+++ b/policy/ci-lane-whitelist.toml
@@ -650,3 +650,24 @@ allowed_triggers = ["pull_request"]
 duplicate_of = ["fuzz-pr"]
 review_after = "2026-06-07"
 expires = "2026-11-07"
+
+[[lane]]
+id = "coverage"
+workflow = ".github/workflows/coverage.yml"
+job = "coverage"
+display_name = "Codecov Coverage"
+kind = "execution_surface"
+tier = "frontdoor"
+default_pr = false
+blocking = false
+runner = "ubuntu_latest"
+base_lem = 45
+owner = "release/ci"
+intent = "Execution-surface reporting for Adze Rust codebase via cargo-llvm-cov and Codecov."
+failure_mode = "A change removes test execution over the Rust parser/runtime/codegen surface without visibility."
+proof_obligation = "Generate coverage.json, coverage.txt, lcov.info, upload GitHub artifact, and upload LCOV to Codecov when CODECOV_TOKEN is present."
+evidence = ["coverage.json", "coverage.txt", "lcov.info", "coverage-report GitHub artifact"]
+allowed_triggers = ["push", "workflow_dispatch", "pull_request"]
+duplicate_of = []
+review_after = "2026-06-07"
+expires = "2026-11-07"


### PR DESCRIPTION
## Summary

Adds step 4 of the Adze Codecov rollout: registers the Coverage lane in the CI policy whitelist.

## Changes

- Added `coverage` lane entry to `policy/ci-lane-whitelist.toml`
- Lane configuration:
  - Workflow: `.github/workflows/coverage.yml`
  - Job: `coverage`
  - Kind: `execution_surface`
  - Tier: `frontdoor`
  - Default PR: `false` (only runs on push/dispatch/PRs labeled `coverage` or `full-ci`)
  - Blocking: `false` (advisory, not part of required gate)
  - Base LEM: 45 (Linux-equivalent minutes, ~45 minute wall-clock time)
  - Owner: `release/ci`

## Intent & Obligation

- **Intent**: Execution-surface reporting for Adze Rust codebase via cargo-llvm-cov and Codecov
- **Failure mode**: A change removes test execution over the Rust parser/runtime/codegen surface without visibility
- **Proof obligation**: Generate coverage.json, coverage.txt, lcov.info, upload GitHub artifact, and upload LCOV to Codecov when CODECOV_TOKEN is present
- **Evidence**: coverage.json, coverage.txt, lcov.info, coverage-report GitHub artifact

## CI economics

- **Cost per run**: 45 LEM (Linux-equivalent minutes)
- **PR impact**: Zero (not default_pr; only runs on labeled PRs)
- **Block gate**: No (advisory only)
- **Expiry**: 2026-11-07 (requires review on 2026-06-07)

## Validation

- [x] TOML parses correctly
- [x] Lane ID unique and stable
- [x] Base LEM matches workflow timeout-minutes
- [x] Blocking=false (advisory)
- [x] default_pr=false (zero impact on ordinary PRs)
- [x] Proof obligation clear and observable

## Follow-up

- PR 5 will add `docs/ci/coverage.md` documenting the lane
- PR 6 will add coverage receipt artifact (if straightforward)
- PR 7 will baseline and ratchet coverage thresholds (after real data exists on main)


---
_Generated by [Claude Code](https://claude.ai/code/session_016XoCKRUEJu64bKGxFEV2YJ)_