### PR TITLE
docs: refresh post-quickstart proof status

### DIFF
--- a/docs/status/CORRECTNESS_PUSH.md
+++ b/docs/status/CORRECTNESS_PUSH.md
@@ -1,6 +1,6 @@
 # Correctness Push Plan
 
-**Last updated:** 2026-05-10
+**Last updated:** 2026-05-11
 **Scope:** current parser/runtime, GLR, tablegen ABI, CLI, and product-proof convergence.
 
 This is the execution playbook for moving Adze from "bounded core lane is green" to "the product claims are behavior-proven." It is intentionally narrower than a roadmap: keep the required lane bounded, land focused correctness work only when it has receipts, and track remaining product gaps without hiding them inside broad policy or infrastructure PRs.
@@ -12,7 +12,7 @@ This is the execution playbook for moving Adze from "bounded core lane is green"
 - The broader product lane is advisory until each canary proves real behavior instead of only compile/no-run smoke.
 - README-stable claims must map to a proof command in `docs/status/SUPPORT_TIERS.md`.
 - Runtime2 remains an experimental proving ground unless a later promotion plan gives it required behavior tests and a public support contract.
-- Live GitHub state is the execution baseline. As of 2026-05-10, the correctness PR queue is empty after refreshing with `gh pr list --state open --limit 20 --json number,title,isDraft,headRefName,updatedAt,url`.
+- Live GitHub state is the execution baseline. As of 2026-05-11, the correctness PR queue is empty after refreshing with `gh pr list --state open --limit 20 --json number,title,isDraft,headRefName,updatedAt,url`.
 
 ## Live-State Refresh
 
