### PR TITLE
docs: finish worktree cleanup guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,6 +231,8 @@ Example flow:
 ./scripts/cleanup-worktrees.sh prune-stale
 ```
 
+On Windows PowerShell, prefer `just worktree-list` and `just worktree-prune-stale` for the common paths. Run direct script calls from Git Bash or another shell where `bash` is on `PATH`.
+
 Use `rm -rf` only for standalone temporary clones that are no longer registered.
 
 ## Architecture Overview

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,12 +37,12 @@ Adze (formerly `rust-sitter`) is a Rust-native grammar toolchain that turns Rust
 - ✅ **Workflow Hardening**: PR [#280](https://github.com/EffortlessMetrics/adze/pull/280) merged on 2026-04-06 with CI lane hardening and backend-contract stabilization. Backend-selection contract ([issue #267](https://github.com/EffortlessMetrics/adze/issues/267)) resolved.
 - ✅ **Core Crates Publishable**: PR [#275](https://github.com/EffortlessMetrics/adze/pull/275) made core crates publishable with correct metadata.
 - ✅ **Crates.io Release Landed**: `adze` 0.8.0 and `adze-tool` 0.8.0 are published on crates.io as of 2026-04-08.
-- 🟡 **Windows benchmark tail**: [Issue #269](https://github.com/EffortlessMetrics/adze/issues/269) remains open; benchmark compile step on Windows is gated but still slower than ideal.
-- 🟡 **Worktree cleanup docs**: [Issue #268](https://github.com/EffortlessMetrics/adze/issues/268) remains open; `scripts/cleanup-worktrees.sh` exists but full contributor documentation is pending.
+- ✅ **Windows benchmark tail**: [Issue #269](https://github.com/EffortlessMetrics/adze/issues/269) routine PR benchmark compile tails are gated out of the required path; benchmark/performance signal lives in explicit opt-in lanes.
+- ✅ **Worktree cleanup docs**: [Issue #268](https://github.com/EffortlessMetrics/adze/issues/268) has helper-backed contributor guidance for linked worktrees, standalone clones, and stale metadata pruning.
 
 ## 🚀 Milestone 0.9.0: Ecosystem & Tooling (Current)
 - **Post-release hardening**: Finish narrowing workflow-only red and restore any proof surfaces trimmed only for publication.
-- **Close remaining operational issues**: Resolve [#269](https://github.com/EffortlessMetrics/adze/issues/269) (Windows benchmark tail) and [#268](https://github.com/EffortlessMetrics/adze/issues/268) (worktree cleanup docs).
+- **Close remaining operational issues**: Keep routine PR gate tails bounded; move any further worktree or benchmark-policy cleanup into focused follow-up issues instead of the old post-#264 queue.
 - **CI Hardening Beyond the Supported Gate**: Reduce advisory-lane churn and make broader workflow behavior easier to interpret.
 - **CLI Polish**: Improve the already-landed CLI surface (`adze check`, `adze stats`, etc.).
 - **Performance Optimization**: Arena allocator for parse forest nodes; benchmark suite with regression detection.

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -37,6 +37,42 @@ To run the supported gate locally:
 just ci-supported
 ```
 
+## Temporary Worktree Cleanup
+
+Adze PR work should use linked git worktrees when a branch needs an isolated checkout. A disposable standalone clone is also valid for experiments, but cleanup differs because a linked worktree has a `.git` file while a standalone clone has a `.git/` directory.
+
+After a PR lands or is abandoned:
+
+```bash
+# Inspect registered worktrees for this checkout.
+just worktree-list
+
+# Classify a specific temporary path before removing it.
+scripts/cleanup-worktrees.sh status /tmp/adze-example-pr
+```
+
+On Windows PowerShell, prefer the `just` targets for common cleanup commands. For direct script calls, run them from Git Bash or another shell where `bash` is on `PATH`.
+
+Use the helper only for registered linked worktrees:
+
+```bash
+scripts/cleanup-worktrees.sh cleanup /tmp/adze-example-pr
+```
+
+If the status command reports `standalone-repo`, inspect the path for uncommitted work and remove it manually only after confirming it is disposable:
+
+```bash
+rm -rf /tmp/adze-example-pr
+```
+
+If a temp path was already deleted and git still lists it, prune stale metadata:
+
+```bash
+just worktree-prune-stale
+```
+
+The helper refuses to remove the main repository root and refuses standalone clones so linked-worktree cleanup does not accidentally delete an independent checkout.
+
 ## Quick Commands
 
 ### Core Development

