### PR TITLE
ci: align stable product lane

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Support tiers, proof commands, and CI lanes are tracked in [`docs/status/SUPPORT
 
 | Surface | Tier | Proof |
 |---------|------|-------|
-| Typed extraction | **Stable** | `just ci-supported`; `cargo test -p adze --features pure-rust --test typed_ast_contract typed_ast_contract_left_associative_addition -- --exact --nocapture` |
+| Typed extraction | **Stable** | `just ci-supported`; `cargo test -p adze --features pure-rust --test typed_ast_contract typed_ast_contract_left_associative_addition -- --exact --nocapture`; `cargo test -p adze --features pure-rust --test typed_ast_contract typed_ast_contract_repeated_parse_is_deterministic -- --exact --nocapture` |
 | Pure-Rust parser | **Stable** | `just ci-supported`; `cargo test -p adze-cli readme_arithmetic_quickstart_builds_and_runs -- --exact --nocapture` |
 | Operator precedence | **Stable** | `cargo test -p adze-cli readme_arithmetic_quickstart_builds_and_runs -- --exact --nocapture`; `cargo test -p adze-glr-core --test ambiguity_detection_comprehensive test_precedence_resolves_add_mul -- --exact --nocapture` |
 | Serialization (core tables) | **Stable** | `cargo test -p adze-glr-core --features serialization --doc`; `cargo test -p adze-glr-core --features serialization --test serialization_v9 sv9_complex_precedence_roundtrip -- --exact --nocapture` |

--- a/scripts/ci-product-stable.sh
+++ b/scripts/ci-product-stable.sh
@@ -10,7 +10,8 @@ fi
 # Broader stabilizing/advisory surfaces remain in scripts/ci-product.sh.
 CANARIES=(
   "typed extraction exact value|cargo test -p adze --features pure-rust --test typed_ast_contract typed_ast_contract_left_associative_addition -- --exact --nocapture"
-  "README quickstart clean-room parse|cargo test -p adze-cli readme_arithmetic_quickstart_builds_and_runs -- --exact --nocapture"
+  "typed extraction repeated-parse determinism|cargo test -p adze --features pure-rust --test typed_ast_contract typed_ast_contract_repeated_parse_is_deterministic -- --exact --nocapture"
+  "README quickstart clean-room parse and diagnostics|cargo test -p adze-cli readme_arithmetic_quickstart_builds_and_runs -- --exact --nocapture"
   "operator precedence core shape|cargo test -p adze-glr-core --test ambiguity_detection_comprehensive test_precedence_resolves_add_mul -- --exact --nocapture"
   "core parse-table serialization roundtrip|cargo test -p adze-glr-core --features serialization --test serialization_v9 sv9_complex_precedence_roundtrip -- --exact --nocapture"
 )


### PR DESCRIPTION
## Summary
- add the typed-AST repeated-parse determinism canary to `ci-product-stable`
- update the quickstart stable-lane label to reflect parse and diagnostic coverage
- align the README Stable typed-extraction proof row with the support-tier canary list

## Proof
- `C:\Program Files\Git\bin\bash.exe scripts/ci-product-stable.sh --dry-run`
- `cargo test -p adze --features pure-rust --test typed_ast_contract typed_ast_contract_repeated_parse_is_deterministic -- --exact --nocapture`
- `cargo test -p adze --features pure-rust --test typed_ast_contract typed_ast_contract_left_associative_addition -- --exact --nocapture`
- `cargo test -p adze-cli readme_arithmetic_quickstart_builds_and_runs -- --exact --nocapture`
- `C:\Program Files\Git\bin\bash.exe scripts/ci-product-stable.sh`
- `git diff --check`

## Notes
- CI lane alignment only; no support-tier promotion or branch-protection change.