### PR TITLE
ts-compat: extend error-state and field-id metadata canaries

### DIFF
--- a/runtime/tests/ts_compat_language_fields.rs
+++ b/runtime/tests/ts_compat_language_fields.rs
@@ -135,3 +135,117 @@ fn language_field_ids_are_metadata_ids_not_internal_field_map_indexes() {
         Some("operator")
     );
 }
+
+/// Field name → field ID → field name roundtrip must be lossless for every
+/// registered field.
+#[test]
+fn field_name_to_id_roundtrip_is_lossless() {
+    let lang = arithmetic_with_fields();
+
+    let expected_fields = &["left", "operator", "right"];
+
+    for &name in expected_fields {
+        let id = lang
+            .field_id_for_name(name)
+            .unwrap_or_else(|| panic!("field_id_for_name({name:?}) should return Some"));
+        let roundtrip_name = lang
+            .field_name_for_id(id.get())
+            .unwrap_or_else(|| panic!("field_name_for_id({}) should return Some", id.get()));
+        assert_eq!(
+            roundtrip_name,
+            name,
+            "field name roundtrip failed: {name:?} → id={} → {roundtrip_name:?}",
+            id.get()
+        );
+    }
+}
+
+/// Field ID → field name → field ID roundtrip must be lossless for every
+/// valid 1-based field ID.
+#[test]
+fn field_id_to_name_roundtrip_is_lossless() {
+    let lang = arithmetic_with_fields();
+    let count = lang.field_count();
+
+    for raw_id in 1..=count {
+        let name = lang
+            .field_name_for_id(raw_id as u16)
+            .unwrap_or_else(|| panic!("field_name_for_id({raw_id}) should return Some"));
+        let roundtrip_id = lang
+            .field_id_for_name(name)
+            .unwrap_or_else(|| panic!("field_id_for_name({name:?}) should return Some"));
+        assert_eq!(
+            roundtrip_id.get(),
+            raw_id as u16,
+            "field id roundtrip failed: id={raw_id} → name={name:?} → id={}",
+            roundtrip_id.get()
+        );
+    }
+}
+
+/// Unknown or out-of-range field IDs must return `None` (not panic).
+#[test]
+fn unknown_field_ids_return_none() {
+    let lang = arithmetic_with_fields();
+
+    // ID 0 is the Tree-sitter sentinel and must not resolve
+    assert_eq!(lang.field_name_for_id(0), None);
+
+    // IDs beyond the field count must not resolve
+    let count = lang.field_count() as u16;
+    assert_eq!(lang.field_name_for_id(count + 1), None);
+    assert_eq!(lang.field_name_for_id(u16::MAX), None);
+}
+
+/// Unknown field names must return `None` (not panic).
+#[test]
+fn unknown_field_names_return_none() {
+    let lang = arithmetic_with_fields();
+
+    assert!(lang.field_id_for_name("").is_none());
+    assert!(lang.field_id_for_name("nonexistent").is_none());
+    assert!(
+        lang.field_id_for_name("LEFT").is_none(),
+        "field lookup is case-sensitive"
+    );
+    assert!(
+        lang.field_id_for_name("left ").is_none(),
+        "field lookup must not trim whitespace"
+    );
+}
+
+/// Field lookups through the parsed tree (via node methods) use the same
+/// ID space as the Language-level methods, ensuring no mapping divergence.
+#[test]
+fn node_field_ids_match_language_field_ids() {
+    let lang = Arc::new(arithmetic_with_fields());
+    let mut parser = Parser::new();
+    parser
+        .set_language(Arc::clone(&lang))
+        .expect("Failed to set language");
+
+    let tree = parser.parse("1-2", None).expect("Parse failed");
+    let expression = tree
+        .root_node()
+        .child(0)
+        .expect("root should expose expression child");
+
+    // For each child with a field name, verify the field id from the node
+    // matches the field id from the language
+    for i in 0..expression.child_count() {
+        if let Some(field_name) = expression.field_name_for_child(i) {
+            let node_field_id = expression
+                .field_id_for_child(i)
+                .expect("child with field_name should have a field_id");
+            let lang_field_id = lang
+                .field_id_for_name(field_name)
+                .expect("field_name from node should resolve via language");
+
+            assert_eq!(
+                node_field_id, lang_field_id,
+                "node field_id ({node_field_id}) must match language field_id ({lang_field_id}) \
+                 for field {field_name:?} at child index {i}"
+            );
+        }
+    }
+}

