### PR TITLE
runtime: expose document field ids

### DIFF
--- a/runtime/src/document.rs
+++ b/runtime/src/document.rs
@@ -8,7 +8,14 @@
 use crate::parser_v4::ParseNode;
 use adze_glr_core::{ParseTable, SymbolMetadata as TableSymbolMetadata};
 use adze_ir::{Grammar, SymbolId};
+use std::num::NonZeroU16;
 use std::ops::Range;
+
+/// Nonzero public field identifier used by native document field metadata.
+///
+/// This matches Tree-sitter's public field-id convention: ID 0 is the
+/// sentinel and real field names start at 1.
+pub type FieldId = NonZeroU16;
 
 /// A native parse-product document.
 ///
@@ -164,6 +171,7 @@ struct NodeIndex {
 pub struct LanguageMetadata {
     name: String,
     symbols: Vec<NodeKind>,
+    fields: Vec<String>,
 }
 
 impl LanguageMetadata {
@@ -218,6 +226,7 @@ impl LanguageMetadata {
         Self {
             name: language_name.to_string(),
             symbols,
+            fields: parse_table.field_names.clone(),
         }
     }
 
@@ -241,6 +250,37 @@ impl LanguageMetadata {
     /// Return the display name for a symbol id.
     pub fn symbol_name(&self, symbol_id: SymbolId) -> Option<&str> {
         self.symbol(symbol_id).map(NodeKind::name)
+    }
+
+    /// Return the number of public fields in this language.
+    pub fn field_count(&self) -> usize {
+        self.fields.len()
+    }
+
+    /// Return all public field names in their zero-based table order.
+    ///
+    /// Public field IDs are one-based, so `fields()[0]` corresponds to
+    /// [`field_name_for_id(1)`](Self::field_name_for_id).
+    pub fn fields(&self) -> &[String] {
+        &self.fields
+    }
+
+    /// Return a field name for a nonzero public field id.
+    pub fn field_name_for_id(&self, field_id: u16) -> Option<&str> {
+        let index = field_id.checked_sub(1)? as usize;
+        self.fields.get(index).map(String::as_str)
+    }
+
+    /// Return the nonzero public field id for a field name.
+    pub fn field_id_for_name(&self, field_name: impl AsRef<[u8]>) -> Option<FieldId> {
+        let field_name = field_name.as_ref();
+        self.fields
+            .iter()
+            .position(|candidate| candidate.as_bytes() == field_name)
+            .and_then(|index| {
+                let field_id = u16::try_from(index.checked_add(1)?).ok()?;
+                FieldId::new(field_id)
+            })
     }
 }
 
@@ -577,6 +617,12 @@ impl<'doc> AdzeNode<'doc> {
         self.node.field_name.as_deref()
     }
 
+    /// Return the public field id attached to this node's parent edge, if any.
+    pub fn field_id(&self) -> Option<FieldId> {
+        self.field_name()
+            .and_then(|field_name| self.document.language().field_id_for_name(field_name))
+    }
+
     /// Return the number of direct children.
     pub fn child_count(&self) -> usize {
         self.node.children.len()
@@ -597,6 +643,10 @@ impl<'doc> AdzeNode<'doc> {
             child_index: index,
             child_id,
             field_name: child.field_name.as_deref(),
+            field_id: child
+                .field_name
+                .as_deref()
+                .and_then(|field_name| self.document.language().field_id_for_name(field_name)),
         })
     }
 
@@ -681,6 +731,7 @@ pub struct AdzeEdge<'doc> {
     child_index: usize,
     child_id: NodeId,
     field_name: Option<&'doc str>,
+    field_id: Option<FieldId>,
 }
 
 impl<'doc> AdzeEdge<'doc> {
@@ -707,6 +758,11 @@ impl<'doc> AdzeEdge<'doc> {
     /// Return the field name attached to this edge, if any.
     pub fn field_name(&self) -> Option<&'doc str> {
         self.field_name
+    }
+
+    /// Return the public field id attached to this edge, if any.
+    pub fn field_id(&self) -> Option<FieldId> {
+        self.field_id
     }
 }
 

