### PR TITLE
docs: map README claims to proof commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,12 @@ Support tiers, proof commands, and CI lanes are tracked in [`docs/status/SUPPORT
 | GLR conflict routing | **Stabilizing** | `cargo test -p adze --features "pure-rust,glr,runtime-e2e" --test test_e2e_ambiguous_grammar_glr test_ambiguous_grammar_glr_parsing -- --exact --nocapture`; `cargo test -p adze --features "pure-rust,glr,runtime-e2e" --test test_e2e_ambiguous_grammar_glr generated_ambiguous_expr_glr_runtime_retains_multiple_complete_alternatives -- --exact --nocapture` |
 | Tablegen TSLanguage ABI | **Stabilizing** | `cargo test -p adze --features "pure-rust,glr,ts-compat" --test tablegen_abi_decode_roundtrip combined_tslanguage_decode_preserves_metadata_fields_aliases_externals_and_lex_modes -- --exact --nocapture` |
 | Structured parse errors | **Stabilizing** | `cargo test -p adze --features "pure-rust,glr" --test generated_parse_errors generated_typed_parser_unexpected_eof_expected_field_is_populated -- --exact --nocapture`; `cargo test -p adze --features pure-rust --test generated_parse_errors expected_token_sets_are_reported -- --exact --nocapture` |
+| AdzeDocument native API | **Experimental** | `cargo test -p adze --features "pure-rust,ts-compat" --test adze_document_alpha -- --nocapture`; `cargo test -p adze --features pure-rust --test typed_cst_generated_document -- --nocapture` |
+| Typed CST native view | **Experimental** | `cargo test -p adze --features "pure-rust,ts-compat" --test typed_cst_arithmetic_spike -- --nocapture`; `cargo test -p adze-tablegen typed_cst_generator -- --nocapture` |
 | External scanners | **Experimental** | `cargo test -p adze --features external_scanners` |
 | Incremental parsing | **Experimental** | `cargo test --workspace --features incremental_glr` |
 | CLI | **Advisory** | `cargo test -p adze-cli test_init_default_cwd_generates_buildable_project -- --exact --nocapture`; `cargo test -p adze-cli test_init_cargo_toml_references_adze_dependency -- --exact --nocapture` |
+| `adze-tool` CLI | **Advisory** | `cargo test -p adze-tool --test cli_test test_test_command_rejects_corpus_without_parser -- --exact --nocapture` |
 | WASM | **Advisory** | `cargo check --manifest-path wasm-demo/Cargo.toml --target wasm32-unknown-unknown` |
 | Tree-sitter interop | **Advisory** | `./scripts/smoke-link.sh ts-bridge` |
 | Tree-sitter compatibility API | **Advisory** | `cargo test -p adze --features "pure-rust,ts-compat" --test ts_compat_node_error -- --nocapture` |


### PR DESCRIPTION
## Purpose
Close the gap between `docs/status/SUPPORT_TIERS.md` (source of truth) and the public-facing README capability table by adding missing surface entries.

## Scope
- `README.md` (3 lines added)
- Does not touch runtime, GLR, CLI, workflows, policy, or xtask

## What this does not touch
- No code changes
- No workflow changes
- No SUPPORT_TIERS.md changes (it is already complete)

## Changes
Added three missing capability table rows that exist in SUPPORT_TIERS.md but were absent from the README:
- AdzeDocument native API (Experimental)
- Typed CST native view (Experimental)
- `adze-tool` CLI (Advisory)

Each row carries a named proof command.

## Coordination
- Active PR overlap checked: yes (#642 touches runtime/tests, #643 touches xtask/)
- Shared surfaces touched: none
- GLR-engine impact: none

## Proof
```
cargo doc --workspace --no-deps
git diff --check
```

## Rollback
Revert this PR.