--- a/runtime/tests/ts_compat_node_error.rs
+++ b/runtime/tests/ts_compat_node_error.rs
@@ -104,3 +104,183 @@ fn generated_tree_reports_error_free_node_metadata_for_valid_input() {
     assert_node_error_free(operator);
     assert_node_error_free(right);
 }
+
+/// Walk every node in a tree that reports parser errors with a cursor and
+/// confirm no method panics. This exercises the full walk + metadata surface
+/// over partial/error-recovered trees.
+#[test]
+fn walking_error_tree_does_not_panic() {
+    let mut parser = Parser::new();
+    parser
+        .set_language(adze_example::ts_langs::arithmetic())
+        .expect("Failed to set language");
+
+    let source = "1-@#";
+    let tree = parser
+        .parse(source, None)
+        .expect("parser should return an inspectable error tree");
+
+    let root = tree.root_node();
+    assert!(
+        tree.error_count() > 0,
+        "expected parse errors for invalid input"
+    );
+
+    // Walk with cursor — no method should panic on error nodes
+    let mut cursor = root.walk();
+    loop {
+        let node = cursor.node();
+        // Exercise every metadata getter; none may panic
+        let _kind = node.kind();
+        let _kind_id = node.kind_id();
+        let _start = node.start_byte();
+        let _end = node.end_byte();
+        let _is_error = node.is_error();
+        let _is_missing = node.is_missing();
+        let _has_error = node.has_error();
+        let _is_named = node.is_named();
+        let _is_extra = node.is_extra();
+        let _child_count = node.child_count();
+        let _descendant_count = node.descendant_count();
+        let _range = node.range();
+        let _byte_range = node.byte_range();
+
+        if !cursor.goto_first_child() {
+            while !cursor.goto_next_sibling() {
+                if !cursor.goto_parent() {
+                    return; // walked the whole tree
+                }
+            }
+        }
+    }
+}
+
+/// The root `has_error()` result must reflect parser recovery/error metadata.
+/// This intentionally stays separate from `is_error()`, which is node-local.
+#[test]
+fn root_has_error_reflects_parser_recovery_metadata() {
+    let mut parser = Parser::new();
+    parser
+        .set_language(adze_example::ts_langs::arithmetic())
+        .expect("Failed to set language");
+
+    let tree = parser
+        .parse("1-@", None)
+        .expect("parser should return an inspectable error tree");
+
+    assert!(
+        tree.error_count() > 0,
+        "expected parse errors for invalid input"
+    );
+    assert!(tree.has_errors());
+
+    let root = tree.root_node();
+    // Root itself is not an error node, but must report has_error because the
+    // parser recorded recovery/error metadata for this tree.
+    assert!(!root.is_error());
+    assert!(root.has_error(), "root must propagate descendant errors");
+}
+
+/// Verify that `is_error()` remains node-local and does not turn ordinary
+/// nodes into ERROR nodes just because the tree has parser errors.
+#[test]
+fn is_error_remains_node_local_for_valid_and_recovered_trees() {
+    let mut parser = Parser::new();
+    parser
+        .set_language(adze_example::ts_langs::arithmetic())
+        .expect("Failed to set language");
+
+    // Valid input — no node should be an error
+    let valid_tree = parser.parse("1-2", None).expect("Parse failed");
+    let root = valid_tree.root_node();
+    assert!(!root.is_error());
+    assert!(!root.has_error());
+
+    for i in 0..root.child_count() {
+        let child = root.child(i).expect("child index should be valid");
+        assert!(
+            !child.is_error(),
+            "valid tree child {i} should not be an error node"
+        );
+    }
+
+    // Invalid input — at least some error state should be present
+    let error_tree = parser
+        .parse("@@@@", None)
+        .expect("parser should still return a tree for recovery");
+
+    let error_root = error_tree.root_node();
+    // The root itself may or may not be an error node depending on recovery,
+    // but has_error must be consistent with error_count.
+    if error_tree.error_count() > 0 {
+        assert!(
+            error_root.has_error(),
+            "root has_error must be true when error_count > 0"
+        );
+    }
+}
+
+/// Error nodes should have a deterministic kind name.  Symbol-id-0 nodes
+/// resolve to whatever name the grammar has for symbol 0 (typically "end"
+/// or "EOF"), while non-error children in a partial tree retain their
+/// grammar kind.
+#[test]
+fn error_node_kind_name_is_deterministic() {
+    let mut parser = Parser::new();
+    parser
+        .set_language(adze_example::ts_langs::arithmetic())
+        .expect("Failed to set language");
+
+    let tree = parser
+        .parse("1-@", None)
+        .expect("parser should return an inspectable error tree");
+    let root = tree.root_node();
+
+    // Walk all nodes; every kind() call must return a valid string (never panic)
+    let mut cursor = root.walk();
+    loop {
+        let node = cursor.node();
+        let kind = node.kind();
+        // kind() must never panic and must return a non-empty string for every node
+        // that is not a synthetic error node
+        if !node.is_error() {
+            assert!(!kind.is_empty(), "non-error node kind should be non-empty");
+        }
+
+        if !cursor.goto_first_child() {
+            while !cursor.goto_next_sibling() {
+                if !cursor.goto_parent() {
+                    return; // walked the whole tree
+                }
+            }
+        }
+    }
+}
+
+/// Verify that Tree-level and Node-level error metadata are consistent:
+/// `tree.has_errors()` must agree with `tree.error_count() > 0`,
+/// and `root.has_error()` must agree with `tree.has_errors()`.
+#[test]
+fn tree_and_node_error_metadata_are_consistent() {
+    let mut parser = Parser::new();
+    parser
+        .set_language(adze_example::ts_langs::arithmetic())
+        .expect("Failed to set language");
+
+    // Valid input: no errors at any level
+    let valid_tree = parser.parse("1-2", None).expect("Parse failed");
+    assert_eq!(valid_tree.error_count(), 0);
+    assert!(!valid_tree.has_errors());
+    assert!(!valid_tree.root_node().has_error());
+
+    // Invalid input: errors at tree and root level
+    let error_tree = parser
+        .parse("1-@", None)
+        .expect("parser should return an inspectable error tree");
+    assert!(error_tree.error_count() > 0);
+    assert!(error_tree.has_errors());
+    assert!(error_tree.root_node().has_error());
+
+    // Cross-check: tree.has_errors() ⟺ error_count > 0
+    assert_eq!(error_tree.has_errors(), error_tree.error_count() > 0);
+}


