### PR TITLE
tablegen: preserve rule-id production map order

### DIFF
--- a/runtime/src/decoder.rs
+++ b/runtime/src/decoder.rs
@@ -962,10 +962,12 @@ pub fn decode_parse_table(lang: &'static TSLanguage) -> ParseTable {
                     let action = if action_index == 0xFFFF {
                         Action::Accept
                     } else if action_index & 0x8000 != 0 {
-                        // Reduce action - for pure-rust backend, bits 14-0 contain sequential rule ID (1-based)
-                        let rule_id = (action_index & 0x7FFF) - 1;
-                        if rule_id < rules.len() {
-                            Action::Reduce(RuleId(rule_id as u16))
+                        // Reduce action - bits 14-0 contain encoded GLR rule ID (1-based).
+                        let encoded_rule_id = (action_index & 0x7FFF) - 1;
+                        if let Some(production_id) =
+                            mapped_production_id(lang, encoded_rule_id, rules.len())
+                        {
+                            Action::Reduce(RuleId(production_id))
                         } else {
                             Action::Error
                         }
@@ -1184,6 +1186,28 @@ pub fn decode_parse_table(lang: &'static TSLanguage) -> ParseTable {
     table.detect_goto_indexing();
 
     table
+}
+
+fn mapped_production_id(
+    lang: &TSLanguage,
+    encoded_rule_id: usize,
+    production_count: usize,
+) -> Option<u16> {
+    let production_id = if !lang.production_id_map.is_null()
+        && encoded_rule_id < lang.production_id_count as usize
+    {
+        // SAFETY: `encoded_rule_id` is bounded by `production_id_count`, and
+        // TSLanguage production_id_map contains one entry per production slot.
+        unsafe { *lang.production_id_map.add(encoded_rule_id) }
+    } else {
+        u16::try_from(encoded_rule_id).ok()?
+    };
+
+    if production_id == u16::MAX || production_id as usize >= production_count {
+        None
+    } else {
+        Some(production_id)
+    }
 }
 
 /// Determine if a symbol is a terminal based on metadata and name
@@ -1440,6 +1464,78 @@ mod tests {
             decode_action(&recover_action, &empty_rules, &empty_map),
             Action::Error
         ));
+    }
+
+    #[test]
+    fn small_table_reduce_actions_map_rule_id_to_production_id() {
+        static PRODUCTION_ID_MAP: [u16; 2] = [1, 0];
+        static PRODUCTION_LHS_INDEX: [u16; 2] = [2, 2];
+        static SMALL_PARSE_TABLE: [u16; 2] = [1, 0x8001];
+        static SMALL_PARSE_TABLE_MAP: [u32; 2] = [0, 2];
+        static NAME_ERROR: &[u8] = b"end\0";
+        static NAME_TOKEN: &[u8] = b"token\0";
+        static NAME_NODE: &[u8] = b"node\0";
+        static RULES: [crate::pure_parser::TSRule; 2] = [
+            crate::pure_parser::TSRule {
+                lhs: 2,
+                rhs_len: 1,
+                _pad: 0,
+            },
+            crate::pure_parser::TSRule {
+                lhs: 2,
+                rhs_len: 1,
+                _pad: 0,
+            },
+        ];
+        let symbol_names = Box::leak(Box::new([
+            NAME_ERROR.as_ptr(),
+            NAME_TOKEN.as_ptr(),
+            NAME_NODE.as_ptr(),
+        ]));
+
+        let language = Box::leak(Box::new(TSLanguage {
+            version: crate::pure_parser::TREE_SITTER_LANGUAGE_VERSION,
+            symbol_count: 3,
+            alias_count: 0,
+            token_count: 2,
+            external_token_count: 0,
+            state_count: 1,
+            large_state_count: 0,
+            production_id_count: 2,
+            field_count: 0,
+            max_alias_sequence_length: 0,
+            production_id_map: PRODUCTION_ID_MAP.as_ptr(),
+            parse_table: std::ptr::null(),
+            small_parse_table: SMALL_PARSE_TABLE.as_ptr(),
+            small_parse_table_map: SMALL_PARSE_TABLE_MAP.as_ptr(),
+            parse_actions: std::ptr::null(),
+            symbol_names: symbol_names.as_ptr(),
+            field_names: std::ptr::null(),
+            field_map_slices: std::ptr::null(),
+            field_map_entries: std::ptr::null(),
+            symbol_metadata: std::ptr::null(),
+            public_symbol_map: std::ptr::null(),
+            alias_map: std::ptr::null(),
+            alias_sequences: std::ptr::null(),
+            lex_modes: std::ptr::null(),
+            lex_fn: None,
+            keyword_lex_fn: None,
+            keyword_capture_token: 0,
+            external_scanner: crate::pure_parser::ExternalScanner::default(),
+            primary_state_ids: std::ptr::null(),
+            production_lhs_index: PRODUCTION_LHS_INDEX.as_ptr(),
+            production_count: 2,
+            eof_symbol: 0,
+            rules: RULES.as_ptr(),
+            rule_count: 2,
+        }));
+
+        let table = decode_parse_table(language);
+
+        match table.action_table[0][1][0] {
+            Action::Reduce(RuleId(rule_id)) => assert_eq!(rule_id, 1),
+            ref action => panic!("expected mapped reduce action, got {action:?}"),
+        }
     }
 
     #[test]

--- a/runtime/src/parser_v4.rs
+++ b/runtime/src/parser_v4.rs
@@ -742,6 +742,7 @@ impl Parser {
                         }
                     }
                     children.reverse(); // Children were popped in reverse order
