### PR TITLE
ts-compat: expose fielded child access

### DIFF
--- a/runtime/src/ts_compat/mod.rs
+++ b/runtime/src/ts_compat/mod.rs
@@ -299,6 +299,28 @@ impl<'a> Node<'a> {
             .map(|child| Node::new(self.tree, child))
     }
 
+    /// Get the field name attached to this node's edge from its parent.
+    pub fn field_name(&self) -> Option<&str> {
+        self.node.field_name.as_deref()
+    }
+
+    /// Get the field name for a child edge by child index.
+    pub fn field_name_for_child(&self, index: usize) -> Option<&str> {
+        self.node
+            .children
+            .get(index)
+            .and_then(|child| child.field_name.as_deref())
+    }
+
+    /// Get the first child attached through the given field name.
+    pub fn child_by_field_name(&self, field_name: &str) -> Option<Node<'a>> {
+        self.node
+            .children
+            .iter()
+            .find(|child| child.field_name.as_deref() == Some(field_name))
+            .map(|child| Node::new(self.tree, child))
+    }
+
     /// Check if this node is an error node.
     pub fn is_error(&self) -> bool {
         (self.node.symbol.0 == 0 && self.node.children.is_empty()) || self.tree.error_count() > 0

--- a/runtime/tests/ts_compat_tree_children.rs
+++ b/runtime/tests/ts_compat_tree_children.rs
@@ -2,7 +2,8 @@
 
 #![cfg(all(test, feature = "ts-compat", feature = "pure-rust"))]
 
-use adze::ts_compat::Parser;
+use adze::{adze_ir::RuleId, ts_compat::Parser};
+use std::sync::Arc;
 
 #[test]
 fn generated_tree_exposes_nested_children() {
@@ -40,4 +41,53 @@ fn generated_tree_exposes_nested_children() {
     assert_eq!(right.kind(), "expression");
     assert_eq!(right.text(source.as_bytes()), "2");
     assert!(expression.child(3).is_none());
+}
+
+#[test]
+fn generated_tree_exposes_fielded_children() {
+    let mut lang = (*adze_example::ts_langs::arithmetic()).clone();
+    lang.table.field_names = vec![
+        "left".to_string(),
+        "operator".to_string(),
+        "right".to_string(),
+    ];
+    lang.table.field_map.insert((RuleId(2), 0), 0);
+    lang.table.field_map.insert((RuleId(2), 1), 1);
+    lang.table.field_map.insert((RuleId(2), 2), 2);
+
+    let mut parser = Parser::new();
+    parser
+        .set_language(Arc::new(lang))
+        .expect("Failed to set language");
+
+    let source = "1-2";
+    let tree = parser.parse(source, None).expect("Parse failed");
+    let expression = tree
+        .root_node()
+        .child(0)
+        .expect("root should expose expression child");
+
+    assert_eq!(expression.field_name(), None);
+    assert_eq!(expression.field_name_for_child(0), Some("left"));
+    assert_eq!(expression.field_name_for_child(1), Some("operator"));
+    assert_eq!(expression.field_name_for_child(2), Some("right"));
+    assert_eq!(expression.field_name_for_child(3), None);
+
+    let left = expression
+        .child_by_field_name("left")
+        .expect("left field should resolve");
+    let operator = expression
+        .child_by_field_name("operator")
+        .expect("operator field should resolve");
+    let right = expression
+        .child_by_field_name("right")
+        .expect("right field should resolve");
+
+    assert_eq!(left.field_name(), Some("left"));
+    assert_eq!(left.text(source.as_bytes()), "1");
+    assert_eq!(operator.field_name(), Some("operator"));
+    assert_eq!(operator.text(source.as_bytes()), "-");
+    assert_eq!(right.field_name(), Some("right"));
+    assert_eq!(right.text(source.as_bytes()), "2");
+    assert!(expression.child_by_field_name("missing").is_none());
 }


### PR DESCRIPTION
## Summary
- expose `ts_compat::Node` field-edge accessors: `field_name`, `field_name_for_child`, and `child_by_field_name`
- add a generated-parser canary proving field names attached during reductions are visible through the ts-compat node API
- keep scope to field-aware child lookup; cursor traversal remains a separate follow-up

## Proof
- cargo test -p adze --features "pure-rust,ts-compat" --test ts_compat_tree_children -- --nocapture
- cargo clippy -p adze --features "pure-rust,ts-compat" --test ts_compat_tree_children -- -D warnings
- cargo test -p adze --features "pure-rust,glr,ts-compat" --test tablegen_abi_decode_roundtrip -- --nocapture
- cargo test -p adze --features "pure-rust,ts-compat" --lib -- --nocapture
- cargo fmt -p adze -- --check
- git diff --check

Local host note: `just ci-supported` cannot start on this Windows host because `cygpath` is unavailable; hosted `CI / ci-supported` is the merge gate.