### PR TITLE
benchmarks: classify benchmark inventory and document status

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -4,6 +4,20 @@ version = "0.1.0"
 license = "MIT OR Apache-2.0"
 edition = "2024"
 
+# Benchmark classification metadata.
+# Each entry maps a bench name to its classification, status, and CI coverage.
+[package.metadata.bench-classification]
+
+parse_bench = { classification = "real_parser", status = "active", ci = "performance.yml Quick Performance Smoke Test (compile-only), pure-rust-ci.yml benchmark compile check (compile-only)" }
+glr_performance = { classification = "real_parser", status = "active", ci = "performance.yml Quick Performance Smoke Test (compile-only), pure-rust-ci.yml benchmark compile check (compile-only)", note = "substantially duplicates parse_bench.rs" }
+glr_hot = { classification = "real_parser", status = "active", ci = "performance.yml Quick Performance Smoke Test (compile-only), pure-rust-ci.yml benchmark compile check (compile-only)" }
+glr_performance_real = { classification = "real_parser", status = "active", ci = "performance.yml Quick Performance Smoke Test (compile-only), pure-rust-ci.yml benchmark compile check (compile-only)" }
+incremental_bench = { classification = "real_parser", status = "active", ci = "ci.yml Benchmark Compilation (compile-only), performance.yml Quick Performance Smoke Test (compile-only), pure-rust-ci.yml benchmark compile check (compile-only)" }
+optimization_bench = { classification = "infrastructure", status = "legacy", ci = "performance.yml Quick Performance Smoke Test (compile-only), pure-rust-ci.yml benchmark compile check (compile-only)", note = "superseded by arena_vs_box_allocation and stack_optimization" }
+stack_optimization = { classification = "infrastructure", status = "active", ci = "performance.yml Quick Performance Smoke Test (compile-only), pure-rust-ci.yml benchmark compile check (compile-only)" }
+arena_vs_box_allocation = { classification = "infrastructure", status = "active", ci = "performance.yml Quick Performance Smoke Test (compile-only), pure-rust-ci.yml benchmark compile check (compile-only)" }
+core_baselines = { classification = "build_pipeline", status = "active", ci = "performance.yml Quick Performance Smoke Test (compile-only), pure-rust-ci.yml benchmark compile check (compile-only)" }
+
 [[bench]]
 name = "parse_bench"
 harness = false

--- a/benchmarks/benches/arena_vs_box_allocation.rs
+++ b/benchmarks/benches/arena_vs_box_allocation.rs
@@ -1,3 +1,8 @@
+//! Classification: infrastructure
+//! Status: active
+//! CI coverage: performance.yml Quick Performance Smoke Test (compile-only),
+//!   pure-rust-ci.yml benchmark compile check (compile-only)
+//!
 //! Arena vs Box Allocation Benchmark
 //!
 //! This benchmark compares the performance of arena allocation vs individual Box allocations

--- a/benchmarks/benches/core_baselines.rs
+++ b/benchmarks/benches/core_baselines.rs
@@ -1,3 +1,8 @@
+//! Classification: build_pipeline
+//! Status: active
+//! CI coverage: performance.yml Quick Performance Smoke Test (compile-only),
+//!   pure-rust-ci.yml benchmark compile check (compile-only)
+//!
 //! Criterion baselines for core crates:
 //!   1. IR normalization (varying grammar sizes)
 //!   2. FIRST/FOLLOW set computation

--- a/benchmarks/benches/glr_hot.rs
+++ b/benchmarks/benches/glr_hot.rs
@@ -1,3 +1,10 @@
+//! Classification: real_parser
+//! Status: active
+//! CI coverage: performance.yml Quick Performance Smoke Test (compile-only),
+//!   pure-rust-ci.yml benchmark compile check (compile-only)
+//!
+//! Hot-path GLR parser benchmark for medium/large arithmetic fixtures.
+
 use adze_example::arithmetic::grammar::parse;
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use std::hint::black_box;

--- a/benchmarks/benches/glr_performance.rs
+++ b/benchmarks/benches/glr_performance.rs
@@ -1,3 +1,12 @@
+//! Classification: real_parser
+//! Status: active
+//! CI coverage: performance.yml Quick Performance Smoke Test (compile-only),
+//!   pure-rust-ci.yml benchmark compile check (compile-only)
+//!
+//! NOTE: This bench substantially duplicates `parse_bench.rs`. Both benchmark
+//! arithmetic expression parsing using the same fixtures (small/medium/large).
+//! Consider consolidating or differentiating the two in a future cleanup pass.
+
 use adze_example::arithmetic::grammar::parse;
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use std::hint::black_box;

