### PR TITLE
ci: stabilize cargo-fuzz install

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -37,7 +37,7 @@ jobs:
       uses: dtolnay/rust-toolchain@nightly
     
     - name: Install cargo-fuzz
-      run: cargo +nightly install cargo-fuzz
+      run: cargo install cargo-fuzz --locked
     
     - name: Cache cargo registry
       uses: actions/cache@v5.0.3
@@ -81,7 +81,7 @@ jobs:
       uses: dtolnay/rust-toolchain@nightly
     
     - name: Install cargo-fuzz
-      run: cargo +nightly install cargo-fuzz
+      run: cargo install cargo-fuzz --locked
     
     - name: Cache cargo registry
       uses: actions/cache@v5.0.3
@@ -142,7 +142,7 @@ jobs:
           fi
       - name: Install cargo-fuzz
         if: steps.risk.outputs.needs_smoke == 'true'
-        run: cargo +nightly install cargo-fuzz --locked
+        run: cargo install cargo-fuzz --locked
       - name: Build fuzz harness (smoke)
         if: steps.risk.outputs.needs_smoke == 'true'
         run: |


### PR DESCRIPTION
Avoid installing cargo-fuzz with latest nightly; nightly is still used for fuzz build where required.

The \cargo +nightly install cargo-fuzz --locked\ command fails under nightly-1.97.0 because the locked \ustix\ dependency uses \ustc_*\ attributes that are now reserved. Installing with stable avoids this; nightly is only needed for the actual fuzz harness compilation.

This is a CI toolchain drift fix, not a code change.