### PR TITLE
runtime: prove generated GLR alternatives

### DIFF
--- a/runtime/src/__private.rs
+++ b/runtime/src/__private.rs
@@ -591,7 +591,8 @@ fn parse_with_true_glr_runtime<T: Extract<T>>(
 }
 
 #[cfg(all(feature = "glr", feature = "pure-rust"))]
-fn align_true_glr_parse_table_to_language_symbols(
+/// Align a decoded parse table to the generated language's dense symbol IDs.
+pub fn align_true_glr_parse_table_to_language_symbols(
     language: &'static crate::pure_parser::TSLanguage,
     parse_table: &mut adze_glr_core::ParseTable,
 ) {
@@ -668,7 +669,8 @@ fn align_true_glr_parse_table_to_language_symbols(
 }
 
 #[cfg(all(feature = "glr", feature = "pure-rust"))]
-fn lex_with_language_fn(
+/// Tokenize source text with a generated language lexer function.
+pub fn lex_with_language_fn(
     language: &'static crate::pure_parser::TSLanguage,
     lex_fn: unsafe extern "C" fn(*mut core::ffi::c_void, crate::pure_parser::TSLexState) -> bool,
     source: &[u8],

--- a/runtime/src/glr_parser.rs
+++ b/runtime/src/glr_parser.rs
@@ -1999,8 +1999,10 @@ impl GLRParser {
     ///
     /// # Note
     /// In case of ambiguous parses where multiple stacks complete successfully, this
-    /// currently returns the first valid parse found. Future enhancements could return
-    /// all valid parses or use additional criteria to select the best one.
+    /// returns one selected tree. Selection first compares GLR stack versions using
+    /// dynamic-precedence and recovery state, then applies a stable structural
+    /// tie-break. Use [`Self::finish_all_alternatives`] to inspect all complete
+    /// parse alternatives retained by the runtime.
     pub fn finish(&self) -> Result<Arc<Subtree>, String> {
         // Find a successfully parsed stack
         // Success criteria:

--- a/runtime/tests/test_e2e_ambiguous_grammar_glr.rs
+++ b/runtime/tests/test_e2e_ambiguous_grammar_glr.rs
@@ -16,9 +16,13 @@
 //!   4. Backward compatibility with precedence grammars maintained
 
 use adze::decoder;
+#[cfg(feature = "glr")]
+use adze::glr_parser::GLRParser;
 use adze::pure_parser::TSLanguage;
 use adze_glr_core::Action;
 use adze_glr_core::conflict_inspection::cell_has_conflict;
+#[cfg(feature = "glr")]
+use std::collections::BTreeSet;
 
 /// Helper: Count multi-action cells (GLR conflicts) in a parse table
 fn count_multi_action_cells(lang: &'static TSLanguage) -> usize {
@@ -294,6 +298,53 @@ fn generated_ambiguous_expr_multi_conflict_selection_is_deterministic() {
 }
 
 #[test]
+#[cfg(feature = "glr")]
+fn generated_ambiguous_expr_glr_runtime_retains_multiple_complete_alternatives() {
+    use adze_example::ambiguous_expr::grammar;
+
+    let input = "1 + 2 + 3";
+    let language = grammar::language();
+    let mut parse_table = decoder::decode_parse_table(language);
+    adze::__private::align_true_glr_parse_table_to_language_symbols(language, &mut parse_table);
+    let grammar = decoder::decode_grammar(language);
+    let mut parser = GLRParser::new(parse_table, grammar);
+
+    let lex_fn = language
+        .lex_fn
+        .expect("generated language should expose a lex_fn");
+    for token in adze::__private::lex_with_language_fn(language, lex_fn, input.as_bytes())
+        .expect("generated lexer should tokenize ambiguous expression")
+    {
+        parser.process_token(token.symbol_id, &token.text, token.byte_offset);
+    }
+    parser.process_eof(input.len());
+
+    let alternatives = parser
+        .finish_all_alternatives()
+        .expect("ambiguous generated grammar should finish successfully");
+    let unique_shapes = alternatives
+        .iter()
+        .map(|alternative| format!("{alternative:?}"))
+        .collect::<BTreeSet<_>>();
+
+    assert!(
+        alternatives.len() >= 2,
+        "ambiguous generated grammar should retain more than one complete parse alternative, got {}",
+        alternatives.len()
+    );
+    assert!(
+        unique_shapes.len() >= 2,
+        "ambiguous generated grammar should retain structurally distinct parse alternatives"
+    );
+    assert!(
+        alternatives
+            .iter()
+            .all(|alternative| alternative.node.byte_range == (0..input.len())),
+        "all complete alternatives should span the full input"
+    );
+}
+
+#[test]
 fn generated_glr_parser_bad_inputs_return_errors_without_panicking() {
     use adze_example::ambiguous_expr::grammar;
 
@@ -445,7 +496,8 @@ fn test_contract_documentation() {
     eprintln!("  1. ✓ Enum variant inlining enables ambiguous grammars");
     eprintln!("  2. ✓ GLR conflict generation works correctly");
     eprintln!("  3. ✓ GLR runtime parses ambiguous input successfully");
-    eprintln!("  4. ✓ Backward compatibility with precedence grammars");
+    eprintln!("  4. ✓ GLR runtime retains complete alternatives for ambiguous input");
+    eprintln!("  5. ✓ Backward compatibility with precedence grammars");
     eprintln!();
     eprintln!("To run validation:");
     eprintln!(
@@ -455,6 +507,9 @@ fn test_contract_documentation() {
     eprintln!("Expected Results:");
     eprintln!("  - test_ambiguous_grammar_conflict_generation: PASS");
     eprintln!("  - test_ambiguous_grammar_glr_parsing: PASS");
+    eprintln!(
+        "  - generated_ambiguous_expr_glr_runtime_retains_multiple_complete_alternatives: PASS"
+    );
     eprintln!("  - test_glr_backward_compatibility: PASS");
     eprintln!("  - test_ambiguous_vs_arithmetic_comparison: PASS");
     eprintln!();


### PR DESCRIPTION
## Summary
- expose existing generated-runtime lexer/alignment helpers through __private for E2E product canaries
- add a generated ambiguous_expr canary that drives the true GLR runtime directly and asserts multiple complete, structurally distinct alternatives are retained
- gate that GLR-specific canary for default-feature runtime jobs and update GLRParser::finish docs to describe the current deterministic selection policy

## Validation
- cargo test -p adze --test test_e2e_ambiguous_grammar_glr --no-run
- cargo clippy -p adze --test test_e2e_ambiguous_grammar_glr -- -D warnings
- cargo test -p adze --features "pure-rust,glr,runtime-e2e" --test test_e2e_ambiguous_grammar_glr generated_ambiguous_expr_glr_runtime_retains_multiple_complete_alternatives -- --exact --nocapture
- cargo test -p adze --features "pure-rust,glr,runtime-e2e" --test test_e2e_ambiguous_grammar_glr generated_ambiguous_expr_multi_conflict_selection_is_deterministic -- --exact --nocapture
- cargo test -p adze --features "pure-rust,glr,runtime-e2e" --test test_e2e_ambiguous_grammar_glr test_ambiguous_grammar_glr_parsing -- --exact --nocapture
- cargo test -p adze --features "pure-rust,glr,runtime-e2e" --test test_e2e_ambiguous_grammar_glr -- --nocapture
- cargo clippy -p adze --features "pure-rust,glr,runtime-e2e" --test test_e2e_ambiguous_grammar_glr -- -D warnings
- rustfmt --check --edition 2024 runtime\src\__private.rs runtime\src\glr_parser.rs runtime\tests\test_e2e_ambiguous_grammar_glr.rs
- git diff --check