### PR TITLE
runtime: expose document node point ranges

### DIFF
--- a/runtime/src/document.rs
+++ b/runtime/src/document.rs
@@ -602,6 +602,11 @@ impl<'doc> AdzeNode<'doc> {
         self.start_byte()..self.end_byte()
     }
 
+    /// Return this node's zero-based point range.
+    pub fn point_range(&self) -> PointRange {
+        PointRange::from_byte_range(self.document.source_text(), self.byte_range())
+    }
+
     /// Return this node's source text if the byte range is valid UTF-8.
     pub fn utf8_text(&self) -> Result<&'doc str, std::str::Utf8Error> {
         let slice = self
@@ -805,6 +810,11 @@ pub trait SyntaxNode<'doc>: Copy {
     /// Return this handle's byte range, when the node resolves.
     fn byte_range(&self) -> Option<Range<usize>> {
         self.node().map(|node| node.byte_range())
+    }
+
+    /// Return this handle's zero-based point range, when the node resolves.
+    fn point_range(&self) -> Option<PointRange> {
+        self.node().map(|node| node.point_range())
     }
 
     /// Return this handle's source text, when the range is a valid UTF-8 slice.

--- a/runtime/tests/typed_cst_generated_document.rs
+++ b/runtime/tests/typed_cst_generated_document.rs
@@ -244,6 +244,40 @@ fn generated_typed_cst_wrappers_cast_generic_document_nodes() {
 }
 
 #[test]
+fn generated_typed_cst_wrappers_share_document_point_ranges() {
+    let source = "1+\n2+3";
+    let document = adze_example::typed_ast_contract::grammar::parse_document(source)
+        .expect("generated parse_document helper should return a multiline AdzeDocument");
+    let root = document.tree().root();
+    let syntax = adze_example::typed_ast_contract::grammar::syntax::source_file(&document)
+        .expect("generated source_file wrapper should cast the generic root");
+
+    assert_eq!(syntax.point_range(), Some(root.point_range()));
+    assert_eq!(root.point_range().start.row, 0);
+    assert_eq!(root.point_range().start.column, 0);
+    assert_eq!(root.point_range().end.row, 1);
+    assert_eq!(root.point_range().end.column, 3);
+
+    let second_number =
+        find_node(root, "/\\d+/", "2").expect("generic CST should contain the second-line token");
+    let wrapper = adze_example::typed_ast_contract::grammar::syntax::DToken::cast(
+        &document,
+        second_number.node_id(),
+    )
+    .expect("generated number token wrapper should cast the matching generic node");
+    let point_range = wrapper
+        .point_range()
+        .expect("typed CST wrapper should expose the generic node point range");
+
+    assert_same_node(wrapper, second_number);
+    assert_eq!(point_range, second_number.point_range());
+    assert_eq!(point_range.start.row, 1);
+    assert_eq!(point_range.start.column, 0);
+    assert_eq!(point_range.end.row, 1);
+    assert_eq!(point_range.end.column, 1);
+}
+
+#[test]
 fn generated_typed_cst_field_accessors_project_native_edges() {
     let source = "123+";
     let document = adze_example::fielded_typed_cst_contract::grammar::parse_document(source)
@@ -346,6 +380,7 @@ fn assert_same_node<'doc>(wrapper: impl SyntaxNode<'doc>, node: adze::document::
     assert_eq!(wrapper.node_id(), node.node_id());
     assert_eq!(wrapper.kind_name(), node.kind_name());
     assert_eq!(wrapper.byte_range(), Some(node.byte_range()));
+    assert_eq!(wrapper.point_range(), Some(node.point_range()));
     assert_eq!(wrapper.text(), node.utf8_text().ok());
 }
 


### PR DESCRIPTION
## Summary
- add `AdzeNode::point_range()` over the document source text
- add `SyntaxNode::point_range()` so generated typed CST wrappers can expose the same native point range
- add a multiline generated-document canary proving wrapper and generic CST point ranges agree for a second-line token

## Proof
- `cargo test -p adze --features pure-rust --test typed_cst_generated_document generated_typed_cst_wrappers_share_document_point_ranges -- --exact --nocapture`
- `cargo test -p adze --features pure-rust --test typed_cst_generated_document -- --nocapture`
- `cargo clippy -p adze --features pure-rust --tests -- -D warnings`
- `cargo fmt -p adze -- --check`
- `git diff --check`
