### PR TITLE
runtime: add document field id lookup

### DIFF
--- a/runtime/src/document.rs
+++ b/runtime/src/document.rs
@@ -660,6 +660,11 @@ impl<'doc> AdzeNode<'doc> {
         self.child_edge(index).and_then(|edge| edge.field_name())
     }
 
+    /// Return the public field id for a child edge by index.
+    pub fn field_id_for_child(&self, index: usize) -> Option<FieldId> {
+        self.child_edge(index).and_then(|edge| edge.field_id())
+    }
+
     /// Return the first child edge attached through the given field name.
     pub fn edge_by_field_name(&self, field_name: &str) -> Option<AdzeEdge<'doc>> {
         self.child_edges()
@@ -669,6 +674,13 @@ impl<'doc> AdzeNode<'doc> {
     /// Return the first child attached through the given field name.
     pub fn child_by_field_name(&self, field_name: &str) -> Option<AdzeNode<'doc>> {
         self.edge_by_field_name(field_name)?.child()
+    }
+
+    /// Return the first child attached through the given public field id.
+    pub fn child_by_field_id(&self, field_id: FieldId) -> Option<AdzeNode<'doc>> {
+        self.child_edges()
+            .find(|edge| edge.field_id() == Some(field_id))?
+            .child()
     }
 
     /// Return whether this node is named according to language metadata.

--- a/runtime/tests/adze_document_alpha.rs
+++ b/runtime/tests/adze_document_alpha.rs
@@ -148,6 +148,22 @@ fn parse_document_exposes_generic_tree_and_ts_projection_from_same_parse() {
     assert_eq!(expression.field_name_for_child(0), Some("left"));
     assert_eq!(expression.field_name_for_child(1), Some("operator"));
     assert_eq!(expression.field_name_for_child(2), Some("right"));
+    let left_field_id = document
+        .language()
+        .field_id_for_name("left")
+        .expect("left field should resolve");
+    let operator_field_id = document
+        .language()
+        .field_id_for_name("operator")
+        .expect("operator field should resolve");
+    let right_field_id = document
+        .language()
+        .field_id_for_name("right")
+        .expect("right field should resolve");
+    assert_eq!(expression.field_id_for_child(0), Some(left_field_id));
+    assert_eq!(expression.field_id_for_child(1), Some(operator_field_id));
+    assert_eq!(expression.field_id_for_child(2), Some(right_field_id));
+    assert_eq!(expression.field_id_for_child(3), None);
     assert!(expression.child_edge(3).is_none());
     assert!(expression.edge_by_field_name("missing").is_none());
     assert!(expression.child_by_field_name("missing").is_none());
@@ -180,6 +196,27 @@ fn parse_document_exposes_generic_tree_and_ts_projection_from_same_parse() {
             .expect("operator field should resolve")
             .node_id(),
         operator.node_id()
+    );
+    assert_eq!(
+        expression
+            .child_by_field_id(left_field_id)
+            .expect("left field id should resolve")
+            .node_id(),
+        left.node_id()
+    );
+    assert_eq!(
+        expression
+            .child_by_field_id(operator_field_id)
+            .expect("operator field id should resolve")
+            .node_id(),
+        operator.node_id()
+    );
+    assert_eq!(
+        expression
+            .child_by_field_id(right_field_id)
+            .expect("right field id should resolve")
+            .node_id(),
+        right.node_id()
     );
     assert_ne!(left.node_id(), operator.node_id());
     assert_ne!(operator.node_id(), right.node_id());


### PR DESCRIPTION
## Summary
- add native `AdzeNode::field_id_for_child` lookup over document edge metadata
- add native `AdzeNode::child_by_field_id` lookup using the document `FieldId` type
- extend the `adze_document_alpha` canary to prove field-name and field-id child lookup resolve to the same document nodes

## Proof
- `cargo test -p adze --features "pure-rust,ts-compat" --test adze_document_alpha parse_document_exposes_generic_tree_and_ts_projection_from_same_parse -- --exact --nocapture`
- `cargo test -p adze --features "pure-rust,ts-compat" --test adze_document_alpha -- --nocapture`
- `cargo clippy -p adze --features "pure-rust,ts-compat" --tests -- -D warnings`
- `cargo fmt -p adze -- --check`
- `git diff --check`
