### PR TITLE
ts-compat: expose named child access

### DIFF
--- a/runtime/src/ts_compat/mod.rs
+++ b/runtime/src/ts_compat/mod.rs
@@ -299,6 +299,43 @@ impl<'a> Node<'a> {
             .map(|child| Node::new(self.tree, child))
     }
 
+    /// Check if this node is a named grammar node.
+    pub fn is_named(&self) -> bool {
+        self.tree
+            .language
+            .table
+            .symbol_metadata
+            .get(self.node.symbol.0 as usize)
+            .map(|metadata| metadata.is_named)
+            .unwrap_or_else(|| {
+                !self
+                    .tree
+                    .language
+                    .grammar
+                    .tokens
+                    .contains_key(&self.node.symbol)
+            })
+    }
+
+    /// Get the number of named children.
+    pub fn named_child_count(&self) -> usize {
+        self.node
+            .children
+            .iter()
+            .filter(|child| Node::new(self.tree, child).is_named())
+            .count()
+    }
+
+    /// Get a named child by named-child index.
+    pub fn named_child(&self, index: usize) -> Option<Node<'a>> {
+        self.node
+            .children
+            .iter()
+            .filter(|child| Node::new(self.tree, child).is_named())
+            .nth(index)
+            .map(|child| Node::new(self.tree, child))
+    }
+
     /// Create a cursor rooted at this node.
     pub fn walk(&self) -> TreeCursor<'a> {
         TreeCursor::new(self.tree, self.node)

--- a/runtime/tests/ts_compat_tree_children.rs
+++ b/runtime/tests/ts_compat_tree_children.rs
@@ -91,3 +91,49 @@ fn generated_tree_exposes_fielded_children() {
     assert_eq!(right.text(source.as_bytes()), "2");
     assert!(expression.child_by_field_name("missing").is_none());
 }
+
+#[test]
+fn generated_tree_exposes_named_children() {
+    let mut parser = Parser::new();
+    let lang = adze_example::ts_langs::arithmetic();
+
+    parser.set_language(lang).expect("Failed to set language");
+
+    let source = "1-2";
+    let tree = parser.parse(source, None).expect("Parse failed");
+    let root = tree.root_node();
+    let expression = root.child(0).expect("root should expose expression child");
+
+    assert!(root.is_named());
+    assert_eq!(root.named_child_count(), 1);
+    assert_eq!(
+        root.named_child(0)
+            .expect("root should expose named expression child")
+            .kind(),
+        "expression"
+    );
+    assert!(root.named_child(1).is_none());
+
+    assert!(expression.is_named());
+    assert_eq!(expression.child_count(), 3);
+    assert_eq!(expression.named_child_count(), 2);
+
+    let left = expression
+        .named_child(0)
+        .expect("expression should expose left named child");
+    let right = expression
+        .named_child(1)
+        .expect("expression should expose right named child");
+
+    assert_eq!(left.kind(), "expression");
+    assert_eq!(left.text(source.as_bytes()), "1");
+    assert_eq!(right.kind(), "expression");
+    assert_eq!(right.text(source.as_bytes()), "2");
+    assert!(
+        !expression
+            .child(1)
+            .expect("operator child should exist")
+            .is_named()
+    );
+    assert!(expression.named_child(2).is_none());
+}


### PR DESCRIPTION
## Summary
- expose `ts_compat::Node::is_named`, `named_child_count`, and `named_child`
- resolve named-node status from parse-table symbol metadata, with a conservative fallback for hand-built tables
- add a generated arithmetic canary proving named-child traversal filters anonymous operator children while preserving raw child traversal

## Proof
- cargo test -p adze --features "pure-rust,ts-compat" --test ts_compat_tree_children -- --nocapture
- cargo clippy -p adze --features "pure-rust,ts-compat" --test ts_compat_tree_children -- -D warnings
- cargo test -p adze --features "pure-rust,ts-compat" --lib -- --nocapture
- cargo clippy -p adze --features "pure-rust,ts-compat" --lib -- -D warnings
- cargo test -p adze --features "pure-rust,glr,ts-compat" --test tablegen_abi_decode_roundtrip -- --nocapture
- cargo fmt -p adze -- --check
- git diff --check

Local host note: `just ci-supported` cannot start on this Windows host because `cygpath` is unavailable; hosted `CI / ci-supported` is the merge gate.