### PR TITLE
docs: define ts-compat alias semantics

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,7 @@ Welcome to the Adze documentation. Adze (formerly `rust-sitter`) is a Rust-nativ
 - [**Language Support**](./reference/language-support.md) - Status of built-in grammars (Python, JS, Go).
 - [**Known Limitations**](./reference/known-limitations.md) - Current status of experimental features.
 - [**Tree-sitter Compatibility**](./reference/tree-sitter-compatibility.md) - Adze's implementation of the Tree-sitter table format.
+- [**Tree-sitter Alias Semantics**](./reference/ts-compat-alias-semantics.md) - Draft target contract for alias-visible compatibility behavior.
 - [**Empty Rules Reference**](./reference/empty-rules-reference.md) - Quick reference for handling ε-productions.
 
 ---

--- a/docs/reference/tree-sitter-compatibility.md
+++ b/docs/reference/tree-sitter-compatibility.md
@@ -70,6 +70,8 @@ The GLR implementation maintains bit-for-bit compatibility with Tree-sitter's C 
 This file covers generated `TSLanguage` table format and decode invariants.
 The `ts_compat::Node` runtime identity APIs have a separate contract in
 [`ts-compat-node-identity.md`](ts-compat-node-identity.md).
+The future alias-aware target semantics are drafted in
+[`ts-compat-alias-semantics.md`](ts-compat-alias-semantics.md).
 
 Current `ts_compat` nodes expose raw parsed-symbol identity:
 

