### PR TITLE
test: guard README stable proof lane

### DIFF
--- a/cli/tests/readme_quickstart.rs
+++ b/cli/tests/readme_quickstart.rs
@@ -116,6 +116,35 @@ fn readme_bad_input_reports_useful_diagnostic() {
     );
 }
 
+#[test]
+fn readme_stable_claims_are_in_stable_product_lane() {
+    let readme = include_str!("../../README.md");
+    let support_tiers = include_str!("../../docs/status/SUPPORT_TIERS.md");
+    let stable_lane = include_str!("../../scripts/ci-product-stable.sh");
+    let proof_commands = readme_stable_proof_commands(readme);
+
+    assert!(
+        !proof_commands.is_empty(),
+        "README capability table should include Stable proof commands"
+    );
+
+    for command in proof_commands {
+        assert!(
+            support_tiers.contains(&command),
+            "README Stable proof command must be documented in docs/status/SUPPORT_TIERS.md:\n{command}"
+        );
+
+        if is_required_gate(&command) {
+            continue;
+        }
+
+        assert!(
+            stable_lane.contains(&command),
+            "README Stable proof command must be present in scripts/ci-product-stable.sh:\n{command}"
+        );
+    }
+}
+
 fn downstream_manifest(readme_toml: &str, runtime_path: &str, tool_path: &str) -> String {
     assert!(
         readme_toml.contains(r#"adze = { version = "0.8", default-features = false }"#),
@@ -145,6 +174,70 @@ edition = "2024"
 {dependencies}
 "#
     )
+}
+
+fn readme_stable_proof_commands(readme: &str) -> Vec<String> {
+    let mut commands = Vec::new();
+    let mut in_capability_table = false;
+
+    for line in readme.lines() {
+        if line == "### Capability table" {
+            in_capability_table = true;
+            continue;
+        }
+
+        if in_capability_table && line.starts_with("##") {
+            break;
+        }
+
+        if !in_capability_table {
+            continue;
+        }
+
+        if !line.starts_with('|') || !line.contains("| **Stable** |") {
+            continue;
+        }
+
+        let columns: Vec<&str> = line.split('|').collect();
+        assert!(
+            columns.len() >= 4,
+            "README Stable capability row should have a proof column: {line}"
+        );
+
+        let proof = columns[3];
+        let row_commands = inline_code_spans(proof);
+        assert!(
+            !row_commands.is_empty(),
+            "README Stable capability row should name at least one proof command: {line}"
+        );
+
+        commands.extend(row_commands);
+    }
+
+    commands.sort();
+    commands.dedup();
+    commands
+}
+
+fn inline_code_spans(text: &str) -> Vec<String> {
+    let mut spans = Vec::new();
+    let mut rest = text;
+
+    while let Some(start) = rest.find('`') {
+        let after_start = &rest[start + 1..];
+        let Some(end) = after_start.find('`') else {
+            break;
+        };
+
+        spans.push(after_start[..end].to_string());
+        rest = &after_start[end + 1..];
+    }
+
+    spans
+}
+
+fn is_required_gate(command: &str) -> bool {
+    matches!(command, "just ci-supported" | "CI / ci-supported")
 }
 
 fn grammar_module_from_readme(snippet: &str) -> String {

--- a/docs/status/CORRECTNESS_PUSH.md
+++ b/docs/status/CORRECTNESS_PUSH.md
@@ -77,7 +77,7 @@ just ci-supported
 just ci-product-stable
 ```
 
-The stable product lane covers a clean-room README quickstart, typed extraction exact-value test, operator precedence test, and serialization canary. GLR ambiguity and structured parse-error diagnostics remain in the broader advisory lane until those surfaces graduate from Stabilizing.
+The stable product lane covers README stable proof-map alignment, a clean-room README quickstart, typed extraction exact-value and repeated-parse determinism tests, operator precedence, serialization doctests, and serialization roundtrip canaries. GLR ambiguity and structured parse-error diagnostics remain in the broader advisory lane until those surfaces graduate from Stabilizing.
 
 Rung 3 remains scheduled/manual: full workspace all-features, fuzzing, Miri, sanitizers, benchmarks, grammar corpus, runtime2, and browser WASM execution.
 

--- a/scripts/ci-product-stable.sh
+++ b/scripts/ci-product-stable.sh
@@ -9,6 +9,7 @@ fi
 # Stable product canaries map to README Stable claims only.
 # Broader stabilizing/advisory surfaces remain in scripts/ci-product.sh.
 CANARIES=(
+  "README stable proof alignment|cargo test -p adze-cli readme_stable_claims_are_in_stable_product_lane -- --exact --nocapture"
   "typed extraction exact value|cargo test -p adze --features pure-rust --test typed_ast_contract typed_ast_contract_left_associative_addition -- --exact --nocapture"
   "typed extraction repeated-parse determinism|cargo test -p adze --features pure-rust --test typed_ast_contract typed_ast_contract_repeated_parse_is_deterministic -- --exact --nocapture"
   "README quickstart clean-room parse and diagnostics|cargo test -p adze-cli readme_arithmetic_quickstart_builds_and_runs -- --exact --nocapture"


### PR DESCRIPTION
## Summary
- add a README capability-table guard that checks every Stable proof command is documented in SUPPORT_TIERS.md
- require every non-required-gate README Stable proof command to appear in scripts/ci-product-stable.sh
- run that guard as the first ci-product-stable canary and refresh the correctness plan lane description

## Validation
- cargo test -p adze-cli readme_stable_claims_are_in_stable_product_lane -- --exact --nocapture
- cargo test -p adze-cli --test readme_quickstart -- --nocapture
- cargo clippy -p adze-cli --tests -- -D warnings
- cargo fmt -p adze-cli -- --check
- git diff --check
- scripts/ci-product-stable.sh --dry-run
- scripts/ci-product-stable.sh

Note: workspace-wide cargo fmt --all --check still hits Windows os error 206 in this checkout; the touched package fmt check passed.