### PR TITLE
ci: use synchronize-only run cancellation in PR workflows

### DIFF
--- a/.github/workflows/ci-policy.yml
+++ b/.github/workflows/ci-policy.yml
@@ -12,7 +12,7 @@ permissions:
 
 concurrency:
   group: ci-policy-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
 
 jobs:
   ci-lane-whitelist:

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -12,7 +12,7 @@ permissions:
 
 concurrency:
   group: pr-gate-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
 
 jobs:
   plan:

--- a/.github/workflows/pr-plan.yml
+++ b/.github/workflows/pr-plan.yml
@@ -25,7 +25,7 @@ concurrency:
   # Include github.workflow so a parent (pr-gate / ripr) gets its own group
   # rather than cancelling the other parent's invocation.
   group: pr-plan-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
 
 jobs:
   plan:

--- a/.github/workflows/ripr.yml
+++ b/.github/workflows/ripr.yml
@@ -11,7 +11,7 @@ permissions:
 
 concurrency:
   group: ripr-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
 
 jobs:
   plan:


### PR DESCRIPTION
## Purpose

Prevent label-change events from cancelling in-flight CI runs.

Currently all four PR-triggered workflows use:
```yaml
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```
This cancels the run whenever *any* PR event fires — including `labeled` and `unlabeled`. As label-driven routing expands (routing lanes by `ci:perf`, `ci:golden`, `full-ci`, etc.), reviewers will add labels mid-run. Cancelling the existing run on a label event destroys valid verification that was already in progress.

The fix scopes cancellation to code-push events only:
```yaml
cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
```

## Files changed

- `.github/workflows/pr-gate.yml`
- `.github/workflows/pr-plan.yml`
- `.github/workflows/ripr.yml`
- `.github/workflows/ci-policy.yml`

## Default PR LEM impact

Zero — pure workflow metadata change; no jobs added or removed.

## Workflows touched

All four above — one-line change in each `concurrency:` block.

## Branch protection impact

None.

## Failure mode caught

Without this fix: adding a `ci:perf` label to a PR while `PR Gate Success` is running would cancel the gate and require a re-push to re-trigger. With this fix: the gate continues and the label is picked up on the next push.

## Cheaper signal considered

This is the minimum viable fix — a single expression change.

## Rollback path

Revert any of the four workflow files to restore the old `cancel-in-progress` expression.

## Commands run

```bash
cargo xtask check-ci-lane-whitelist --mode advisory
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKqUMJ9rkccPzyV2aW5oc9)_