### PR TITLE
docs: define parse document failure semantics

### DIFF
--- a/docs/design/adze-document.md
+++ b/docs/design/adze-document.md
@@ -48,6 +48,34 @@ let ts_tree = doc.as_tree_sitter();
 
 They are not fields on the document and must not define separate parse truths.
 
+## Document Versus Failure Semantics
+
+`parse_document` should distinguish parse facts from infrastructure failures.
+
+Syntax errors, recovery, and ambiguity should generally produce an
+`AdzeDocument` with diagnostics, node flags, and metadata:
+
+```rust
+let doc = grammar::parse_document("1 +")?;
+assert!(!doc.diagnostics().is_empty());
+```
+
+Hard failures are reserved for cases where no trustworthy document can be
+produced:
+
+```rust
+pub enum ParseFailure {
+    NoLanguage,
+    Cancelled,
+    InternalInvariant,
+}
+```
+
+This keeps native parsing useful for editors, LSPs, formatters, and agents that
+must inspect incomplete source text. Tree-sitter-compatible projections can
+render the same state as `is_error()`, `has_error()`, and `is_missing()`, while
+native APIs expose the structured diagnostics that explain what happened.
+
 ## Native Tree Model
 
 The generic native CST should be lossless enough to support formatting,


### PR DESCRIPTION
## Summary
- define `parse_document` failure semantics in the AdzeDocument design contract
- require syntax/recovery/ambiguity cases to produce a document with diagnostics when a trustworthy document exists
- reserve hard `ParseFailure` cases for missing language, cancellation, and internal invariants

## Proof
- `git show --check --stat --oneline HEAD`
- `python scripts/ci/pr-plan.py --base origin/main --head HEAD`

## Notes
- Docs-only design contract update; no implementation or support-tier promotion.
- Local `cargo fmt --all --check` is blocked on this Windows checkout by `os error 206`; hosted Linux Docs Gate should run the formatting check.