### PR TITLE
ts-compat: add tree cursor traversal

### DIFF
--- a/runtime/src/ts_compat/mod.rs
+++ b/runtime/src/ts_compat/mod.rs
@@ -299,6 +299,11 @@ impl<'a> Node<'a> {
             .map(|child| Node::new(self.tree, child))
     }
 
+    /// Create a cursor rooted at this node.
+    pub fn walk(&self) -> TreeCursor<'a> {
+        TreeCursor::new(self.tree, self.node)
+    }
+
     /// Get the field name attached to this node's edge from its parent.
     pub fn field_name(&self) -> Option<&str> {
         self.node.field_name.as_deref()
@@ -346,6 +351,80 @@ impl<'a> Node<'a> {
     /// Get the text content of this node as a string.
     pub fn text(&self, source: &[u8]) -> String {
         self.utf8_text(source).unwrap_or("").to_string()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CursorFrame<'a> {
+    node: &'a ParseNode,
+    child_index: usize,
+}
+
+/// A cursor for walking a syntax tree without allocating child vectors.
+#[derive(Debug, Clone)]
+pub struct TreeCursor<'a> {
+    tree: &'a Tree,
+    current: &'a ParseNode,
+    parents: Vec<CursorFrame<'a>>,
+}
+
+impl<'a> TreeCursor<'a> {
+    fn new(tree: &'a Tree, current: &'a ParseNode) -> Self {
+        Self {
+            tree,
+            current,
+            parents: Vec::new(),
+        }
+    }
+
+    /// Get the cursor's current node.
+    pub fn node(&self) -> Node<'a> {
+        Node::new(self.tree, self.current)
+    }
+
+    /// Move to the first child of the current node.
+    pub fn goto_first_child(&mut self) -> bool {
+        let Some(child) = self.current.children.first() else {
+            return false;
+        };
+
+        self.parents.push(CursorFrame {
+            node: self.current,
+            child_index: 0,
+        });
+        self.current = child;
+        true
+    }
+
+    /// Move to the next sibling of the current node.
+    pub fn goto_next_sibling(&mut self) -> bool {
+        let Some(parent) = self.parents.last_mut() else {
+            return false;
+        };
+
+        let next_index = parent.child_index + 1;
+        let Some(next) = parent.node.children.get(next_index) else {
+            return false;
+        };
+
+        parent.child_index = next_index;
+        self.current = next;
+        true
+    }
+
+    /// Move to the parent of the current node.
+    pub fn goto_parent(&mut self) -> bool {
+        let Some(parent) = self.parents.pop() else {
+            return false;
+        };
+
+        self.current = parent.node;
+        true
+    }
+
+    /// Get the field name attached to the current node's parent edge.
+    pub fn field_name(&self) -> Option<&str> {
+        self.current.field_name.as_deref()
     }
 }
 

--- a/runtime/tests/ts_compat_tree_cursor.rs
+++ b/runtime/tests/ts_compat_tree_cursor.rs
@@ -1,0 +1,62 @@
+//! Tree-sitter compatibility cursor traversal canaries.
+
+#![cfg(all(test, feature = "ts-compat", feature = "pure-rust"))]
+
+use adze::{adze_ir::RuleId, ts_compat::Parser};
+use std::sync::Arc;
+
+#[test]
+fn tree_cursor_walks_generated_arithmetic_tree() {
+    let mut lang = (*adze_example::ts_langs::arithmetic()).clone();
+    lang.table.field_names = vec![
+        "left".to_string(),
+        "operator".to_string(),
+        "right".to_string(),
+    ];
+    lang.table.field_map.insert((RuleId(2), 0), 0);
+    lang.table.field_map.insert((RuleId(2), 1), 1);
+    lang.table.field_map.insert((RuleId(2), 2), 2);
+
+    let mut parser = Parser::new();
+    parser
+        .set_language(Arc::new(lang))
+        .expect("Failed to set language");
+
+    let source = "1-2";
+    let tree = parser.parse(source, None).expect("Parse failed");
+    let mut cursor = tree.root_node().walk();
+
+    assert_eq!(cursor.node().kind(), "source_file");
+    assert!(!cursor.goto_next_sibling());
+
+    assert!(cursor.goto_first_child());
+    assert_eq!(cursor.node().kind(), "expression");
+    assert_eq!(cursor.field_name(), None);
+
+    assert!(cursor.goto_first_child());
+    assert_eq!(cursor.field_name(), Some("left"));
+    assert_eq!(cursor.node().text(source.as_bytes()), "1");
+    assert!(cursor.goto_first_child());
+    assert_eq!(cursor.node().text(source.as_bytes()), "1");
+    assert!(!cursor.goto_first_child());
+    assert_eq!(cursor.node().text(source.as_bytes()), "1");
+    assert!(cursor.goto_parent());
+
+    assert!(cursor.goto_next_sibling());
+    assert_eq!(cursor.field_name(), Some("operator"));
+    assert_eq!(cursor.node().text(source.as_bytes()), "-");
+
+    assert!(cursor.goto_next_sibling());
+    assert_eq!(cursor.field_name(), Some("right"));
+    assert_eq!(cursor.node().text(source.as_bytes()), "2");
+    assert!(!cursor.goto_next_sibling());
+    assert_eq!(cursor.node().text(source.as_bytes()), "2");
+
+    assert!(cursor.goto_parent());
+    assert_eq!(cursor.node().kind(), "expression");
+    assert_eq!(cursor.node().text(source.as_bytes()), source);
+
+    assert!(cursor.goto_parent());
+    assert_eq!(cursor.node().kind(), "source_file");
+    assert!(!cursor.goto_parent());
+}


### PR DESCRIPTION
## Summary
- add `ts_compat::TreeCursor` plus `Node::walk()` over the parsed `ParseNode` tree
- implement current node access, first-child, next-sibling, parent traversal, and cursor field-name lookup
- add a generated arithmetic canary that walks nested children and fielded sibling edges

## Proof
- cargo test -p adze --features "pure-rust,ts-compat" --test ts_compat_tree_cursor -- --nocapture
- cargo test -p adze --features "pure-rust,ts-compat" --test ts_compat_tree_children -- --nocapture
- cargo clippy -p adze --features "pure-rust,ts-compat" --test ts_compat_tree_cursor -- -D warnings
- cargo clippy -p adze --features "pure-rust,ts-compat" --lib -- -D warnings
- cargo test -p adze --features "pure-rust,ts-compat" --lib -- --nocapture
- cargo test -p adze --features "pure-rust,glr,ts-compat" --test tablegen_abi_decode_roundtrip -- --nocapture
- cargo fmt -p adze -- --check
- git diff --cached --check

Local host note: `just ci-supported` cannot start on this Windows host because `cygpath` is unavailable; hosted `CI / ci-supported` is the merge gate.