### PR TITLE
diagnostics: add structured expected-token sets to parse errors

### DIFF
--- a/runtime/src/__private.rs
+++ b/runtime/src/__private.rs
@@ -240,6 +240,7 @@ pub fn parse<T: Extract<T>>(
             ),
             start: 0,
             end: 0,
+            expected: vec![],
         }]
     })?;
 
@@ -250,6 +251,7 @@ pub fn parse<T: Extract<T>>(
             ),
             start: 0,
             end: 0,
+            expected: vec![],
         }]
     })?;
 
@@ -296,6 +298,7 @@ pub fn parse<T: Extract<T>>(
                 ),
                 start: 0,
                 end: 0,
+                expected: vec![],
             }];
             Err(errors)
         }
@@ -315,6 +318,7 @@ fn parse_with_pure_parser<T: Extract<T>>(
             reason: crate::errors::ParseErrorReason::UnexpectedToken(e),
             start: 0,
             end: 0,
+            expected: vec![],
         }]
     })?;
 
@@ -343,10 +347,11 @@ fn parse_with_pure_parser<T: Extract<T>>(
                 let expected = expected_symbol_names_for_diagnostic(lang, &e.expected);
                 crate::errors::ParseError {
                     reason: crate::errors::ParseErrorReason::UnexpectedToken(
-                        unexpected_token_message(symbol_name, expected),
+                        unexpected_token_message(symbol_name, expected.clone()),
                     ),
                     start: e.position,
                     end: diagnostic_end_for_byte(input.as_bytes(), e.position),
+                    expected,
                 }
             })
             .collect();
@@ -362,6 +367,7 @@ fn parse_with_pure_parser<T: Extract<T>>(
                 ),
                 start: 0,
                 end: 0,
+                expected: vec![],
             }]);
         }
     };
@@ -417,6 +423,7 @@ fn parse_with_glr<T: Extract<T>>(
             reason: crate::errors::ParseErrorReason::UnexpectedToken(e.to_string()),
             start: 0,
             end: 0,
+            expected: vec![],
         }]
     })?;
 
@@ -473,6 +480,7 @@ fn parse_with_true_glr_runtime<T: Extract<T>>(
                     reason: crate::errors::ParseErrorReason::UnexpectedToken(message),
                     start: 0,
                     end: source.len(),
+                    expected: vec![],
                 }]);
             }
         };
@@ -487,6 +495,7 @@ fn parse_with_true_glr_runtime<T: Extract<T>>(
                 ),
                 start,
                 end,
+                expected: vec![],
             }]);
         }
     }
@@ -499,6 +508,7 @@ fn parse_with_true_glr_runtime<T: Extract<T>>(
                 reason: crate::errors::ParseErrorReason::UnexpectedToken(message),
                 start: 0,
                 end: source.len(),
+                expected: vec![],
             }]);
         }
     };
@@ -647,6 +657,7 @@ fn lex_with_language_fn(
                 ),
                 start,
                 end: invalid_end,
+                expected: vec![],
             }]);
         }
 
@@ -927,6 +938,7 @@ fn parse_with_glr<T: Extract<T>>(
         ),
         start: 0,
         end: 0,
+        expected: vec![],
     }])
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1179,6 +1179,13 @@ pub mod errors {
         pub start: usize,
         /// Exclusive end of the error.
         pub end: usize,
+        /// Structured list of expected token names at the error position.
+        ///
+        /// This is populated by the pure-rust parsing path and contains
+        /// human-readable token names (not opaque symbol IDs). The list
+        /// is sorted and deduplicated. It may be empty when expected-token
+        /// information is not available (e.g. tree-sitter backend errors).
+        pub expected: Vec<String>,
     }
 
     /// One-indexed source position for a parse diagnostic.
@@ -1281,7 +1288,21 @@ pub mod errors {
 
     impl std::fmt::Display for ParseError {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "{} at bytes {}..{}", self.reason, self.start, self.end)
+            let reason = self.reason.to_string();
+            if matches!(self.reason, ParseErrorReason::UnexpectedToken(_))
+                && !self.expected.is_empty()
+                && !reason.contains("expected one of:")
+            {
+                write!(
+                    f,
+                    "{reason}, expected one of: {} at bytes {}..{}",
+                    self.expected.join(", "),
+                    self.start,
+                    self.end
+                )
+            } else {
+                write!(f, "{reason} at bytes {}..{}", self.start, self.end)
+            }
         }
     }
 
