### PR TITLE
ci: repair post-rollout workflow guardrails

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,12 +1,11 @@
 name: Performance Regression Tests
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
     types: [opened, synchronize, reopened, labeled]
     paths:
+      - '.github/workflows/performance.yml'
       - 'runtime/**'
       - 'runtime2/**'
       - 'glr-core/**'
@@ -24,10 +23,9 @@ concurrency:
 jobs:
   performance-check:
     name: Performance Regression Check
-    # Full baseline+comparison only with ci:perf/full-ci label or on push.
+    # Full baseline+comparison only with ci:perf/full-ci label.
     # Default PR touching performance paths gets quick-smoke-test only.
     if: |
-      github.event_name == 'push' ||
       contains(github.event.pull_request.labels.*.name, 'ci:perf') ||
       contains(github.event.pull_request.labels.*.name, 'full-ci')
     runs-on: ubuntu-latest

--- a/.github/workflows/ripr.yml
+++ b/.github/workflows/ripr.yml
@@ -46,23 +46,20 @@ jobs:
           fi
           echo "base=$BASE_SHA" >> "$GITHUB_OUTPUT"
           echo "head=$HEAD_SHA" >> "$GITHUB_OUTPUT"
-      - name: Install Rust 1.93 toolchain (isolated for ripr only)
-        # ripr requires Rust 1.93+; adze MSRV stays at 1.92.0.
-        # This installs 1.93 alongside the workspace toolchain without
-        # overriding the default for subsequent cargo commands.
-        run: |
-          rustup toolchain install 1.93 --no-self-update --profile minimal --quiet
       - name: Install ripr (advisory, graceful on failure)
         id: ripr-install
+        # ripr requires Rust 1.93+; adze MSRV stays at 1.92.0. Keep both the
+        # isolated toolchain install and ripr install on the graceful path.
         run: |
           set -euo pipefail
-          if cargo +1.93 install --locked ripr 2>/dev/null; then
+          if rustup toolchain install 1.93 --no-self-update --profile minimal --quiet \
+            && cargo +1.93 install --locked ripr 2>/dev/null; then
             echo "available=true" >> "$GITHUB_OUTPUT"
             ripr --version || true
           else
             # ripr may not yet be published to crates.io; keep graceful fallback.
             echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "ripr install via Rust 1.93 failed; using stub report."
+            echo "ripr or Rust 1.93 install unavailable; using stub report."
           fi
       - name: Run ripr (advisory)
         if: steps.ripr-install.outputs.available == 'true'

--- a/docs/ci/adze-rollout-status.md
+++ b/docs/ci/adze-rollout-status.md
@@ -2,10 +2,13 @@
 
 Last review: 2026-05-08.
 
+This file is a status snapshot, not a live source of truth. Before using it for
+execution, refresh with `gh pr list` and the current workflow state.
+
 ## Status legend
 
 - ✅ landed — present on `main` and working
-- 🟡 in progress — this PR stack
+- 🟡 in progress — open PR or active follow-up
 - ⏳ planned — not yet started
 - ⏸ deferred — waiting on actuals or coordination
 
@@ -18,16 +21,16 @@ Last review: 2026-05-08.
 | F03 | PR Plan workflow (`pr-plan.yml`) | ✅ | Calls `xtask ci-plan`, emits `ci-plan.json` with outputs `docs_only`, `estimated_lem`, `band` |
 | F04 | PR Gate Success workflow (`pr-gate.yml`) | ✅ | Supported Gate + Docs Gate + `PR Gate Success` aggregator |
 | F05 | ci-actuals telemetry scaffold | ✅ | `scripts/ci/emit-ci-actuals.py` emits plan vs actual; uploaded as artifact |
-| F06 | ripr advisory stub (`ripr.yml`) | ✅ | Graceful no-op stub; real binary provisioning in PR `ci/ripr-provision` |
+| F06 | ripr advisory (`ripr.yml`) | ✅ | Advisory install attempts run on an isolated Rust 1.93 toolchain and fall back to a stub report on install failure |
 
 ## Control plane
 
 | # | Item | Status | Notes |
 | --- | --- | --- | --- |
 | C01 | CI policy workflow (`ci-policy.yml`) | ✅ | Runs `check-ci-lane-whitelist --mode advisory` on every PR |
