### PR TITLE
build: use Git Bash for just on Windows

### DIFF
--- a/justfile
+++ b/justfile
@@ -6,6 +6,9 @@
 # Or:  JUST_TEMPDIR=/tmp/just just <recipe>
 
 set shell := ["bash", "-eu", "-o", "pipefail", "-c"]
+# Git for Windows installs Bash here, but does not always put it on PATH for
+# PowerShell-launched tools. Keep just recipes usable from a clean Windows shell.
+set windows-shell := ["C:\\Program Files\\Git\\bin\\bash.exe", "-eu", "-o", "pipefail", "-c"]
 
 # Format all code
 fmt:


### PR DESCRIPTION
## Summary
- configure `just` to use the standard Git-for-Windows Bash path on Windows
- keep Bash-based recipes usable from PowerShell when `bash` is installed but not on `PATH`

## Validation
- just --dry-run ci-product-stable
- just ci-product-stable
- just --dry-run ci-product-advisory
- git diff --check