@@ -1357,6 +1378,7 @@ pub mod errors {
                     reason: ParseErrorReason::FailedNode(inner_errors),
                     start: node.start_byte(),
                     end: node.end_byte(),
+                    expected: vec![],
                 })
             } else {
                 match node.utf8_text(source) {
@@ -1364,11 +1386,13 @@ pub mod errors {
                         reason: ParseErrorReason::UnexpectedToken(contents.to_string()),
                         start: node.start_byte(),
                         end: node.end_byte(),
+                        expected: vec![],
                     }),
                     Ok(_) | Err(_) => errors.push(ParseError {
                         reason: ParseErrorReason::FailedNode(vec![]),
                         start: node.start_byte(),
                         end: node.end_byte(),
+                        expected: vec![],
                     }),
                 }
             }
@@ -1377,6 +1401,7 @@ pub mod errors {
                 reason: ParseErrorReason::MissingToken(node.kind().to_string()),
                 start: node.start_byte(),
                 end: node.end_byte(),
+                expected: vec![node.kind().to_string()],
             })
         } else if node.has_error() {
             let mut cursor = node.walk();
@@ -1405,6 +1430,7 @@ pub mod errors {
                     reason: ParseErrorReason::FailedNode(inner_errors),
                     start: node.start_byte(),
                     end: node.end_byte(),
+                    expected: vec![],
                 });
             } else {
                 match node.utf8_text(source) {
@@ -1412,11 +1438,13 @@ pub mod errors {
                         reason: ParseErrorReason::UnexpectedToken(contents.to_string()),
                         start: node.start_byte(),
                         end: node.end_byte(),
+                        expected: vec![],
                     }),
                     Ok(_) | Err(_) => errors.push(ParseError {
                         reason: ParseErrorReason::FailedNode(vec![]),
                         start: node.start_byte(),
                         end: node.end_byte(),
+                        expected: vec![],
                     }),
                 }
             }
@@ -1425,6 +1453,7 @@ pub mod errors {
                 reason: ParseErrorReason::MissingToken(node.kind().to_string()),
                 start: node.start_byte(),
                 end: node.end_byte(),
+                expected: vec![node.kind().to_string()],
             });
         } else if node.has_error() {
             for child in node.children() {

--- a/runtime/tests/error_display_proptest.rs
+++ b/runtime/tests/error_display_proptest.rs
@@ -257,6 +257,7 @@ proptest! {
                 reason: ParseErrorReason::UnexpectedToken(format!("tok{i}")),
                 start: i,
                 end: i + 1,
+                expected: vec![],
             })
             .collect();
         let reason = ParseErrorReason::FailedNode(inner);
@@ -281,6 +282,7 @@ proptest! {
             reason: ParseErrorReason::UnexpectedToken(token),
             start,
             end,
+            expected: vec![],
         };
         let dbg = format!("{err:?}");
         prop_assert!(dbg.contains(&start.to_string()));
@@ -304,6 +306,7 @@ proptest! {
             reason: ParseErrorReason::UnexpectedToken(token),
             start,
             end,
+            expected: vec![],
         };
         let _ = format!("{err:?}");
     }
@@ -558,6 +561,7 @@ proptest! {
                 reason: ParseErrorReason::UnexpectedToken(format!("tok_{i}")),
                 start: base_start + i * 10,
                 end: base_start + i * 10 + 5,
+                expected: vec![],
             })
             .collect();
 