--- a/benchmarks/benches/glr_performance_real.rs
+++ b/benchmarks/benches/glr_performance_real.rs
@@ -1,3 +1,8 @@
+//! Classification: real_parser
+//! Status: active
+//! CI coverage: performance.yml Quick Performance Smoke Test (compile-only),
+//!   pure-rust-ci.yml benchmark compile check (compile-only)
+//!
 //! Real parsing benchmarks for adze
 //!
 //! This benchmark measures actual parsing performance using valid arithmetic

--- a/benchmarks/benches/incremental_bench.rs
+++ b/benchmarks/benches/incremental_bench.rs
@@ -1,3 +1,13 @@
+//! Classification: real_parser
+//! Status: active
+//! CI coverage: ci.yml Benchmark Compilation (compile-only incremental_bench),
+//!   performance.yml Quick Performance Smoke Test (compile-only),
+//!   pure-rust-ci.yml benchmark compile check (compile-only)
+//!
+//! Incremental GLR parser benchmark. Measures full-reparse vs incremental
+//! reparse across different edit patterns and file sizes, plus fork
+//! preservation and subtree reuse efficiency.
+
 use adze::glr_incremental::{GLREdit, GLRToken, IncrementalGLRParser};
 use adze::glr_parser::GLRParser;
 use adze_benchmarks::test_grammars::{load_arithmetic_grammar, tokenize_arithmetic};

--- a/benchmarks/benches/optimization_bench.rs
+++ b/benchmarks/benches/optimization_bench.rs
@@ -1,3 +1,13 @@
+//! Classification: infrastructure
+//! Status: legacy
+//! CI coverage: performance.yml Quick Performance Smoke Test (compile-only),
+//!   pure-rust-ci.yml benchmark compile check (compile-only)
+//!
+//! Legacy auxiliary benchmark. Superseded by `arena_vs_box_allocation` and
+//! `stack_optimization` which provide more focused micro-benches. The
+//! Cargo.toml [[bench]] entry already carries a legacy note. Retain for
+//! historical comparison but prefer the newer benches for perf gating.
+
 use adze::arena_allocator::{TreeArena, TreeNode};
 use adze::stack_pool::StackPool;
 use criterion::{Criterion, criterion_group, criterion_main};

--- a/benchmarks/benches/parse_bench.rs
+++ b/benchmarks/benches/parse_bench.rs
@@ -1,3 +1,8 @@
+//! Classification: real_parser
+//! Status: active
+//! CI coverage: performance.yml Quick Performance Smoke Test (compile-only),
+//!   pure-rust-ci.yml benchmark compile check (compile-only)
+//!
 //! Baseline parser benchmark for valid arithmetic fixtures.
 //!
 //! This bench measures real parser work: each iteration parses a valid

--- a/benchmarks/benches/stack_optimization.rs
+++ b/benchmarks/benches/stack_optimization.rs
@@ -1,3 +1,12 @@
+//! Classification: infrastructure
+//! Status: active
+//! CI coverage: performance.yml Quick Performance Smoke Test (compile-only),
+//!   pure-rust-ci.yml benchmark compile check (compile-only)
+//!
+//! Stack implementation and memory pooling micro-benchmarks. Compares
+//! Vec-based stacks vs persistent stacks with structural sharing, plus
+//! fork/merge patterns at varying depths.
+
 use adze::pool::NodePool;
 use adze_glr_core::stack::StackNode;
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};


### PR DESCRIPTION
## Summary
- classify every `adze-benchmarks` benchmark as real-parser, infrastructure, or build-pipeline signal
- record active/legacy status and CI coverage in `benchmarks/Cargo.toml`
- add per-benchmark headers that distinguish compile-only coverage from performance/product proof

## Proof
- cargo test -p adze-benchmarks --test verify_fixture_parsing verify_parse_bench_uses_real_parser_workload -- --exact --nocapture
- cargo bench -p adze-benchmarks --no-run
- cargo fmt -p adze-benchmarks -- --check
- cargo metadata --no-deps --format-version 1
- git diff --check