### PR TITLE
ts-compat: preserve parser error metadata

### DIFF
--- a/runtime/src/ts_compat/mod.rs
+++ b/runtime/src/ts_compat/mod.rs
@@ -237,13 +237,14 @@ impl Parser {
         let core_parser = self.core.as_mut()?;
         let lang = self.lang.as_ref()?;
 
-        // Use parse_tree() which returns an owned ParseNode
-        match core_parser.parse_tree(source) {
-            Ok(root) => Some(Tree {
+        // Use parse_tree_with_error_count() so the compatibility tree preserves
+        // parser_v4 recovery/error metadata for node error-state queries.
+        match core_parser.parse_tree_with_error_count(source) {
+            Ok((root, error_count)) => Some(Tree {
                 core: OwnedCoreTree {
                     root,
                     source: source.as_bytes().to_vec(),
-                    error_count: 0, // TODO: track error count properly
+                    error_count,
                 },
                 last_edit: None,
                 language: lang.clone(),
@@ -761,7 +762,7 @@ impl<'a> Node<'a> {
 
     /// Check if this node is an error node.
     pub fn is_error(&self) -> bool {
-        (self.node.symbol.0 == 0 && self.node.children.is_empty()) || self.tree.error_count() > 0
+        self.node.symbol.0 == 0 && self.node.children.is_empty()
     }
 
     /// Check if this node is missing (was expected but not found).
@@ -772,6 +773,7 @@ impl<'a> Node<'a> {
     /// Check if this node or any descendant is an error node.
     pub fn has_error(&self) -> bool {
         self.is_error()
+            || (std::ptr::eq(self.node, &self.tree.core.root) && self.tree.error_count() > 0)
             || self
                 .node
                 .children

--- a/runtime/tests/ts_compat_node_error.rs
+++ b/runtime/tests/ts_compat_node_error.rs
@@ -28,6 +28,34 @@ fn assert_node_error_free(node: Node<'_>) {
 }
 
 #[test]
+fn generated_tree_reports_error_metadata_when_parser_recovers() {
+    let mut parser = Parser::new();
+    parser
+        .set_language(adze_example::ts_langs::arithmetic())
+        .expect("Failed to set language");
+
+    let source = "1-@";
+    let tree = parser
+        .parse(source, None)
+        .expect("parser should return an inspectable error tree");
+    let root = tree.root_node();
+
+    assert!(
+        tree.error_count() > 0,
+        "parser recovery errors should be preserved on the compatibility tree"
+    );
+    assert!(tree.has_errors());
+    assert!(
+        !root.is_error(),
+        "partial roots with parser recoveries should report has_error, not is_error"
+    );
+    assert!(root.has_error());
+    assert!(!root.is_missing());
+    assert!(root.start_byte() <= root.end_byte());
+    assert!(root.end_byte() <= source.len());
+}
+
+#[test]
 fn generated_tree_reports_error_free_node_metadata_for_valid_input() {
     let mut parser = Parser::new();
     parser

--- a/runtime/tests/ts_compat_node_test.rs
+++ b/runtime/tests/ts_compat_node_test.rs
@@ -179,9 +179,17 @@ mod ts_compat_tests {
         let _: bool = is_error; // Ensure it's a boolean type
         let _: bool = is_missing; // Ensure it's a boolean type
 
-        // If there are errors in the tree, the node should reflect that
+        // Parser-level errors make the root report aggregate error state, but
+        // `is_error` remains local to synthetic ERROR nodes.
         if tree.error_count() > 0 {
-            assert!(root.is_error(), "Node should be error if tree has errors");
+            assert!(
+                root.has_error(),
+                "Root should report aggregate errors when the tree has errors"
+            );
+            assert!(
+                tree.has_errors(),
+                "Tree should report errors when error_count is nonzero"
+            );
         }
 
         // For root node, test that the methods work consistently


### PR DESCRIPTION
## Summary
- preserve `parser_v4` recovery/error counts in `ts_compat::Parser::parse`
- keep `Node::is_error()` node-local for synthetic error nodes while `has_error()` reports root-level parser recoveries
- add a generated arithmetic bad-input canary for inspectable error metadata

## Proof
- cargo test -p adze --features "pure-rust,ts-compat" --test ts_compat_node_error -- --nocapture
- cargo test -p adze --features "pure-rust,glr" --test generated_parse_errors -- --nocapture
- cargo test -p adze --features "pure-rust,ts-compat" --test ts_compat_to_sexp -- --nocapture
- cargo clippy -p adze --features "pure-rust,ts-compat" --lib --test ts_compat_node_error -- -D warnings
- cargo fmt -p adze -- --check
- git diff --check

## Local caveat
- `just ci-supported` is still blocked locally by missing `cygpath`; hosted `CI / ci-supported` is authoritative.