@@ -58,6 +58,7 @@ The post-queue work is tracked as focused issues instead of broad catch-all impl
 - [#463](https://github.com/EffortlessMetrics/adze/issues/463) Parse diagnostics: spans, expected token sets, line/column mapping, excerpts, no panic.
 - [#464](https://github.com/EffortlessMetrics/adze/issues/464) CLI clean-room quickstart and parse command truthfulness — closed after behavior canaries landed; reopen or replace only for new CLI parser behavior work.
 - [#465](https://github.com/EffortlessMetrics/adze/issues/465) README/support-tier reconciliation — closed after the proof map and stable product lane landed; keep the invariant in future docs edits.
+- [#629](https://github.com/EffortlessMetrics/adze/pull/629), [#630](https://github.com/EffortlessMetrics/adze/pull/630), and [#631](https://github.com/EffortlessMetrics/adze/pull/631) extended the stable quickstart proof to a checked-in downstream demo, the Getting Started tutorial, and tutorial bad-input diagnostics.
 - [#73](https://github.com/EffortlessMetrics/adze/issues/73) and [#75](https://github.com/EffortlessMetrics/adze/issues/75) Benchmark truthfulness: real parser work vs infrastructure-only measurements.
 
 ## Native Product Contract Lane
@@ -120,7 +121,7 @@ just ci-supported
 just ci-product-stable
 ```
 
-The stable product lane covers README stable proof-map alignment, a clean-room README quickstart, typed extraction exact-value and repeated-parse determinism tests, operator precedence, serialization doctests, and serialization roundtrip canaries. GLR ambiguity and structured parse-error diagnostics remain in the broader advisory lane until those surfaces graduate from Stabilizing.
+The stable product lane covers README stable proof-map alignment, clean-room README and Getting Started quickstarts, the checked-in downstream demo, typed extraction exact-value and repeated-parse determinism tests, operator precedence, serialization doctests, and serialization roundtrip canaries. GLR ambiguity and broad structured parse-error diagnostics remain in the wider advisory lane until those surfaces graduate from Stabilizing.
 
 Rung 3 remains scheduled/manual: full workspace all-features, fuzzing, Miri, sanitizers, benchmarks, grammar corpus, runtime2, and browser WASM execution.
 

--- a/docs/status/KNOWN_RED.md
+++ b/docs/status/KNOWN_RED.md
@@ -125,6 +125,8 @@ Current canaries:
 - `adze-tablegen` alias ABI pointer/data preservation — **behavior** (`cargo test -p adze-tablegen --test alias_handling_comprehensive alias_abi_emits_non_null_pointers_when_counters_nonzero -- --exact --nocapture`)
 - `adze-tablegen` sparse production LHS ABI preservation — **behavior** (`cargo test -p adze-tablegen --test production_id_comprehensive edge_sparse_production_ids_emit_dense_production_lhs_index -- --exact --nocapture`)
 - README arithmetic quickstart clean-room parse and diagnostics — **behavior** (`cargo test -p adze-cli readme_arithmetic_quickstart_builds_and_runs -- --exact --nocapture`)
+- Getting Started quickstart clean-room parse and diagnostics — **behavior** (`cargo test -p adze-cli getting_started_quickstart_builds_parses_and_reports_diagnostics -- --exact --nocapture`)
+- Checked-in downstream quickstart sample — **behavior** (`cargo test -p downstream-demo -- --nocapture`)
 - `adze` typed AST repeated-parse determinism — **behavior** (`cargo test -p adze --features pure-rust --test typed_ast_contract typed_ast_contract_repeated_parse_is_deterministic -- --exact --nocapture`)
 - `adze-cli` default-cwd init/check smoke — **behavior** (`cargo test -p adze-cli test_init_default_cwd_generates_buildable_project -- --exact --nocapture`)
 - `adze-cli` clean-room init dependency smoke — **behavior** (`cargo test -p adze-cli test_init_cargo_toml_references_adze_dependency -- --exact --nocapture`)

--- a/docs/status/NOW_NEXT_LATER.md
+++ b/docs/status/NOW_NEXT_LATER.md
@@ -1,7 +1,7 @@
 # Now / Next / Later
 
-**Last updated:** 2026-05-10
-**Status:** **Post-queue correctness proof** — `adze` 0.8.0 is live on crates.io, the supported gate remains bounded, and the live GitHub PR queue is empty as of the latest refresh. Remaining work is tracked as focused proof issues rather than a broad merge queue. The current push is tracked in [`CORRECTNESS_PUSH.md`](./CORRECTNESS_PUSH.md).
+**Last updated:** 2026-05-11
+**Status:** **Post-queue correctness proof** — `adze` 0.8.0 is live on crates.io, the supported gate remains bounded, and the live GitHub PR queue is empty after the downstream demo, Getting Started, and tutorial-diagnostics proof PRs landed. Remaining work is tracked as focused proof issues rather than a broad merge queue. The current push is tracked in [`CORRECTNESS_PUSH.md`](./CORRECTNESS_PUSH.md).
 
 Adze status and rolling execution plan. For recurring pain points, see [`docs/status/FRICTION_LOG.md`](./FRICTION_LOG.md). For API stability guarantees per crate, see [`docs/status/API_STABILITY.md`](./API_STABILITY.md). For support-tier proof commands, see [`docs/status/SUPPORT_TIERS.md`](./SUPPORT_TIERS.md).
 
@@ -40,6 +40,7 @@ Adze status and rolling execution plan. For recurring pain points, see [`docs/st
 - [x] Track GLR product proof in [#460](https://github.com/EffortlessMetrics/adze/issues/460), tablegen ABI completeness in [#461](https://github.com/EffortlessMetrics/adze/issues/461), and parse diagnostics in [#463](https://github.com/EffortlessMetrics/adze/issues/463).
 - [x] Close out CLI clean-room quickstart/truthfulness and README/support-tier reconciliation as landed proof work ([#464](https://github.com/EffortlessMetrics/adze/issues/464), [#465](https://github.com/EffortlessMetrics/adze/issues/465)).
 - [x] Keep README feature claims aligned with [`SUPPORT_TIERS.md`](./SUPPORT_TIERS.md): no Stable claim without a named proof command; guarded by `readme_stable_claims_are_in_stable_product_lane`.
+- [x] Add stable-product canaries for the checked-in downstream demo, README quickstart, and Getting Started tutorial so clean downstream crates prove typed parsing and useful bad-input diagnostics.
 
 ### Operational tail
 - [ ] [Issue #269](https://github.com/EffortlessMetrics/adze/issues/269): Windows pure-rust benchmark-compilation tail is gated but still open; decide whether to trim further or close as acceptable.


### PR DESCRIPTION
## Summary
- refresh Now/Next/Later and Correctness Push status after #629, #630, and #631 landed
- document that the live PR queue is empty on 2026-05-11
- add Getting Started and downstream-demo canaries to the advisory product-proof inventory

## Validation
- gh pr list --state open --limit 20 --json number,title,isDraft,headRefName,updatedAt,url
- rg -n "2026-05-10|2026-05-11|#629|#630|#631|getting_started_quickstart_builds_parses_and_reports_diagnostics|downstream-demo" docs/status/NOW_NEXT_LATER.md docs/status/CORRECTNESS_PUSH.md docs/status/KNOWN_RED.md
- git diff --check