### PR TITLE
tablegen: preserve rule names in node-types

### DIFF
--- a/tablegen/src/lib.rs
+++ b/tablegen/src/lib.rs
@@ -136,9 +136,12 @@ impl StaticLanguageGenerator {
 
         // Generate node types for non-terminal rules
         for (symbol_id, rules) in &self.grammar.rules {
-            // For now, use generated rule names
-            // TODO: Add proper symbol name mapping to Grammar
-            let rule_name = format!("rule_{}", symbol_id.0);
+            let rule_name = self
+                .grammar
+                .rule_names
+                .get(symbol_id)
+                .cloned()
+                .unwrap_or_else(|| format!("rule_{}", symbol_id.0));
 
             // Skip hidden rules (those starting with underscore)
             if rule_name.starts_with('_') {

--- a/tablegen/tests/abi_compat_v5.rs
+++ b/tablegen/tests/abi_compat_v5.rs
@@ -376,11 +376,14 @@ fn abi_builder_preserves_grammar_name_in_fn() {
 fn static_gen_preserves_rule_name_in_node_types() {
     let (grammar, table) = build_pipeline(statement_grammar);
     let json_str = StaticLanguageGenerator::new(grammar, table).generate_node_types();
-    // StaticLanguageGenerator uses "rule_{id}" format for rule names
-    let has_rule_ref = json_str.contains("rule_");
+    let has_rule_ref = json_str.contains("\"stmt\"") || json_str.contains("\"expr\"");
     assert!(
         has_rule_ref,
-        "rule references should be in node types output"
+        "grammar rule names should be in node types output"
+    );
+    assert!(
+        !json_str.contains("rule_"),
+        "named rules should not fall back to generated rule_<id> names"
     );
 }
 

--- a/tablegen/tests/codegen_output_v2.rs
+++ b/tablegen/tests/codegen_output_v2.rs
@@ -339,7 +339,7 @@ fn test_node_types_json_large() {
 // =====================================================================
 // 4. Node types contain grammar info (7 tests)
 //
-// Note: generate_node_types() emits rules as "rule_N" and only includes
+// Note: generate_node_types() emits grammar rule names and only includes
 // tokens with regex patterns (TokenPattern::Regex), not string literals.
 // =====================================================================
 
@@ -348,8 +348,12 @@ fn test_node_types_contain_rule_entries() {
     let (grammar, table) = single_token_grammar();
     let json = StaticLanguageGenerator::new(grammar, table).generate_node_types();
     assert!(
-        json.contains("rule_"),
-        "Expected rule entries in node types JSON"
+        json.contains("\"s\""),
+        "Expected grammar rule name in node types JSON"
+    );
+    assert!(
+        !json.contains("rule_"),
+        "Named rules should not use fallback rule_<id> names"
     );
 }
 
@@ -378,8 +382,12 @@ fn test_node_types_chain_has_rule_entries() {
     let (grammar, table) = chain_grammar();
     let json = StaticLanguageGenerator::new(grammar, table).generate_node_types();
     assert!(
-        json.contains("rule_"),
-        "Expected rule entries in chain grammar node types"
+        json.contains("\"s\""),
+        "Expected chain grammar rule name in node types"
+    );
+    assert!(
+        !json.contains("rule_"),
+        "Named rules should not use fallback rule_<id> names"
     );
 }
 

--- a/tablegen/tests/codegen_output_v6.rs
+++ b/tablegen/tests/codegen_output_v6.rs
@@ -299,8 +299,16 @@ fn codegen_node_types_contains_rule_entries() {
     let (g, t) = multi_rule_grammar();
     let json = StaticLanguageGenerator::new(g, t).generate_node_types();
     assert!(
-        json.contains("rule_"),
-        "Node types must include rule entries"
+        json.contains("\"s\""),
+        "Node types must include start rule name"
+    );
+    assert!(
+        json.contains("\"m\""),
+        "Node types must include nested rule name"
+    );
+    assert!(
+        !json.contains("rule_"),
+        "Named rules should not use fallback rule_<id> names"
     );
 }
 

--- a/tablegen/tests/codegen_output_v8.rs
+++ b/tablegen/tests/codegen_output_v8.rs
@@ -300,7 +300,12 @@ fn node_types_includes_regex_token() {
 fn node_types_contains_rule_entries() {
     let (g, t) = multi_rule_grammar();
     let json = StaticLanguageGenerator::new(g, t).generate_node_types();
-    assert!(json.contains("rule_"), "must include rule entries");
+    assert!(json.contains("\"s\""), "must include the start rule name");
+    assert!(json.contains("\"m\""), "must include nested rule names");
+    assert!(
+        !json.contains("rule_"),
+        "named rules should not fall back to generated rule_<id> names"
+    );
 }
 
 // =====================================================================

--- a/tablegen/tests/snapshots/snapshot_codegen__expr_node_types_json.snap
+++ b/tablegen/tests/snapshots/snapshot_codegen__expr_node_types_json.snap
@@ -1,10 +1,11 @@
 ---
 source: tablegen/tests/snapshot_codegen.rs
+assertion_line: 883
 expression: json
 ---
 [
   {
-    "type": "rule_4",
+    "type": "expression",
     "named": true,
     "children": {
       "multiple": false,

--- a/tablegen/tests/snapshots/snapshot_codegen__external_scanner_node_types.snap
+++ b/tablegen/tests/snapshots/snapshot_codegen__external_scanner_node_types.snap
@@ -1,10 +1,11 @@
 ---
 source: tablegen/tests/snapshot_codegen.rs
+assertion_line: 940
 expression: json
 ---
 [
   {
-    "type": "rule_6",
+    "type": "block",
     "named": true,
     "children": {
       "multiple": false,

--- a/tablegen/tests/snapshots/snapshot_codegen__many_states_node_types.snap
+++ b/tablegen/tests/snapshots/snapshot_codegen__many_states_node_types.snap
@@ -1,10 +1,11 @@
 ---
 source: tablegen/tests/snapshot_codegen.rs
+assertion_line: 977
 expression: json
 ---
 [
   {
-    "type": "rule_7",
+    "type": "nt_a",
     "named": true,
     "children": {
       "multiple": false,
@@ -13,7 +14,7 @@ expression: json
     }
   },
   {
-    "type": "rule_8",
+    "type": "nt_b",
     "named": true,
     "children": {
       "multiple": false,
@@ -22,7 +23,7 @@ expression: json
     }
   },
   {
-    "type": "rule_9",
+    "type": "nt_c",
     "named": true,
     "children": {
       "multiple": false,
@@ -31,7 +32,7 @@ expression: json
     }
   },
   {
-    "type": "rule_10",
+    "type": "nt_d",
     "named": true,
     "children": {
       "multiple": false,
@@ -40,7 +41,7 @@ expression: json
     }
   },
   {
-    "type": "rule_6",
+    "type": "start",
     "named": true,
     "children": {
       "multiple": false,

--- a/tablegen/tests/snapshots/snapshot_codegen__node_types_json.snap
+++ b/tablegen/tests/snapshots/snapshot_codegen__node_types_json.snap
@@ -1,10 +1,11 @@
 ---
 source: tablegen/tests/snapshot_codegen.rs
+assertion_line: 202
 expression: json
 ---
 [
   {
-    "type": "rule_3",
+    "type": "expression",
     "named": true,
     "children": {
       "multiple": false,

--- a/tablegen/tests/static_gen_adv_v9.rs
+++ b/tablegen/tests/static_gen_adv_v9.rs
@@ -1152,9 +1152,9 @@ fn test_node_types_different_grammars_differ() {
         GrammarBuilder::new("sga_v9_ntdiff_b")
             .token("a", "a")
             .token("b", "b")
-            .rule("start", vec!["a"])
-            .rule("start", vec!["b"])
-            .start("start"),
+            .rule("program", vec!["a"])
+            .rule("program", vec!["b"])
+            .start("program"),
     );
     assert_ne!(gen_node_types(g1, t1), gen_node_types(g2, t2));
 }

--- a/tablegen/tests/static_language_gen_comprehensive.rs
+++ b/tablegen/tests/static_language_gen_comprehensive.rs
@@ -254,6 +254,33 @@ fn generate_node_types_array_has_entries() {
 }
 
 #[test]
+fn generate_node_types_preserves_rule_names() {
+    let grammar = GrammarBuilder::new("named_node_types")
+        .token("number", r"\d+")
+        .rule("source_file", vec!["expression"])
+        .rule("expression", vec!["number"])
+        .start("source_file")
+        .build();
+    let generator = StaticLanguageGenerator::new(grammar, ParseTable::default());
+    let json_str = generator.generate_node_types();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&json_str).expect("node types must be valid JSON");
+    let types: Vec<&str> = parsed
+        .as_array()
+        .expect("node types should be an array")
+        .iter()
+        .filter_map(|entry| entry.get("type").and_then(|value| value.as_str()))
+        .collect();
+
+    assert!(types.contains(&"source_file"));
+    assert!(types.contains(&"expression"));
+    assert!(
+        !types.iter().any(|type_name| type_name.starts_with("rule_")),
+        "named rules should not be emitted through fallback rule_<id> names"
+    );
+}
+
+#[test]
 fn generate_node_types_entries_have_type_field() {
     let (grammar, table) = minimal_grammar_and_table();
     let generator = StaticLanguageGenerator::new(grammar, table);
@@ -294,6 +321,10 @@ fn generate_node_types_excludes_hidden_tokens() {
     assert!(
         !json_str.contains("\"_internal\""),
         "hidden rules (prefixed _) must not appear in node types"
+    );
+    assert!(
+        !json_str.contains("rule_"),
+        "hidden rules must not leak through generated fallback rule names"
     );
 }
 


### PR DESCRIPTION
## Summary
- make StaticLanguageGenerator node-types use grammar rule names before falling back to rule_<id>
- add canaries that named rules emit source_file/expression-style names and hidden rules do not leak through fallback names
- update stale tablegen expectations and snapshots from fallback rule_<id> node-types to real rule names

## Proof
- cargo test -p adze-tablegen --test static_language_gen_comprehensive generate_node_types_preserves_rule_names -- --exact --nocapture
- cargo test -p adze-tablegen --test static_language_gen_comprehensive generate_node_types_excludes_hidden_tokens -- --exact --nocapture
- cargo test -p adze-tablegen --test codegen_output_v8 node_types_contains_rule_entries -- --exact --nocapture
- cargo test -p adze-tablegen --test abi_compat_v5 static_gen_preserves_rule_name_in_node_types -- --exact --nocapture
- cargo test -p adze-tablegen --test snapshot_codegen -- --nocapture
- cargo test -p adze-tablegen --all-features -- --test-threads=2
- cargo fmt -p adze-tablegen -- --check
- cargo clippy -p adze-tablegen --all-targets --all-features -- -D warnings
- git diff --check

## Local note
- just ci-supported is blocked locally because this Windows environment is missing cygpath; hosted CI / ci-supported remains authoritative.