### PR DESCRIPTION
## Purpose

Extend ts-compat canary test coverage for Node error-state detection (`has_error`, `is_error`, `is_missing`) and Language field-id roundtrip metadata.

## Files changed

- `runtime/tests/ts_compat_node_error.rs` - Added 5 new test functions:
  - `walking_error_tree_does_not_panic` - cursor walk over a tree that reports parser errors, exercising all metadata getters
  - `root_has_error_reflects_parser_recovery_metadata` - root-level `has_error()` reflects parser recovery/error metadata while `is_error()` remains node-local
  - `is_error_remains_node_local_for_valid_and_recovered_trees` - verifies ordinary nodes do not become ERROR nodes just because the tree has parser errors
  - `error_node_kind_name_is_deterministic` - kind() must return deterministic names for all nodes
  - `tree_and_node_error_metadata_are_consistent` - tree.has_errors() is consistent with error_count > 0 and root.has_error()

- `runtime/tests/ts_compat_language_fields.rs` - Added 5 new test functions:
  - `field_name_to_id_roundtrip_is_lossless` - name to id to name roundtrip
  - `field_id_to_name_roundtrip_is_lossless` - id to name to id roundtrip
  - `unknown_field_ids_return_none` - out-of-range and zero field IDs return None
  - `unknown_field_names_return_none` - missing/empty/case-mismatched names return None
  - `node_field_ids_match_language_field_ids` - node-level field IDs match language-level IDs

## Branch protection impact

No changes to library code. Only test additions. The PR gate (`just ci-supported`) is unaffected since these tests run under `--features "pure-rust,ts-compat"` which is not part of the default PR gate lane.

## Proof commands

```bash
# Run the affected test targets (15 tests total after #576: 8 + 7)
cargo test -p adze --features "pure-rust,ts-compat" --test ts_compat_node_error --test ts_compat_language_fields -- --nocapture

# Clippy on affected test targets
cargo clippy -p adze --features "pure-rust,ts-compat" --test ts_compat_node_error --test ts_compat_language_fields -- -D warnings

# Formatting and whitespace
cargo fmt -p adze -- --check
git diff --check
```

## Rollback path

`git revert` the single commit on this branch. No library changes to unwind.