@@ -586,11 +590,13 @@ proptest! {
             reason: ParseErrorReason::UnexpectedToken(inner_token.clone()),
             start: 0,
             end: 1,
+            expected: vec![],
         };
         let outer = ParseError {
             reason: ParseErrorReason::FailedNode(vec![inner]),
             start: outer_start,
             end: outer_end,
+            expected: vec![],
         };
         let dbg = format!("{outer:?}");
         prop_assert!(dbg.contains(&inner_token),
@@ -714,6 +720,7 @@ proptest! {
             reason: ParseErrorReason::MissingToken(token.clone()),
             start,
             end,
+            expected: vec![],
         };
         let dbg = format!("{err:?}");
         prop_assert!(dbg.contains(&token));

--- a/runtime/tests/error_display_tests.rs
+++ b/runtime/tests/error_display_tests.rs
@@ -22,6 +22,7 @@ fn parse_error_includes_byte_positions() {
         reason: ParseErrorReason::UnexpectedToken("@".to_string()),
         start: 10,
         end: 11,
+        expected: vec![],
     };
     let dbg = format!("{:?}", err);
     assert!(dbg.contains("10"), "Debug should include start byte: {dbg}");
@@ -34,6 +35,7 @@ fn parse_error_display_includes_reason_and_byte_span() {
         reason: ParseErrorReason::UnexpectedToken("@".to_string()),
         start: 10,
         end: 11,
+        expected: vec![],
     };
     let display = format!("{err}");
     assert!(
@@ -53,6 +55,7 @@ fn parse_error_source_span_is_one_indexed() {
         reason: ParseErrorReason::UnexpectedToken("@".to_string()),
         start: 8,
         end: 9,
+        expected: vec![],
     };
 
     let span = err.source_span(source.as_bytes());
@@ -70,6 +73,7 @@ fn parse_error_display_with_source_includes_line_column_and_excerpt() {
         reason: ParseErrorReason::UnexpectedToken("@".to_string()),
         start: 8,
         end: 9,
+        expected: vec![],
     };
 
     let display = format!("{}", err.display_with_source(source));
@@ -99,6 +103,7 @@ fn parse_error_display_with_source_marks_zero_width_spans() {
         reason: ParseErrorReason::MissingToken(";".to_string()),
         start: 3,
         end: 3,
+        expected: vec![],
     };
 
     let display = format!("{}", err.display_with_source(source));
@@ -155,6 +160,7 @@ fn unexpected_token_error_includes_token_text() {
         reason: ParseErrorReason::UnexpectedToken("foobar".to_string()),
         start: 0,
         end: 6,
+        expected: vec![],
     };
     let dbg = format!("{:?}", err);
     assert!(
@@ -253,6 +259,7 @@ fn missing_token_error_names_the_token() {
         reason: ParseErrorReason::MissingToken("semicolon".to_string()),
         start: 5,
         end: 5,
+        expected: vec![],
     };
     let dbg = format!("{:?}", err);
     assert!(
@@ -443,6 +450,7 @@ fn parse_error_debug_includes_reason_and_range() {
         reason: ParseErrorReason::UnexpectedToken("xyz".to_string()),
         start: 42,
         end: 45,
+        expected: vec![],
     };
     let dbg = format!("{:?}", err);
     assert!(
@@ -480,11 +488,13 @@ fn failed_node_debug_includes_inner_errors() {
         reason: ParseErrorReason::UnexpectedToken("bad".to_string()),
         start: 2,
         end: 5,
+        expected: vec![],
     };
     let outer = ParseError {
         reason: ParseErrorReason::FailedNode(vec![inner]),
         start: 0,
         end: 10,
+        expected: vec![],
     };
     let dbg = format!("{:?}", outer);
     assert!(
@@ -632,6 +642,7 @@ fn parse_error_byte_positions_for_unicode() {
         reason: ParseErrorReason::UnexpectedToken("ñ".to_string()),
         start: 5,
         end: 7, // 2-byte character
+        expected: vec![],
     };
     let dbg = format!("{:?}", err);
     assert!(dbg.contains("5"), "Start byte position present: {dbg}");
@@ -699,16 +710,19 @@ fn multiple_parse_errors_are_distinct() {
             reason: ParseErrorReason::UnexpectedToken("@".to_string()),
             start: 0,
             end: 1,
+            expected: vec![],
         },
         ParseError {
             reason: ParseErrorReason::MissingToken(";".to_string()),
             start: 5,
             end: 5,
+            expected: vec![],
         },
         ParseError {
             reason: ParseErrorReason::UnexpectedToken("#".to_string()),
             start: 10,
             end: 11,
+            expected: vec![],
         },
     ];
 
@@ -961,11 +975,13 @@ fn failed_node_wraps_inner_errors() {
         reason: ParseErrorReason::UnexpectedToken("x".to_string()),
         start: 0,
         end: 1,
+        expected: vec![],
     };
     let outer = ParseError {
         reason: ParseErrorReason::FailedNode(vec![inner]),
         start: 0,
         end: 10,
+        expected: vec![],
     };
     // FailedNode contains child errors accessible via the reason
     match &outer.reason {
@@ -1418,4 +1434,96 @@ fn make_dummy_parser() -> adze::glr_parser::GLRParser {
     let table = build_lr1_automaton(&g, &ff).unwrap();
 
     adze::glr_parser::GLRParser::new(table, g)
+}
+
+// ============================================================================
+// 18. Structured expected-tokens field on errors::ParseError
+// ============================================================================
+
+#[test]
+fn parse_error_expected_field_default_is_empty_vec() {
+    let err = ParseError {
+        reason: ParseErrorReason::UnexpectedToken("x".to_string()),
+        start: 0,
+        end: 1,
+        expected: vec![],
+    };
+    assert!(
+        err.expected.is_empty(),
+        "expected field should default to empty vec"
+    );
+}
+
+#[test]
+fn parse_error_expected_field_holds_token_names() {
+    let err = ParseError {
+        reason: ParseErrorReason::UnexpectedToken("x".to_string()),
+        start: 0,
+        end: 1,
+        expected: vec!["number".to_string(), "string".to_string()],
+    };
+    assert_eq!(err.expected, vec!["number", "string"]);
+}
+
+#[test]
+fn parse_error_expected_field_backward_compatible_display() {
+    // When expected is empty, Display should not mention "expected one of:"
+    let err = ParseError {
+        reason: ParseErrorReason::UnexpectedToken("@".to_string()),
+        start: 10,
+        end: 11,
+        expected: vec![],
+    };
+    let display = format!("{err}");
+    assert!(
+        !display.contains("expected one of:"),
+        "empty expected should not produce 'expected one of:' in Display: {display}"
+    );
+
+    // When expected is populated but the reason string already contains
+    // expected info, Display should remain backward compatible
+    let err = ParseError {
+        reason: ParseErrorReason::UnexpectedToken(
+            "unexpected; expected one of: number, string".to_string(),
+        ),
+        start: 0,
+        end: 1,
+        expected: vec!["number".to_string(), "string".to_string()],
+    };
+    let display = format!("{err}");
+    assert!(
+        display.contains("expected one of: number, string"),
+        "Display should include expected tokens from reason: {display}"
+    );
+}
+
+#[test]
+fn parse_error_display_uses_structured_expected_when_reason_has_no_expected() {
+    let err = ParseError {
+        reason: ParseErrorReason::UnexpectedToken("@".to_string()),
+        start: 0,
+        end: 1,
+        expected: vec!["number".to_string(), "string".to_string()],
+    };
+    let display = format!("{err}");
+    assert!(
+        display.contains("expected one of: number, string"),
+        "Display should render structured expected tokens when reason has none: {display}"
+    );
+}
+
+#[test]
+fn missing_token_expected_field_contains_token_name() {
+    let err = ParseError {
+        reason: ParseErrorReason::MissingToken(";".to_string()),
+        start: 5,
+        end: 5,
+        expected: vec![";".to_string()],
+    };
+    assert_eq!(err.expected, vec![";"]);
+    let display = format!("{err}");
+    assert!(
+        display.contains("missing token \";\""),
+        "Display should include missing token: {display}"
+    );
 }

--- a/runtime/tests/extract_derive_comprehensive.rs
+++ b/runtime/tests/extract_derive_comprehensive.rs
@@ -303,6 +303,7 @@ fn parse_error_unexpected_token_fields() {
         reason: ParseErrorReason::UnexpectedToken("@".to_string()),
         start: 5,
         end: 6,
+        expected: vec![],
     };
     assert_eq!(err.start, 5);
     assert_eq!(err.end, 6);
@@ -318,6 +319,7 @@ fn parse_error_missing_token_fields() {
         reason: ParseErrorReason::MissingToken("identifier".to_string()),
         start: 0,
         end: 0,
+        expected: vec![],
     };
     match &err.reason {
         ParseErrorReason::MissingToken(tok) => assert_eq!(tok, "identifier"),
@@ -331,6 +333,7 @@ fn parse_error_failed_node_empty() {
         reason: ParseErrorReason::FailedNode(vec![]),
         start: 0,
         end: 10,
+        expected: vec![],
     };
     match &err.reason {
         ParseErrorReason::FailedNode(inner) => assert!(inner.is_empty()),
@@ -344,6 +347,7 @@ fn parse_error_debug_format() {
         reason: ParseErrorReason::UnexpectedToken("!!".to_string()),
         start: 3,
         end: 5,
+        expected: vec![],
     };
     let dbg = format!("{:?}", err);
     assert!(dbg.contains("UnexpectedToken"));

--- a/runtime/tests/extract_trait_comprehensive.rs
+++ b/runtime/tests/extract_trait_comprehensive.rs
@@ -570,6 +570,7 @@ fn parse_error_unexpected_token_debug() {
         reason: ParseErrorReason::UnexpectedToken("foo".into()),
         start: 0,
         end: 3,
+        expected: vec![],
     };
     let debug = format!("{:?}", err);
     assert!(debug.contains("UnexpectedToken"));
@@ -583,6 +584,7 @@ fn parse_error_missing_token_debug() {
         reason: ParseErrorReason::MissingToken(";".into()),
         start: 5,
         end: 5,
+        expected: vec![],
     };
     let debug = format!("{:?}", err);
     assert!(debug.contains("MissingToken"));
@@ -595,11 +597,13 @@ fn parse_error_failed_node_nested() {
         reason: ParseErrorReason::UnexpectedToken("x".into()),
         start: 0,
         end: 1,
+        expected: vec![],
     };
     let outer = ParseError {
         reason: ParseErrorReason::FailedNode(vec![inner]),
         start: 0,
         end: 5,
+        expected: vec![],
     };
     match &outer.reason {
         ParseErrorReason::FailedNode(v) => assert_eq!(v.len(), 1),

--- a/runtime/tests/extract_trait_edge_cases_comprehensive.rs
+++ b/runtime/tests/extract_trait_edge_cases_comprehensive.rs
@@ -374,6 +374,7 @@ fn parse_error_unexpected_token_debug() {
         reason: ParseErrorReason::UnexpectedToken("@".to_string()),
         start: 0,
         end: 1,
+        expected: vec![],
     };
     let debug = format!("{:?}", err);
     assert!(debug.contains("UnexpectedToken"));
@@ -386,6 +387,7 @@ fn parse_error_missing_token_debug() {
         reason: ParseErrorReason::MissingToken("identifier".to_string()),
         start: 5,
         end: 5,
+        expected: vec![],
     };
     let debug = format!("{:?}", err);
     assert!(debug.contains("MissingToken"));
@@ -398,11 +400,13 @@ fn parse_error_failed_node_with_children() {
         reason: ParseErrorReason::UnexpectedToken("!".to_string()),
         start: 0,
         end: 1,
+        expected: vec![],
     };
     let outer = ParseError {
         reason: ParseErrorReason::FailedNode(vec![inner]),
         start: 0,
         end: 5,
+        expected: vec![],
     };
     let debug = format!("{:?}", outer);
     assert!(debug.contains("FailedNode"));
@@ -415,6 +419,7 @@ fn parse_error_failed_node_empty_children() {
         reason: ParseErrorReason::FailedNode(vec![]),
         start: 0,
         end: 0,
+        expected: vec![],
     };
     let debug = format!("{:?}", err);
     assert!(debug.contains("FailedNode"));

--- a/runtime/tests/extract_trait_v2.rs
+++ b/runtime/tests/extract_trait_v2.rs
@@ -412,6 +412,7 @@ fn test_parse_error_reason_unexpected_token() {
         reason: ParseErrorReason::UnexpectedToken("$".to_string()),
         start: 0,
         end: 1,
+        expected: vec![],
     };
     assert_eq!(err.start, 0);
     assert_eq!(err.end, 1);
@@ -427,6 +428,7 @@ fn test_parse_error_reason_missing_token() {
         reason: ParseErrorReason::MissingToken("semicolon".to_string()),
         start: 5,
         end: 5,
+        expected: vec![],
     };
     match &err.reason {
         ParseErrorReason::MissingToken(tok) => assert_eq!(tok, "semicolon"),
@@ -440,6 +442,7 @@ fn test_parse_error_reason_failed_node_empty() {
         reason: ParseErrorReason::FailedNode(vec![]),
         start: 0,
         end: 10,
+        expected: vec![],
     };
     match &err.reason {
         ParseErrorReason::FailedNode(inner) => assert!(inner.is_empty()),
@@ -453,11 +456,13 @@ fn test_parse_error_reason_failed_node_nested() {
         reason: ParseErrorReason::UnexpectedToken("x".to_string()),
         start: 3,
         end: 4,
+        expected: vec![],
     };
     let outer = ParseError {
         reason: ParseErrorReason::FailedNode(vec![inner]),
         start: 0,
         end: 10,
+        expected: vec![],
     };
     match &outer.reason {
         ParseErrorReason::FailedNode(v) => assert_eq!(v.len(), 1),

--- a/runtime/tests/extract_trait_v9.rs
+++ b/runtime/tests/extract_trait_v9.rs
@@ -427,6 +427,7 @@ fn test_parse_error_debug() {
         reason: ParseErrorReason::UnexpectedToken("!".to_string()),
         start: 0,
         end: 1,
+        expected: vec![],
     };
     let dbg = format!("{err:?}");
     assert!(dbg.contains("ParseError"));
@@ -439,6 +440,7 @@ fn test_parse_error_fields_accessible() {
         reason: ParseErrorReason::MissingToken(";".to_string()),
         start: 10,
         end: 10,
+        expected: vec![],
     };
     assert_eq!(err.start, 10);
     assert_eq!(err.end, 10);

--- a/runtime/tests/generated_parse_errors.rs
+++ b/runtime/tests/generated_parse_errors.rs
@@ -178,3 +178,112 @@ fn generated_typed_parser_multiline_bad_token_reports_line_column_and_excerpt() 
         "rendered diagnostic should include the second source line and caret: {rendered}"
     );
 }
+
+// ============================================================================
+// Structured expected-token field tests
+// ============================================================================
+
+#[test]
+fn generated_typed_parser_unexpected_eof_expected_field_is_populated() {
+    let source = "1 +";
+    let errors = adze_example::typed_ast_contract::grammar::parse(source)
+        .expect_err("truncated expression must fail through the generated typed parser");
+
+    let first = errors
+        .first()
+        .expect("generated parser should return at least one parse error");
+
+    // The structured `expected` field should contain meaningful token names
+    assert!(
+        !first.expected.is_empty(),
+        "expected field should be populated for unexpected EOF, got: {:?}",
+        first.expected
+    );
+
+    // Token names should be human-readable, not raw IDs
+    for name in &first.expected {
+        assert!(
+            !name.contains("SymbolId"),
+            "expected token names should not contain raw SymbolId, got: {name}"
+        );
+        assert!(
+            !name.contains("symbol "),
+            "expected token names should not contain 'symbol ' prefix, got: {name}"
+        );
+    }
+}
+
+#[test]
+fn generated_typed_parser_unexpected_eof_expected_field_sorted_and_deduped() {
+    let source = "1 +";
+    let errors = adze_example::typed_ast_contract::grammar::parse(source)
+        .expect_err("truncated expression must fail through the generated typed parser");
+
+    let first = errors
+        .first()
+        .expect("generated parser should return at least one parse error");
+
+    // The expected list should be sorted
+    let mut sorted = first.expected.clone();
+    sorted.sort();
+    assert_eq!(
+        first.expected, sorted,
+        "expected field should be sorted: {:?}",
+        first.expected
+    );
+
+    // The expected list should be deduplicated
+    let mut deduped = first.expected.clone();
+    deduped.dedup();
+    assert_eq!(
+        first.expected.len(),
+        deduped.len(),
+        "expected field should not contain duplicates: {:?}",
+        first.expected
+    );
+}
+
+#[test]
+fn generated_typed_parser_bad_token_expected_field_is_populated() {
+    let source = "1 + @";
+    let errors = adze_example::typed_ast_contract::grammar::parse(source)
+        .expect_err("invalid token must fail through the generated typed parser");
+
+    let first = errors
+        .first()
+        .expect("generated parser should return at least one parse error");
+
+    // Even for bad tokens, the expected field should be populated with what
+    // the parser expected at that position.
+    assert!(
+        !first.expected.is_empty(),
+        "expected field should be populated for bad token, got: {:?}",
+        first.expected
+    );
+
+    // Token names should be human-readable
+    for name in &first.expected {
+        assert!(
+            !name.contains("SymbolId"),
+            "expected token names should not contain raw SymbolId, got: {name}"
+        );
+    }
+}
+
+#[test]
+fn generated_typed_parser_expected_field_contains_digit_pattern() {
+    let source = "1 +";
+    let errors = adze_example::typed_ast_contract::grammar::parse(source)
+        .expect_err("truncated expression must fail through the generated typed parser");
+
+    let first = errors
+        .first()
+        .expect("generated parser should return at least one parse error");
+
+    // For the arithmetic grammar, EOF at this position should expect a number.
+    assert!(
+        first.expected.iter().any(|t| t == r"/\d+/"),
+        "expected tokens should include a digit pattern for arithmetic expression: {:?}",
+        first.expected
+    );
+}

--- a/runtime/tests/parse_error_v3.rs
+++ b/runtime/tests/parse_error_v3.rs
@@ -33,6 +33,7 @@ fn test_failed_node_variant_constructable_with_children() {
         reason: ParseErrorReason::UnexpectedToken("x".to_string()),
         start: 0,
         end: 1,
+        expected: vec![],
     };
     let reason = ParseErrorReason::FailedNode(vec![child]);
     assert!(matches!(reason, ParseErrorReason::FailedNode(ref v) if v.len() == 1));
@@ -374,6 +375,7 @@ fn test_parse_error_debug_contains_reason() {
         reason: ParseErrorReason::UnexpectedToken("abc".to_string()),
         start: 0,
         end: 3,
+        expected: vec![],
     };
     let debug = format!("{err:?}");
     assert!(debug.contains("UnexpectedToken"));
@@ -386,6 +388,7 @@ fn test_parse_error_debug_contains_span() {
         reason: ParseErrorReason::MissingToken("if".to_string()),
         start: 10,
         end: 12,
+        expected: vec![],
     };
     let debug = format!("{err:?}");
     assert!(debug.contains("10"));
@@ -461,6 +464,7 @@ fn test_parse_error_with_unexpected_token() {
         reason: ParseErrorReason::UnexpectedToken("@#$".to_string()),
         start: 5,
         end: 8,
+        expected: vec![],
     };
     assert_eq!(err.start, 5);
     assert_eq!(err.end, 8);
@@ -473,6 +477,7 @@ fn test_parse_error_with_missing_token() {
         reason: ParseErrorReason::MissingToken("}".to_string()),
         start: 20,
         end: 20,
+        expected: vec![],
     };
     // Missing tokens can have zero-length spans
     assert_eq!(err.start, err.end);
@@ -484,16 +489,19 @@ fn test_parse_error_with_nested_failures() {
         reason: ParseErrorReason::UnexpectedToken("a".to_string()),
         start: 0,
         end: 1,
+        expected: vec![],
     };
     let inner2 = ParseError {
         reason: ParseErrorReason::MissingToken("b".to_string()),
         start: 1,
         end: 1,
+        expected: vec![],
     };
     let outer = ParseError {
         reason: ParseErrorReason::FailedNode(vec![inner1, inner2]),
         start: 0,
         end: 5,
+        expected: vec![],
     };
     if let ParseErrorReason::FailedNode(ref children) = outer.reason {
         assert_eq!(children.len(), 2);
@@ -581,6 +589,7 @@ fn test_parse_error_empty_unexpected_token() {
         reason: ParseErrorReason::UnexpectedToken(String::new()),
         start: 0,
         end: 0,
+        expected: vec![],
     };
     assert!(matches!(err.reason, ParseErrorReason::UnexpectedToken(ref s) if s.is_empty()));
 }
@@ -591,6 +600,7 @@ fn test_parse_error_zero_length_span() {
         reason: ParseErrorReason::MissingToken("x".to_string()),
         start: 42,
         end: 42,
+        expected: vec![],
     };
     assert_eq!(err.start, err.end);
 }
@@ -612,16 +622,19 @@ fn test_failed_node_deeply_nested() {
         reason: ParseErrorReason::UnexpectedToken("!".to_string()),
         start: 0,
         end: 1,
+        expected: vec![],
     };
     let mid = ParseError {
         reason: ParseErrorReason::FailedNode(vec![leaf]),
         start: 0,
         end: 5,
+        expected: vec![],
     };
     let outer = ParseError {
         reason: ParseErrorReason::FailedNode(vec![mid]),
         start: 0,
         end: 10,
+        expected: vec![],
     };
     // Verify 3 levels of nesting
     if let ParseErrorReason::FailedNode(ref level1) = outer.reason {

--- a/runtime/tests/parse_result_comprehensive.rs
+++ b/runtime/tests/parse_result_comprehensive.rs
@@ -190,6 +190,7 @@ fn parse_error_reason_failed_node_with_children() {
         reason: ParseErrorReason::UnexpectedToken("bar".into()),
         start: 1,
         end: 4,
+        expected: vec![],
     };
     let reason = ParseErrorReason::FailedNode(vec![inner]);
     match &reason {
@@ -283,16 +284,19 @@ fn errors_parse_error_nested_propagation() {
         reason: ParseErrorReason::UnexpectedToken("+".into()),
         start: 3,
         end: 4,
+        expected: vec![],
     };
     let mid = ErrorsParseError {
         reason: ParseErrorReason::FailedNode(vec![leaf_err]),
         start: 0,
         end: 10,
+        expected: vec![],
     };
     let root = ErrorsParseError {
         reason: ParseErrorReason::FailedNode(vec![mid]),
         start: 0,
         end: 20,
+        expected: vec![],
     };
     match &root.reason {
         ParseErrorReason::FailedNode(level1) => {
@@ -340,16 +344,19 @@ fn errors_parse_error_sibling_propagation() {
         reason: ParseErrorReason::UnexpectedToken("x".into()),
         start: 0,
         end: 1,
+        expected: vec![],
     };
     let b = ErrorsParseError {
         reason: ParseErrorReason::MissingToken(";".into()),
         start: 5,
         end: 5,
+        expected: vec![],
     };
     let parent = ErrorsParseError {
         reason: ParseErrorReason::FailedNode(vec![a, b]),
         start: 0,
         end: 10,
+        expected: vec![],
     };
     match &parent.reason {
         ParseErrorReason::FailedNode(children) => assert_eq!(children.len(), 2),
@@ -424,6 +431,7 @@ fn errors_parse_error_debug_shows_reason() {
         reason: ParseErrorReason::MissingToken("EOF".into()),
         start: 0,
         end: 0,
+        expected: vec![],
     };
     let dbg = format!("{err:?}");
     assert!(dbg.contains("MissingToken"));
@@ -500,16 +508,19 @@ fn multiple_errors_parse_errors_different_reasons() {
             reason: ParseErrorReason::UnexpectedToken("x".into()),
             start: 0,
             end: 1,
+            expected: vec![],
         },
         ErrorsParseError {
             reason: ParseErrorReason::MissingToken(";".into()),
             start: 5,
             end: 5,
+            expected: vec![],
         },
         ErrorsParseError {
             reason: ParseErrorReason::FailedNode(vec![]),
             start: 10,
             end: 15,
+            expected: vec![],
         },
     ];
     assert_eq!(errors.len(), 3);
@@ -546,11 +557,13 @@ fn errors_collect_into_vec() {
             reason: ParseErrorReason::UnexpectedToken("a".into()),
             start: 0,
             end: 1,
+            expected: vec![],
         },
         ErrorsParseError {
             reason: ParseErrorReason::UnexpectedToken("b".into()),
             start: 2,
             end: 3,
+            expected: vec![],
         },
     ];
     assert_eq!(all_errors.len(), 2);

--- a/runtime/tests/unicode_proptest.rs
+++ b/runtime/tests/unicode_proptest.rs
@@ -228,6 +228,7 @@ proptest! {
             reason: ParseErrorReason::UnexpectedToken(s.clone()),
             start: 0,
             end: s.len(),
+            expected: vec![],
         };
         if let ParseErrorReason::UnexpectedToken(ref tok) = err.reason {
             prop_assert_eq!(tok, &s);
@@ -250,6 +251,7 @@ proptest! {
             reason: ParseErrorReason::MissingToken(s.clone()),
             start: 0,
             end: 0,
+            expected: vec![],
         };
         if let ParseErrorReason::MissingToken(ref tok) = err.reason {
             prop_assert_eq!(tok, &s);
@@ -652,6 +654,7 @@ proptest! {
                 reason: ParseErrorReason::UnexpectedToken(s[start..end].to_string()),
                 start,
                 end,
+                expected: vec![],
             };
             prop_assert!(err.start <= err.end);
             prop_assert!(err.end <= s.len());


### PR DESCRIPTION
## Purpose

Add a public `expected: Vec<String>` field to `errors::ParseError` so callers can access structured expected-token names without parsing the opaque reason string. This enables downstream consumers (LSP servers, error reporters, IDE integrations) to programmatically inspect what tokens the parser expected at an error position.

## Public API note

This changes the public `ParseError` struct shape. Existing callers that only receive, inspect, display, or pattern-match returned parse errors continue to work, and existing `Display` output is preserved. Downstream code that constructs `errors::ParseError` with struct literals must add `expected: vec![]` or a populated expected-token set. Structured parse errors are still marked **Stabilizing** in the support tiers.

## Files changed

| File | Change |
|------|--------|
| `runtime/src/lib.rs` | Add `expected: Vec<String>` field to `errors::ParseError`; render structured expected tokens when the reason string does not already include them; populate tree-sitter collected missing-token errors |
| `runtime/src/__private.rs` | Populate `expected` in all `ParseError` construction sites; key site in `parse_with_pure_parser` fills structured token names from `expected_symbol_names_for_diagnostic` |
| `runtime/tests/generated_parse_errors.rs` | Add canaries for populated structured expected tokens, sorted/deduped names, bad-token expected sets, and exact normalized digit-pattern names |
| `runtime/tests/error_display_tests.rs` | Add canaries for default empty expected vectors, token names, display using structured expected tokens, backward-compatible display when the reason already includes expected text, and missing-token expected names |
| `runtime/tests/*.rs` | Add `expected: vec![]` to existing `ParseError` struct literals for compilation |

## Branch protection impact

- `Display`/`Debug` behavior for generated parser errors remains compatible.
- Public struct literals need the new field; this is an intentional stabilizing diagnostics API shape change.
- The structured expected list is populated for the pure-rust generated parser path and remains empty when expected-token information is unavailable.

## Proof commands

```bash
cargo test -p adze --features "pure-rust,glr" --test generated_parse_errors --test error_display_tests -- --nocapture
cargo check -p adze --features "pure-rust,glr" --all-targets
cargo clippy -p adze --features "pure-rust,glr" --all-targets -- -D warnings
cargo fmt -p adze -- --check
git diff --check
```

## Rollback path

Revert this single commit. Removing the field requires updating struct literal sites back to the previous `reason`/`start`/`end` shape.