--- a/docs/reference/ts-compat-alias-semantics.md
+++ b/docs/reference/ts-compat-alias-semantics.md
@@ -1,0 +1,167 @@
+# Tree-sitter Compatibility Alias Semantics
+
+**Status:** Draft target contract; not current runtime behavior.
+
+This document defines the intended alias-aware `ts_compat` node identity
+contract. It complements
+[`ts-compat-node-identity.md`](ts-compat-node-identity.md), which documents the
+current raw parsed-symbol behavior.
+
+Current Adze runtime state:
+
+- alias metadata is preserved at the generated `TSLanguage` ABI boundary,
+- runtime decode preserves alias sequences in native parse-table data,
+- parsed `ts_compat::Node` values do not yet project alias-visible identity.
+
+This document is the target contract for the future projection layer.
+
+## Upstream Shape
+
+Tree-sitter distinguishes visible node identity from grammar identity.
+
+In the Rust binding:
+
+| Upstream API | Meaning |
+|---|---|
+| `Node::kind()` | Visible node type string. |
+| `Node::kind_id()` | Visible node type id. |
+| `Node::grammar_name()` | Grammar symbol name, ignoring aliases. |
+| `Node::grammar_id()` | Grammar symbol id, ignoring aliases. |
+
+The C API has the same split through `ts_node_type`,
+`ts_node_symbol`, `ts_node_grammar_type`, and
+`ts_node_grammar_symbol`.
+
+Adze's compatibility layer should follow that split.
+
+## Target Adze Node Identity
+
+Alias-aware `ts_compat::Node` should carry both visible and grammar identity:
+
+```rust
+pub struct NodeIdentity {
+    visible_name: SymbolName,
+    visible_id: SymbolId,
+    grammar_name: SymbolName,
+    grammar_id: SymbolId,
+    alias: Option<AliasId>,
+    is_named: bool,
+}
+```
+
+Projected APIs should mean:
+
+| API | Target meaning |
+|---|---|
+| `Node::kind()` | Alias-visible node name when an alias applies; otherwise grammar symbol name. |
+| `Node::kind_id()` | Alias-visible/public symbol id when an alias applies; otherwise grammar symbol id. |
+| `Node::grammar_name()` | Original grammar symbol name, ignoring aliases. |
+| `Node::grammar_id()` | Original grammar symbol id, ignoring aliases. |
+| `Node::is_named()` | Alias-adjusted namedness when alias metadata changes visibility; otherwise grammar symbol namedness. |
+| `Node::to_sexp()` | Renders the same visible identity as `kind()` for named nodes. |
+
+The grammar identity APIs must remain usable for parse-state metadata and
+lookahead-style APIs that need original grammar symbols.
+
+## Alias Kinds
+
+The target contract must handle at least these cases:
+
+| Case | Example intent | Expected projection |
+|---|---|---|
+| Named alias over named symbol | grammar `expression` displayed as `binary_expression` | `kind()` is `binary_expression`; `grammar_name()` is `expression`. |
+| Named alias over anonymous symbol | token `"+"` displayed as `plus_operator` | visible node may become named if alias metadata says named. |
+| Anonymous alias over named symbol | grammar node hidden behind anonymous display | named-child filtering follows visible namedness. |
+| No alias | normal grammar symbol | visible identity equals grammar identity. |
+
+If a case cannot be represented by current ABI metadata, the implementation must
+extend native `AdzeDocument`/tree identity data before changing `ts_compat`.
+
+## S-Expression Contract
+
+Alias-aware S-expressions should render visible node identity:
+
+```text
+(source_file (binary_expression left: (number) right: (number)))
+```
+
+For named-node S-expressions:
+
+- visible named nodes are included,
+- anonymous children remain omitted unless the S-expression mode explicitly
+  asks for anonymous nodes,
+- field labels are rendered from edge metadata,
+- `grammar_name()` is not used for display unless no alias applies.
+
+This keeps `to_sexp()` aligned with `kind()`.
+
+## Node-Types Metadata
+
+Alias-aware node-types output should describe visible node types because that is
+what Tree-sitter tooling and queries inspect.
+
+The output must still retain enough metadata to relate visible aliases back to
+grammar symbols for diagnostics, parse-state metadata, and native provenance.
+
+Minimum future node-types canaries:
+
+- an aliased named node appears under its visible alias name,
+- the original grammar symbol does not appear as a separate visible node type
+  unless it is also visible without the alias,
+- field metadata remains attached to parent-child edges,
+- named/anonymous status follows visible alias metadata,
+- grammar identity remains available through `grammar_name()`/`grammar_id()`.
+
+## Native Data Requirement
+
+The Tree-sitter adapter must not guess alias identity.
+
+Native parse data must preserve:
+
+- grammar symbol id,
+- visible symbol id,
+- visible name,
+- grammar name,
+- alias id or alias sequence entry,
+- visible namedness,
+- grammar namedness,
+- edge field metadata.
+
+If `AdzeDocument` does not expose these fields, the adapter should remain on the
+current raw-symbol contract rather than inventing alias behavior locally.
+
+## Proof Requirements
+
+Before implementing this contract, add canaries that prove the ABI, native tree,
+and `ts_compat` projection agree.
+
+Required proof slices:
+
+```bash
+cargo test -p adze --features "pure-rust,glr,ts-compat" \
+  --test tablegen_abi_decode_roundtrip \
+  compressed_tslanguage_decode_preserves_alias_sequences \
+  -- --exact --nocapture
+
+cargo test -p adze --features "pure-rust,ts-compat" \
+  --test ts_compat_node_metadata \
+  alias_visible_kind_and_grammar_identity_are_distinct \
+  -- --exact --nocapture
+
+cargo test -p adze --features "pure-rust,ts-compat" \
+  --test ts_compat_to_sexp \
+  alias_visible_identity_is_used_in_sexp \
+  -- --exact --nocapture
+```
+
+The test names above are target canaries; they are not current tests.
+
+## Compatibility Status
+
+Until implementation and canaries land:
+
+- alias metadata preservation is a tablegen/runtime ABI proof,
+- alias-visible parsed node identity is not claimed,
+- `kind()` and `grammar_name()` may remain equal in current Adze trees,
+- `kind_id()` and `grammar_id()` may remain equal in current Adze trees,
+- users should treat alias-aware Tree-sitter parity as future work.

--- a/docs/reference/ts-compat-node-identity.md
+++ b/docs/reference/ts-compat-node-identity.md
@@ -46,6 +46,9 @@ canary set must define all of these explicitly:
 - how aliases appear in node-types metadata,
 - how anonymous aliases affect named-child filtering.
 
+The draft target contract is
+[`ts-compat-alias-semantics.md`](ts-compat-alias-semantics.md).
+
 Until that work lands, code that needs alias-aware Tree-sitter display behavior
 should treat the `ts_compat` alias surface as advisory.
 


### PR DESCRIPTION
## Summary
- add a draft target contract for alias-aware Tree-sitter-compatible node identity
- define visible identity vs grammar identity, S-expression behavior, node-types expectations, and native data requirements
- cross-link the draft from the current node identity and Tree-sitter compatibility references

## Proof
- git diff --check HEAD~1..HEAD

## Notes
- docs-only; current runtime behavior is unchanged
- this does not claim alias-visible parsed node parity yet