-| C02 | Synchronize-only cancellation | 🟡 | PR: `ci/sync-cancellation` — prevents label events from killing running jobs |
-| C03 | Lane whitelist cost alignment | 🟡 | PR: `ci/whitelist-align` — corrects stale LEM for already-gated lanes |
-| C04 | Real ripr provisioning | 🟡 | PR: `ci/ripr-provision` (#565) — isolated Rust 1.93 install |
+| C02 | Synchronize-only cancellation | ✅ | PR #563 merged — prevents label events from killing running jobs |
+| C03 | Lane whitelist cost alignment | ✅ | PR #564 merged — corrects stale LEM for already-gated lanes |
+| C04 | Real ripr provisioning | ✅ | PR #565 merged — isolated Rust 1.93 install with graceful stub fallback |
 | C05 | Benchmark deduplication | ✅ | PR #566 merged — `performance-check` gated to `ci:perf` label |
 
 ## Routing
@@ -82,7 +85,7 @@ With all routing already in place, the effective default PR cost estimate:
 | Supported Rust Gate | ~20 LEM |
 | PR Gate Success | ~1 LEM |
 | CI Lane Whitelist | ~2 LEM |
-| ripr advisory | ~4 LEM (stub today; install attempted after `ci/ripr-provision`) |
+| ripr advisory | ~4 LEM (isolated install attempted; stub report on toolchain/binary failure) |
 | Test Policy | ~12 LEM |
 | Pure Rust (ubuntu/stable only) | ~18 LEM |
 | Microcrate CI (routed by risk pack) | ~5–20 LEM depending on changed surface |

--- a/docs/ci/inventory.md
+++ b/docs/ci/inventory.md
@@ -22,13 +22,13 @@ See `adze-rollout-status.md` for status of each item.
 | `pr-plan.yml` | Reusable; computes LEM/band/docs_only from `xtask ci-plan` | Active |
 | `pr-gate.yml` | Aggregates Supported + Docs Gate → `PR Gate Success` | Active |
 | `ci-policy.yml` | CI lane whitelist advisory lint | Active |
-| `ripr.yml` | ripr advisory (stub → real in `ci/ripr-provision`) | Stub |
+| `ripr.yml` | ripr advisory with isolated Rust 1.93 install and stub fallback | Active advisory |
 | `fuzz.yml` | Label/push/schedule-gated runtime fuzz; build smoke on parser/glr PRs | Active |
 | `pure-rust-ci.yml` | Matrix-setup: ubuntu/stable on default PR; full matrix on labels/main | Active |
 | `golden-tests.yml` | Grammar-path and `ci:golden`/`full-ci` label gated | Active |
 | `microcrate-ci.yml` | Risk-pack-routed per crate group | Active |
 | `benchmarks.yml` | Label-gated (`ci:perf`/`benchmarks`/`full-ci`) full benchmark suite | Active |
-| `performance.yml` | Path-gated performance comparison; `performance-check` to be label-gated in `ci/benchmark-dedup` | Needs cleanup |
+| `performance.yml` | Path-gated benchmark compile smoke by default; full `performance-check` only on `ci:perf`/`full-ci` PR labels | Active advisory |
 
 ## xtask commands
 


### PR DESCRIPTION
## Summary
- remove the new push-to-main performance comparison path because it still used PR-only refs
- keep performance comparison PR-only and label-gated while letting workflow edits exercise the quick smoke path
- make ripr's Rust 1.93 install part of the same graceful availability path as `cargo install ripr`
- refresh the rollout docs so merged CI PRs are no longer listed as in-progress and the files are marked as snapshots

## Proof
- python YAML parse for `.github/workflows/performance.yml` and `.github/workflows/ripr.yml`
- cargo xtask check-ci-lane-whitelist --mode advisory
- git diff --check

## Notes
- `check-ci-lane-whitelist --mode advisory` still reports existing warnings for undeclared `droid-security-scan` and `golden-tests` `paths` jobs; this PR does not add those.