--- a/docs/status/FRICTION_LOG.md
+++ b/docs/status/FRICTION_LOG.md
@@ -1,6 +1,6 @@
 # Adze Friction Log
 
-**Last updated:** 2026-04-06
+**Last updated:** 2026-05-11
 
 If it happens twice, it's not "user error". It's friction we own until we remove it or document it well enough that it stops recurring.
 
@@ -28,7 +28,7 @@ If it happens twice, it's not "user error". It's friction we own until we remove
 | FR-016 | Testing | Compiler ICE in feature policy contract tests | Blocks test compilation under specific macro/control-flow combinations | Resolved | - |
 | FR-017 | Testing | Backend-selection expectations drift across feature-unified test surfaces | Head-specific CI red and ad hoc panic matching | Resolved | [Issue #267](https://github.com/EffortlessMetrics/adze/issues/267) |
 | FR-018 | CI | Pure-rust benchmark compilation tail in PRs | Routine PRs no longer block on low-signal benchmark compilation | Resolved for routine PRs | [Issue #269](https://github.com/EffortlessMetrics/adze/issues/269) |
-| FR-019 | Tooling | Temp worktree cleanup can drift when a `/tmp` path becomes a standalone repo | Cleanup requires manual removal and prune steps | Mitigated | [Issue #268](https://github.com/EffortlessMetrics/adze/issues/268) |
+| FR-019 | Tooling | Temp worktree cleanup can drift when a `/tmp` path becomes a standalone repo | Cleanup requires manual removal and prune steps | Resolved | [Issue #268](https://github.com/EffortlessMetrics/adze/issues/268) |
 
 ---
 
@@ -232,9 +232,8 @@ If it happens twice, it's not "user error". It's friction we own until we remove
 **Expected:** Temporary worktree cleanup should be predictable and safe after PR closeout.
 **Actual:** During PR #264 cleanup, `/tmp/adze-local-improvements` had a real `.git/` directory, `git worktree remove` failed validation, and cleanup required manual deletion plus `git worktree prune`.
 **Repro:** `fatal: validation failed, cannot remove working tree: '/tmp/adze-local-improvements/.git' is not a .git file, error code 2`
-**Fix:** Document one convention for temp worktrees vs standalone clones and add a safe validation/prune workflow for cleanup.
-**Status:** Mitigated
-**Fix:** Added `scripts/cleanup-worktrees.sh` with classification, safe cleanup, stale listing, and stale metadata pruning helpers. Contributor docs now document the closeout workflow.
+**Fix:** Added `scripts/cleanup-worktrees.sh` with classification, safe cleanup, stale listing, and stale metadata pruning helpers. `just worktree-list` and `just worktree-prune-stale` expose the common commands, and [`DEVELOPER_GUIDE.md`](../DEVELOPER_GUIDE.md) documents the closeout workflow for linked worktrees versus standalone clones.
+**Status:** Resolved
 **Links:** [Issue #268](https://github.com/EffortlessMetrics/adze/issues/268), `scripts/cleanup-worktrees.sh`
 
 ---

--- a/docs/status/NOW_NEXT_LATER.md
+++ b/docs/status/NOW_NEXT_LATER.md
@@ -16,7 +16,7 @@ Adze status and rolling execution plan. For recurring pain points, see [`docs/st
 - [x] PR [#264](https://github.com/EffortlessMetrics/adze/pull/264) merged on 2026-04-03 as commit `2a88deb6e6095682051729290987a78a0565d613`.
 - [x] The temporary convergence worktrees/branches used for the PR stack were cleaned up.
 - [x] A safety archive of the pre-cleanup dirty checkout was preserved outside `/tmp`.
-- [x] Issue #268 worktree cleanup documentation and validation is now documented and backed by a helper script.
+- [x] Issue #268 worktree cleanup documentation and validation is documented in the developer guide and backed by a helper script.
 
 ### ✅ Prior close-out state
 - [x] PR `#280` (workflow hardening) merged on 2026-04-06.
@@ -44,7 +44,7 @@ Adze status and rolling execution plan. For recurring pain points, see [`docs/st
 
 ### Operational tail
 - [x] [Issue #269](https://github.com/EffortlessMetrics/adze/issues/269): pure-rust benchmark-compilation tail is removed from routine PRs; benchmark compile/performance signal remains in explicit performance and benchmark lanes.
-- [ ] [Issue #268](https://github.com/EffortlessMetrics/adze/issues/268): Worktree cleanup script exists (`scripts/cleanup-worktrees.sh`); contributor documentation still needs finishing.
+- [x] [Issue #268](https://github.com/EffortlessMetrics/adze/issues/268): Worktree cleanup script exists (`scripts/cleanup-worktrees.sh`), `just` exposes list/prune helpers, and contributor guidance documents linked-worktree vs standalone-clone cleanup.
 - [ ] Investigate the current rustdoc-only `Documentation` lane failure separately from reader-facing markdown/status drift.
 
 ---

--- a/plans/POST-PR264-CI-FOLLOWUPS.md
+++ b/plans/POST-PR264-CI-FOLLOWUPS.md
@@ -97,4 +97,4 @@ Target outcome:
 - ✅ `main` stayed green on the supported lane throughout follow-up work.
 - ✅ Backend-selection expectations stabilized via `ParserBackendSelection` in `adze-parser-backend-core` (issue #267 closed).
 - ✅ Windows pure-rust CI benchmark tail gated to `-p adze --no-run` on Windows (PRs #276/#280 merged; issue #269 open for further trimming).
-- ✅ Temporary worktree cleanup is documented and reproducible via `scripts/cleanup-worktrees.sh` (issue #268 open for contributor guide finishing).
+- ✅ Temporary worktree cleanup is documented in contributor guidance and reproducible via `scripts/cleanup-worktrees.sh` plus `just` helper targets (issue #268 ready for closeout after merge).

--- a/scripts/cleanup-worktrees.sh
+++ b/scripts/cleanup-worktrees.sh
@@ -29,7 +29,7 @@ fi
 resolve_path() {
   local path="$1"
   local candidate
-  if [[ "$path" = /* ]]; then
+  if [[ "$path" = /* || "$path" =~ ^[A-Za-z]:[/\\] ]]; then
     candidate="$path"
   else
     candidate="$repo_root/$path"
@@ -129,16 +129,34 @@ status_path() {
 }
 
 stale_worktrees() {
-  local line worktree_path found=0
+  local line worktree_path="" prunable_reason="" found=0
+  flush_stale_record() {
+    if [[ -z "$worktree_path" ]]; then
+      return
+    fi
+    if [[ -n "$prunable_reason" ]]; then
+      echo "  $worktree_path ($prunable_reason)"
+      found=1
+    elif [[ ! -d "$worktree_path" ]]; then
+      echo "  $worktree_path (missing on disk)"
+      found=1
+    fi
+  }
+
   while IFS= read -r line; do
     if [[ "$line" == worktree* ]]; then
+      flush_stale_record
       worktree_path="${line#worktree }"
-      if [[ ! -d "$worktree_path" ]]; then
-        echo "  $worktree_path"
-        found=1
-      fi
+      prunable_reason=""
+    elif [[ "$line" == prunable* ]]; then
+      prunable_reason="${line#prunable }"
+    elif [[ -z "$line" ]]; then
+      flush_stale_record
+      worktree_path=""
+      prunable_reason=""
     fi
   done < <(worktree_records)
+  flush_stale_record
 
   if [[ "$found" == 0 ]]; then
     echo "  none"


### PR DESCRIPTION
## Summary
- document temporary worktree closeout in the developer guide, including linked worktrees vs standalone clones
- reconcile #268 status across roadmap/status docs and contributor guidance
- harden cleanup helper stale detection for Git-reported prunable entries and Windows drive-letter paths

Fixes #268.

## Validation
- git diff --check
- `C:\Program Files\Git\bin\bash.exe` -n scripts/cleanup-worktrees.sh
- `C:\Program Files\Git\bin\bash.exe` scripts/cleanup-worktrees.sh stale
- `C:\Program Files\Git\bin\bash.exe` scripts/cleanup-worktrees.sh status .
- `C:\Program Files\Git\bin\bash.exe` scripts/cleanup-worktrees.sh status C:/Code/Rust2/adze-pr335
- just --dry-run worktree-list
- just --dry-run worktree-prune-stale
- git worktree prune --dry-run --verbose