--- a/runtime/tests/adze_document_alpha.rs
+++ b/runtime/tests/adze_document_alpha.rs
@@ -46,6 +46,33 @@ fn parse_document_exposes_generic_tree_and_ts_projection_from_same_parse() {
     assert_eq!(document.source_text(), source);
     assert_eq!(document.source_bytes(), source.as_bytes());
     assert_eq!(document.language().name(), lang.name.as_str());
+    assert_eq!(document.language().field_count(), 3);
+    assert_eq!(document.language().field_name_for_id(0), None);
+    assert_eq!(document.language().field_name_for_id(1), Some("left"));
+    assert_eq!(document.language().field_name_for_id(2), Some("operator"));
+    assert_eq!(document.language().field_name_for_id(3), Some("right"));
+    assert_eq!(
+        document
+            .language()
+            .field_id_for_name("left")
+            .map(|id| id.get()),
+        Some(1)
+    );
+    assert_eq!(
+        document
+            .language()
+            .field_id_for_name("operator")
+            .map(|id| id.get()),
+        Some(2)
+    );
+    assert_eq!(
+        document
+            .language()
+            .field_id_for_name(b"right")
+            .map(|id| id.get()),
+        Some(3)
+    );
+    assert_eq!(document.language().field_id_for_name("missing"), None);
     assert_eq!(document.metadata().error_count, 0);
     assert!(document.diagnostics().is_empty());
 
@@ -86,6 +113,7 @@ fn parse_document_exposes_generic_tree_and_ts_projection_from_same_parse() {
     assert_eq!(root_expression_edge.parent_id(), root.node_id());
     assert_eq!(root_expression_edge.child_index(), 0);
     assert_eq!(root_expression_edge.field_name(), None);
+    assert_eq!(root_expression_edge.field_id(), None);
 
     let expression = root.child(0).expect("root should expose expression child");
     assert_eq!(root_expression_edge.child_id(), expression.node_id());
@@ -134,6 +162,11 @@ fn parse_document_exposes_generic_tree_and_ts_projection_from_same_parse() {
     assert_eq!(edges[0].child_index(), 0);
     assert_eq!(edges[0].child_id(), left.node_id());
     assert_eq!(edges[0].field_name(), Some("left"));
+    assert_eq!(edges[0].field_id().map(|id| id.get()), Some(1));
+    assert_eq!(edges[1].field_name(), Some("operator"));
+    assert_eq!(edges[1].field_id().map(|id| id.get()), Some(2));
+    assert_eq!(edges[2].field_name(), Some("right"));
+    assert_eq!(edges[2].field_id().map(|id| id.get()), Some(3));
     assert_eq!(
         expression
             .edge_by_field_name("left")
@@ -161,13 +194,16 @@ fn parse_document_exposes_generic_tree_and_ts_projection_from_same_parse() {
         "1"
     );
     assert_eq!(left.field_name(), Some("left"));
+    assert_eq!(left.field_id().map(|id| id.get()), Some(1));
     assert_eq!(left.utf8_text().expect("left text should be UTF-8"), "1");
     assert_eq!(operator.field_name(), Some("operator"));
+    assert_eq!(operator.field_id().map(|id| id.get()), Some(2));
     assert_eq!(
         operator.utf8_text().expect("operator text should be UTF-8"),
         "-"
     );
     assert_eq!(right.field_name(), Some("right"));
+    assert_eq!(right.field_id().map(|id| id.get()), Some(3));
     assert_eq!(right.utf8_text().expect("right text should be UTF-8"), "2");
 
     let ts_tree = Tree::from_document(Arc::clone(&lang), &document);
@@ -185,6 +221,33 @@ fn parse_document_exposes_generic_tree_and_ts_projection_from_same_parse() {
     assert_eq!(ts_expression.field_name_for_child(0), Some("left"));
     assert_eq!(ts_expression.field_name_for_child(1), Some("operator"));
     assert_eq!(ts_expression.field_name_for_child(2), Some("right"));
+    assert_eq!(
+        ts_expression
+            .field_id_for_child(0)
+            .map(|field_id| field_id.get()),
+        expression
+            .child_edge(0)
+            .and_then(|edge| edge.field_id())
+            .map(|field_id| field_id.get())
+    );
+    assert_eq!(
+        ts_expression
+            .field_id_for_child(1)
+            .map(|field_id| field_id.get()),
+        expression
+            .child_edge(1)
+            .and_then(|edge| edge.field_id())
+            .map(|field_id| field_id.get())
+    );
+    assert_eq!(
+        ts_expression
+            .field_id_for_child(2)
+            .map(|field_id| field_id.get()),
+        expression
+            .child_edge(2)
+            .and_then(|edge| edge.field_id())
+            .map(|field_id| field_id.get())
+    );
     assert_eq!(
         ts_expression
             .child_by_field_name("left")


### PR DESCRIPTION
## Summary
- retain public field names in native `LanguageMetadata`
- expose nonzero public field IDs from native document language metadata, parent-edge nodes, and `AdzeEdge`
- extend the `adze_document_alpha` canary so native edge field IDs and the Tree-sitter projection agree

## Proof
- `cargo test -p adze --features "pure-rust,ts-compat" --test adze_document_alpha parse_document_exposes_generic_tree_and_ts_projection_from_same_parse -- --exact --nocapture`
- `cargo test -p adze --features "pure-rust,ts-compat" --test ts_compat_language_fields node_field_ids_match_language_field_ids -- --exact --nocapture`
- `cargo test -p adze --features "pure-rust,ts-compat" --test typed_cst_arithmetic_spike typed_cst_scaffold_projects_from_document_node_ids_and_edges -- --exact --nocapture`
- `cargo test -p adze --features "pure-rust,ts-compat" --test adze_document_alpha -- --nocapture`
- `cargo clippy -p adze --features "pure-rust,ts-compat" --tests -- -D warnings`
- `cargo fmt -p adze -- --check`
- `git diff --check`