+                    self.assign_field_names_for_production(rule_id, &mut children);
 
                     // Create a parent node
                     let start_byte = children
@@ -979,6 +980,26 @@ impl Parser {
                     self.parse_table.rules.len()
                 )
             })
+    }
+
+    fn assign_field_names_for_production(&self, rule_id: RuleId, children: &mut [ParseNode]) {
+        if children.is_empty() || self.parse_table.field_names.is_empty() {
+            return;
+        }
+
+        for (child_index, child) in children.iter_mut().enumerate() {
+            let Some(field_id) = self
+                .parse_table
+                .field_map
+                .get(&(rule_id, child_index as u16))
+            else {
+                continue;
+            };
+
+            if let Some(field_name) = self.parse_table.field_names.get(*field_id as usize) {
+                child.field_name = Some(field_name.clone());
+            }
+        }
     }
 
     /// Get the goto state for a non-terminal after a reduce
@@ -1681,6 +1702,46 @@ mod tests {
             let language_ptr = language.as_ref() as *const TSLanguage;
             unsafe { &*language_ptr }
         })
+    }
+
+    #[test]
+    fn test_assign_field_names_for_production_preserves_named_children() {
+        let mut field_map = std::collections::BTreeMap::new();
+        field_map.insert((RuleId(2), 0), 1);
+        let parse_table = ParseTable {
+            field_names: vec!["_".to_string(), "value".to_string()],
+            field_map,
+            ..Default::default()
+        };
+
+        let parser = Parser::new(
+            Grammar::new("field_name_test".to_string()),
+            parse_table,
+            "field_name_test".to_string(),
+        );
+        let mut children = vec![
+            ParseNode {
+                symbol: SymbolId(4),
+                symbol_id: SymbolId(4),
+                start_byte: 0,
+                end_byte: 1,
+                field_name: None,
+                children: vec![],
+            },
+            ParseNode {
+                symbol: SymbolId(5),
+                symbol_id: SymbolId(5),
+                start_byte: 1,
+                end_byte: 2,
+                field_name: None,
+                children: vec![],
+            },
+        ];
+
+        parser.assign_field_names_for_production(RuleId(2), &mut children);
+
+        assert_eq!(children[0].field_name.as_deref(), Some("value"));
+        assert_eq!(children[1].field_name, None);
     }
 
     #[test]

--- a/runtime/src/pure_parser.rs
+++ b/runtime/src/pure_parser.rs
@@ -1495,7 +1495,7 @@ impl Parser {
 
             // Reverse children to correct order
             children.reverse();
-            self.assign_field_ids_for_production(language, production_id, &mut children);
+            self.assign_field_ids_for_production(language, production_index, &mut children);
 
             // Handle empty reduction
             if children.is_empty() && child_count == 0 {
@@ -1613,7 +1613,7 @@ impl Parser {
     fn assign_field_ids_for_production(
         &self,
         language: &TSLanguage,
-        production_id: u16,
+        production_index: u16,
         children: &mut [Subtree],
     ) {
         if children.is_empty()
@@ -1628,7 +1628,7 @@ impl Parser {
         // SAFETY: `field_map_slices` is non-null and points to static language data.
         let field_map_slices =
             unsafe { std::slice::from_raw_parts(language.field_map_slices, slices_len) };
-        let slice_offset = production_id as usize * 2;
+        let slice_offset = production_index as usize * 2;
         if slice_offset + 1 >= field_map_slices.len() {
             return;
         }
@@ -2429,5 +2429,64 @@ mod tests {
         Parser::new().assign_field_ids_for_production(&language, 1, &mut children);
         assert_eq!(children[0].field_id, Some(1));
         assert_eq!(children[1].field_id, Some(2));
+    }
+
+    #[test]
+    fn test_assign_field_ids_for_production_accepts_zero_based_production_index() {
+        let entry = pack_field_map_entry(1, 0, 0);
+        let field_map_entries = [entry[0], entry[1]];
+        let field_map_slices = [0u16, 1u16, 0u16, 0u16];
+        let language = TSLanguage {
+            version: TREE_SITTER_LANGUAGE_VERSION,
+            symbol_count: 2,
+            alias_count: 0,
+            token_count: 1,
+            external_token_count: 0,
+            state_count: 1,
+            large_state_count: 1,
+            production_id_count: 2,
+            field_count: 2,
+            max_alias_sequence_length: 0,
+            production_id_map: std::ptr::null(),
+            parse_table: std::ptr::null(),
+            small_parse_table: std::ptr::null(),
+            small_parse_table_map: std::ptr::null(),
+            parse_actions: std::ptr::null(),
+            symbol_names: std::ptr::null(),
+            field_names: std::ptr::null(),
+            field_map_slices: field_map_slices.as_ptr(),
+            field_map_entries: field_map_entries.as_ptr(),
+            symbol_metadata: std::ptr::null(),
+            public_symbol_map: std::ptr::null(),
+            alias_map: std::ptr::null(),
+            alias_sequences: std::ptr::null(),
+            lex_modes: std::ptr::null(),
+            lex_fn: None,
+            keyword_lex_fn: None,
+            keyword_capture_token: 0,
+            external_scanner: ExternalScanner::default(),
+            primary_state_ids: std::ptr::null(),
+            production_lhs_index: std::ptr::null(),
+            production_count: 0,
+            eof_symbol: 0,
+            rules: std::ptr::null(),
+            rule_count: 0,
+        };
+        let mut children = vec![Subtree {
+            symbol: 1,
+            children: vec![],
+            start_byte: 0,
+            end_byte: 1,
+            start_point: Point { row: 0, column: 0 },
+            end_point: Point { row: 0, column: 1 },
+            is_extra: false,
+            is_error: false,
+            is_missing: false,
+            production_id: 0,
+            field_id: None,
+        }];
+
+        Parser::new().assign_field_ids_for_production(&language, 0, &mut children);
+        assert_eq!(children[0].field_id, Some(1));
     }
 }

--- a/tablegen/src/abi_builder.rs
+++ b/tablegen/src/abi_builder.rs
@@ -288,7 +288,7 @@ impl<'a> AbiLanguageBuilder<'a> {
             // Primary state IDs
             static PRIMARY_STATE_IDS: &[u16] = &[#(#primary_state_ids),*];
 
-            // Production ID map (maps production IDs to rule IDs)
+            // Production ID map (maps encoded rule IDs to production IDs)
             static PRODUCTION_ID_MAP: &[u16] = &[#(#production_id_map),*];
 
             // Production LHS index (maps production IDs to LHS symbols in table index space)
@@ -439,6 +439,16 @@ impl<'a> AbiLanguageBuilder<'a> {
             .collect();
 
         (names, ptrs)
+    }
+
+    fn field_name_indices_by_field_id(&self) -> std::collections::BTreeMap<u16, u16> {
+        let mut fields: Vec<_> = self.grammar.fields.iter().collect();
+        fields.sort_by_key(|(_, name)| name.as_str());
+        fields
+            .into_iter()
+            .enumerate()
+            .map(|(index, (field_id, _))| (field_id.0, index as u16))
+            .collect()
     }
 
     /// Generate symbol metadata
@@ -819,12 +829,12 @@ impl<'a> AbiLanguageBuilder<'a> {
             .collect();
         rules.sort_by_key(|rule| rule.production_id.0);
 
-        for (rule_id, rule) in rules.iter().enumerate() {
+        for rule in rules {
             let index = rule.production_id.0 as usize;
             let child_count = rule.rhs.len() as u8;
 
-            // Store the sequential rule ID directly in the symbol field
-            let symbol = rule_id as u16;
+            // Store the production ID because PARSE_ACTIONS is production-indexed.
+            let symbol = rule.production_id.0;
 
             if index < actions.len() {
                 actions[index] = quote! {
@@ -863,6 +873,7 @@ impl<'a> AbiLanguageBuilder<'a> {
         let production_id_count = self.calculate_counts().production_id_count as usize;
         let mut field_map_slices = vec![quote! { 0u16 }; production_id_count * 2];
         let mut field_map_entries = Vec::new();
+        let field_name_indices = self.field_name_indices_by_field_id();
 
         // Group rules by production ID
         let mut rules_by_production: std::collections::BTreeMap<u16, Vec<&Rule>> =
@@ -885,7 +896,10 @@ impl<'a> AbiLanguageBuilder<'a> {
             for rule in rules {
                 // Add entries for each field in this rule
                 for (field_id, position) in &rule.fields {
-                    let field_id_val = field_id.0;
+                    let field_id_val = field_name_indices
+                        .get(&field_id.0)
+                        .copied()
+                        .unwrap_or(field_id.0);
                     let child_index = *position as u8;
                     let inherited = 0u8; // false - TODO: implement inheritance detection
 
@@ -1018,24 +1032,13 @@ impl<'a> AbiLanguageBuilder<'a> {
         // After decoding to zero-based, runtime indexes this map by RULE ID from parse actions.
         // Therefore this map must be: rule_id -> production_id.
         // PARSE_ACTIONS / TS_RULES are indexed by production_id.
-        let mut rules: Vec<_> = self
-            .grammar
-            .rules
-            .iter()
-            .flat_map(|(_, rules)| rules.iter())
-            .collect();
-        rules.sort_by_key(|rule| rule.production_id.0);
-
-        // Find the maximum production ID to size the map.
-        // Production IDs are encoded directly and can start at 0.
-        let max_production_id = rules.iter().map(|r| r.production_id.0).max().unwrap_or(0);
-        let map_size = max_production_id as usize + 1;
+        let map_size = self.calculate_counts().production_id_count as usize;
 
         // Initialize map with a sentinel value (u16::MAX)
         let mut rule_to_production = vec![u16::MAX; map_size];
 
-        // Fill the map: rule_id (sequential, zero-based) -> production_id
-        for (rule_id, rule) in rules.iter().enumerate() {
+        // Fill the map in the same rule-id order used by GLR action generation.
+        for (rule_id, rule) in self.grammar.all_rules().enumerate() {
             if rule_id < map_size {
                 rule_to_production[rule_id] = rule.production_id.0;
             }
@@ -1099,8 +1102,22 @@ impl<'a> AbiLanguageBuilder<'a> {
     }
 
     fn generate_ts_rules(&self) -> Vec<TokenStream> {
-        // Generate TSRule structs for each production
-        let mut ts_rules = Vec::new();
+        let production_id_count = self.calculate_counts().production_id_count as usize;
+        if self.grammar.all_rules().next().is_none() {
+            return Vec::new();
+        }
+
+        // Generate TSRule structs indexed by production ID.
+        let mut ts_rules = vec![
+            quote! {
+                TSRule {
+                    lhs: 0,
+                    rhs_len: 0,
+                    _pad: 0,
+                }
+            };
+            production_id_count
+        ];
 
         // Get all rules sorted by production ID
         let mut rules: Vec<_> = self
@@ -1113,6 +1130,7 @@ impl<'a> AbiLanguageBuilder<'a> {
 
         // For each production, create a TSRule
         for rule in &rules {
+            let production_index = rule.production_id.0 as usize;
             let symbol_id = rule.lhs;
             let lhs = self
                 .parse_table
@@ -1128,13 +1146,15 @@ impl<'a> AbiLanguageBuilder<'a> {
                     symbol_id.0 as usize
                 }) as u16;
             let rhs_len = rule.rhs.len() as u8;
-            ts_rules.push(quote! {
-                TSRule {
-                    lhs: #lhs,
-                    rhs_len: #rhs_len,
-                    _pad: 0,
-                }
-            });
+            if production_index < ts_rules.len() {
+                ts_rules[production_index] = quote! {
+                    TSRule {
+                        lhs: #lhs,
+                        rhs_len: #rhs_len,
+                        _pad: 0,
+                    }
+                };
+            }
         }
 
         ts_rules
@@ -1869,6 +1889,47 @@ mod tests {
             entries.len(),
             4,
             "two field-map entries should emit two u16 words each"
+        );
+    }
+
+    #[test]
+    fn test_field_map_entries_use_abi_field_name_indices() {
+        let table = crate::empty_table!(states: 1, terms: 1, nonterms: 1);
+        let start = table.start_symbol;
+        let t = SymbolId(1);
+
+        let mut grammar = Grammar::new("field_map_name_indices".to_string());
+        grammar.rule_names.insert(start, "start".to_string());
+        grammar.tokens.insert(
+            t,
+            Token {
+                name: "t".to_string(),
+                pattern: TokenPattern::String("t".to_string()),
+                fragile: false,
+            },
+        );
+        grammar
+            .fields
+            .insert(FieldId(0), "TestModule_statements_vec_element".to_string());
+        grammar.fields.insert(FieldId(1), "value".to_string());
+        grammar.fields.insert(FieldId(2), "statements".to_string());
+        grammar.fields.insert(FieldId(3), "_whitespace".to_string());
+        grammar.add_rule(Rule {
+            lhs: start,
+            rhs: vec![Symbol::Terminal(t)],
+            precedence: None,
+            associativity: None,
+            fields: vec![(FieldId(1), 0)],
+            production_id: ProductionId(0),
+        });
+
+        let builder = AbiLanguageBuilder::new(&grammar, &table);
+        let (_, entries) = builder.generate_field_maps();
+        let entries: Vec<String> = entries.iter().map(ToString::to_string).collect();
+
+        assert_eq!(
+            entries[0], "3u32 as u16",
+            "field map entries must use the FIELD_NAME_PTRS ABI index for value"
         );
     }
 

--- a/tablegen/tests/production_id_comprehensive.rs
+++ b/tablegen/tests/production_id_comprehensive.rs
@@ -708,6 +708,43 @@ fn edge_sparse_production_ids_emit_dense_production_lhs_index() {
     );
 }
 
+/// Production ID map preserves GLR rule-id order even when production IDs are sparse.
+#[test]
+fn edge_sparse_production_ids_preserve_rule_id_order_in_map() {
+    let table = empty_table(1, 1, 2, 0);
+    let (mut g, start, t) = base_grammar("sparse_rule_id_map", &table);
+    let other = SymbolId(start.0 + 1);
+    g.rule_names.insert(other, "other".to_string());
+
+    // GLR action generation assigns rule IDs from grammar insertion order.
+    // These production IDs intentionally do not match that order.
+    g.add_rule(rule(start, vec![Symbol::Terminal(t)], 7));
+    g.add_rule(rule(other, vec![Symbol::Terminal(t)], 0));
+
+    let code = gen_code(&g, &table);
+    let count = extract_production_id_count(&code).unwrap();
+    let map = extract_production_id_map(&code);
+    let lhs_index = extract_production_lhs_index(&code);
+
+    assert_eq!(count, 8);
+    assert_eq!(map.len(), count as usize);
+    assert_eq!(
+        map[0], 7,
+        "rule ID 0 should map to the first inserted rule's production ID"
+    );
+    assert_eq!(
+        map[1], 0,
+        "rule ID 1 should map to the second inserted rule's production ID"
+    );
+    assert!(
+        map[2..].iter().all(|id| *id == u16::MAX),
+        "unused rule-id slots should be explicit sentinels"
+    );
+    assert_eq!(lhs_index.len(), count as usize);
+    assert_eq!(lhs_index[7], table.symbol_to_index[&start] as u16);
+    assert_eq!(lhs_index[0], table.symbol_to_index[&other] as u16);
+}
+
 /// production_id_count accounts for gaps in production IDs.
 #[test]
 fn edge_gap_in_production_ids() {

--- a/tablegen/tests/production_map_comprehensive.rs
+++ b/tablegen/tests/production_map_comprehensive.rs
@@ -522,13 +522,14 @@ fn production_count_matches_total_rules() {
 // ===========================================================================
 
 #[test]
-fn production_id_map_sorted_by_production_id() {
+fn production_id_map_preserves_rule_id_order() {
     let t = SymbolId(1);
     let table = make_empty_table(1, 1, 1, 0);
     let start = table.start_symbol;
-    // Intentionally add rules in reverse order of production IDs
+    // Intentionally add rules out of production-ID order. Parse actions encode
+    // GLR rule IDs, so this map must preserve insertion/rule-ID order.
     let grammar = build_grammar(
-        "sorted",
+        "rule_id_order",
         &table,
         vec![(t, string_token("t", "x"))],
         vec![
@@ -540,9 +541,37 @@ fn production_id_map_sorted_by_production_id() {
     let code = gen_code(&grammar, &table);
     let map = extract_production_id_map(&code);
     assert_eq!(map.len(), 3);
-    for i in 0..3 {
-        assert_eq!(map[i], i as u16);
-    }
+    assert_eq!(map, vec![2, 0, 1]);
+}
+
+#[test]
+fn ts_rules_are_dense_for_sparse_production_ids() {
+    let t = SymbolId(1);
+    let table = make_empty_table(1, 1, 2, 0);
+    let nt1 = table.start_symbol;
+    let nt2 = SymbolId(nt1.0 + 1);
+    let grammar = build_grammar(
+        "sparse_ts_rules",
+        &table,
+        vec![(t, string_token("t", "x"))],
+        vec![
+            simple_rule(nt1, vec![Symbol::Terminal(t)], 7),
+            simple_rule(nt2, vec![Symbol::Terminal(t), Symbol::Terminal(t)], 0),
+        ],
+    );
+
+    let code = gen_code(&grammar, &table);
+    let lens = extract_rhs_lens(&code);
+    let lhs = extract_production_lhs_index(&code);
+
+    assert_eq!(lens.len(), 8);
+    assert_eq!(lhs.len(), 8);
+    assert_eq!(lens[0], 2);
+    assert_eq!(lens[7], 1);
+    assert!(
+        lens[1..7].iter().all(|len| *len == 0),
+        "gapped TS_RULES slots should be explicit zero sentinels"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- generate `PRODUCTION_ID_MAP` in GLR rule-id order instead of sorting by production ID
- keep `PARSE_ACTIONS`, `PRODUCTION_LHS_INDEX`, and `TS_RULES` dense by production ID with explicit gap sentinels
- encode field-map entries with the generated `FIELD_NAME_PTRS` ABI index so field IDs resolve to the right names at runtime
- normalize runtime field-map assignment, parser_v4 reduce field names, and decoded small-table reduce actions through the mapped production ID
- add sparse/out-of-order production ID canaries, field-map ABI index canaries, and update stale map-order expectations
- restore the strict JavaScript `;` -> `EmptyStatement` golden canary and test-vec-wrapper typed Vec extraction without weakening either test

## Proof
- `cargo test -p adze-tablegen --lib abi_builder::tests::test_field_map_entries_use_abi_field_name_indices -- --exact --nocapture`
- `cargo test -p adze-tablegen field_map -- --nocapture`
- `cargo test -p adze-tablegen production_lhs -- --nocapture`
- `cargo test -p adze-tablegen --test production_id_comprehensive -- --nocapture`
- `cargo test -p adze-tablegen --test production_map_comprehensive -- --nocapture`
- `cargo test -p adze-tablegen production_id_map -- --nocapture`
- `cargo test -p adze --lib parser_v4::tests::test_assign_field_names_for_production_preserves_named_children -- --exact --nocapture`
- `cargo test -p adze --lib -- --test-threads=2`
- `cargo test -p adze --features "pure-rust,glr,ts-compat" --test tablegen_abi_decode_roundtrip -- --nocapture`
- `cargo test -p adze-golden-tests javascript_canary_expression_golden --features javascript-grammar -- --nocapture`
- `cargo test -p test-vec-wrapper --test resolver_test -- --nocapture`
- `cargo test -p test-vec-wrapper -- --nocapture` (parse assertions are Windows-skipped locally; resolver tests exercise typed Vec values locally)
- `cargo fmt -p adze -- --check`
- `cargo fmt -p adze-tablegen -- --check`
- `cargo clippy -p adze-tablegen --lib -- -D warnings`
- `cargo clippy -p adze --lib -- -D warnings`
- `cargo clippy -p adze -p adze-macro -p adze-tool -p adze-common -p adze-ir -p adze-glr-core -p adze-tablegen --all-targets -- -D warnings`
- `git diff --check`

## Local environment notes
- `cargo fmt --all -- --check` is blocked on this Windows host by `os error 206` (filename or extension too long); scoped affected-package fmt passes.
- `just ci-supported` is blocked locally because `cygpath` is missing for just shebang path translation.
- Hosted `Supported Rust Gate` should be treated as authoritative for `just ci-supported`.