### PR TITLE
runtime: extract typed ast from typed cst nodes

### DIFF
--- a/docs/design/typed-cst.md
+++ b/docs/design/typed-cst.md
@@ -195,10 +195,13 @@ pub enum Provenance {
 
 This avoids pretending every semantic AST value maps to exactly one CST node.
 
-The current `AdzeDocument` alpha exposes only document-level typed AST
-provenance for the extraction root through `ast_with_provenance()`. Per-AST-node
-provenance remains future work and should not be inferred from that alpha
-wrapper.
+The current `AdzeDocument` alpha exposes document-level typed AST provenance for
+the extraction root through `ast_with_provenance()`. It also exposes
+`AdzeDocument::ast_from_node(...)` and the default `SyntaxNode::ast(...)` helper,
+so a validated typed CST wrapper can extract a semantic AST value from its own
+document node while recording that node as the extraction provenance.
+Per-AST-node provenance remains future work and should not be inferred from
+that alpha wrapper.
 
 ## Generation Scope
 
@@ -376,10 +379,13 @@ cargo test -p adze --features pure-rust \
 It checks that Rust expansion keeps explicit field metadata when precedence
 operator leaves are inlined, that generated token wrappers cast against the
 native document's inline-string kind names, and that generated `Expr_Add`
-accessors agree with the generic CST edges. Generated parser modules do not yet
-have a broad typed CST/generic CST parity matrix, visitor/rewriter surfaces,
-typed query APIs, or typed CST JSON output, and this is not a public typed CST
-support claim.
+accessors agree with the generic CST edges. The same runtime canary now proves a
+validated `Expr_Add` typed CST wrapper can extract the semantic `Expr` typed AST
+from its own node through `SyntaxNode::ast(...)`, with `Provenance::Node`
+recording the wrapper node. Generated parser modules do not yet have a broad
+typed CST/generic CST parity matrix, visitor/rewriter surfaces, typed query
+APIs, or typed CST JSON output, and this is not a public typed CST support
+claim.
 
 ## Support Status
 

--- a/docs/status/CORRECTNESS_PUSH.md
+++ b/docs/status/CORRECTNESS_PUSH.md
@@ -98,8 +98,10 @@ Keep implementation slices small:
    and generated typed CST `left`/`right` accessors. A follow-on generated
    precedence enum canary now proves explicit `left`/`operator`/`right` fields
    survive precedence operator inlining into native edge metadata and generated
-   typed CST accessors without expanding into visitors, rewriters, typed
-   queries, or JSON output.
+   typed CST accessors. The same runtime canary now proves a validated typed
+   CST wrapper can extract a semantic typed AST from its own document node while
+   preserving document-level node provenance, without expanding into visitors,
+   rewriters, typed queries, or JSON output.
 3. Alias-visible compatibility canaries only after native node identity is
    populated from parser alias sequence data, not merely the current raw-symbol
    identity slots.

--- a/docs/status/SUPPORT_TIERS.md
+++ b/docs/status/SUPPORT_TIERS.md
@@ -13,6 +13,12 @@ This document maps major Adze surfaces to five tiers:
 
 ## Feature-to-proof map
 
+Current native-document and typed-CST alpha notes: generated typed CST handles
+can now call the default `SyntaxNode::ast(...)` helper, which delegates to
+`AdzeDocument::ast_from_node(...)` and records `Provenance::Node` for the wrapper
+node used as the extraction root. This remains experimental document-level
+provenance, not per-AST-node provenance or a typed CST support promotion.
+
 | Surface | Tier | Proof command | CI lane | Notes / limitations |
 |---|---|---|---|---|
 | Typed extraction | **Stable** | `cargo test -p adze --lib --tests --bins` (via `just ci-supported`); product canaries: `cargo test -p adze --features pure-rust --test typed_ast_contract typed_ast_contract_left_associative_addition -- --exact --nocapture`, `cargo test -p adze --features pure-rust --test typed_ast_contract typed_ast_contract_repeated_parse_is_deterministic -- --exact --nocapture`, `cargo test -p adze-cli readme_arithmetic_quickstart_builds_and_runs -- --exact --nocapture` | `CI / ci-supported`; `ci-product-stable`; product-proof advisory | Core user contract via `adze` runtime tests in the supported lane, with exact-value, repeated-parse determinism, and README quickstart parse/diagnostic canaries in the stable/advisory product lanes. |

--- a/runtime/src/document.rs
+++ b/runtime/src/document.rs
@@ -178,25 +178,7 @@ impl AdzeDocument {
     where
         T: crate::Extract<T>,
     {
-        if !self.diagnostics.is_empty() {
-            return Err(self
-                .diagnostics
-                .iter()
-                .map(ParseDiagnostic::to_parse_error)
-                .collect());
-        }
-
-        let Some(language) = self.pure_language else {
-            return Err(vec![crate::errors::ParseError {
-                reason: crate::errors::ParseErrorReason::UnexpectedToken(
-                    "typed AST extraction requires generated pure-Rust language metadata"
-                        .to_string(),
-                ),
-                start: 0,
-                end: 0,
-                expected: Vec::new(),
-            }]);
-        };
+        let language = self.typed_ast_language()?;
 
         let parsed_root = document_node_to_parsed_node(&self.root, language, self.source_bytes());
         let extraction_target = self.typed_ast_extraction_target();
@@ -211,6 +193,43 @@ impl AdzeDocument {
         Ok(TypedAst {
             value,
             provenance: extraction_target.provenance,
+        })
+    }
+
+    /// Extract a typed AST from a specific document node.
+    ///
+    /// This supports typed CST handles as cheap syntax views: generated wrappers
+    /// validate their node kind, then ask the backing document to extract the
+    /// semantic value from that exact node. The returned provenance records the
+    /// supplied node id. Documents with parser diagnostics return those
+    /// diagnostics as parse errors instead of extracting from recovered syntax.
+    pub fn ast_from_node<T>(
+        &self,
+        node_id: NodeId,
+    ) -> Result<TypedAst<T>, Vec<crate::errors::ParseError>>
+    where
+        T: crate::Extract<T>,
+    {
+        let language = self.typed_ast_language()?;
+        let Some(node) = self.node_by_id(node_id) else {
+            return Err(vec![crate::errors::ParseError {
+                reason: crate::errors::ParseErrorReason::UnexpectedToken(format!(
+                    "typed AST extraction node {} does not exist in document",
+                    node_id.as_usize()
+                )),
+                start: 0,
+                end: 0,
+                expected: Vec::new(),
+            }]);
+        };
+
+        let parsed_node = document_node_to_parsed_node(node, language, self.source_bytes());
+        let value =
+            <T as crate::Extract<_>>::extract(Some(&parsed_node), self.source_bytes(), 0, None);
+
+        Ok(TypedAst {
+            value,
+            provenance: Provenance::Node(node_id),
         })
     }
 
@@ -270,6 +289,30 @@ impl AdzeDocument {
             child_index: None,
             provenance: Provenance::Node(root.node_id()),
         }
+    }
+
+    fn typed_ast_language(
+        &self,
+    ) -> Result<&'static crate::pure_parser::TSLanguage, Vec<crate::errors::ParseError>> {
+        if !self.diagnostics.is_empty() {
+            return Err(self
+                .diagnostics
+                .iter()
+                .map(ParseDiagnostic::to_parse_error)
+                .collect());
+        }
+
+        self.pure_language.ok_or_else(|| {
+            vec![crate::errors::ParseError {
+                reason: crate::errors::ParseErrorReason::UnexpectedToken(
+                    "typed AST extraction requires generated pure-Rust language metadata"
+                        .to_string(),
+                ),
+                start: 0,
+                end: 0,
+                expected: Vec::new(),
+            }]
+        })
     }
 }
 
@@ -1281,6 +1324,19 @@ pub trait SyntaxNode<'doc>: Copy {
     /// Return whether this handle resolves to syntax that carries error state.
     fn has_error(&self) -> bool {
         self.node().map(|node| node.has_error()).unwrap_or(false)
+    }
+
+    /// Extract a typed AST from this typed CST handle's node.
+    ///
+    /// This is an alpha bridge between typed CST and typed AST views. The
+    /// wrapper remains a cheap node handle; extraction still happens through
+    /// the backing [`AdzeDocument`] and records this handle's node id as
+    /// document-level provenance.
+    fn ast<T>(&self) -> Result<TypedAst<T>, Vec<crate::errors::ParseError>>
+    where
+        T: crate::Extract<T>,
+    {
+        self.document().ast_from_node(self.node_id())
     }
 }
 

--- a/runtime/tests/typed_cst_generated_document.rs
+++ b/runtime/tests/typed_cst_generated_document.rs
@@ -386,6 +386,29 @@ fn generated_typed_cst_field_accessors_survive_precedence_enum_variants() {
     assert_eq!(right.text(), Some("2*3"));
 }
 
+#[test]
+fn generated_typed_cst_wrapper_extracts_typed_ast_from_its_node() {
+    use adze::document::Provenance;
+    use adze_example::fielded_precedence_typed_cst_contract::grammar::{self, Expr};
+
+    let source = "1+2*3";
+    let expected = grammar::parse(source).expect("fielded precedence grammar should parse");
+    let document = grammar::parse_document(source)
+        .expect("generated parse_document helper should return an AdzeDocument");
+    let root = document.tree().root();
+    let add_node =
+        find_node(root, "Expr_Add", source).expect("generic CST should contain the add node");
+    let add = grammar::syntax::ExprAdd::cast(&document, add_node.node_id())
+        .expect("generated Expr_Add wrapper should cast the matching generic node");
+
+    let typed_ast = add
+        .ast::<Expr>()
+        .expect("typed CST wrapper should extract typed AST from its own node");
+
+    assert_eq!(typed_ast.value(), &expected);
+    assert_eq!(typed_ast.provenance(), &Provenance::Node(add.node_id()));
+}
+
 fn assert_same_node<'doc>(wrapper: impl SyntaxNode<'doc>, node: adze::document::AdzeNode<'doc>) {
     assert_eq!(wrapper.node_id(), node.node_id());
     assert_eq!(wrapper.kind_name(), node.kind_name());


### PR DESCRIPTION
## Summary

- add `AdzeDocument::ast_from_node(...)` for typed AST extraction from a specific document node
- add the default `SyntaxNode::ast(...)` bridge for generated typed CST wrappers
- add a generated precedence typed-CST canary proving wrapper-node extraction preserves `Provenance::Node`
- update typed-CST/native support docs without promoting the surface

## Validation

- `cargo fmt -p adze -- --check`
- `git diff --check`
- `cargo test -p adze --features pure-rust --test typed_cst_generated_document -- --nocapture`
- `cargo test -p adze --features pure-rust --test typed_ast_contract -- --nocapture`
- `cargo test -p adze --features pure-rust --test typed_cst_generated_document generated_typed_cst_wrapper_extracts_typed_ast_from_its_node -- --exact --nocapture`
- `cargo check -p adze --features "pure-rust,ts-compat,strict_docs"`
- `cargo clippy -p adze --features "pure-rust,ts-compat" --all-targets -- -D warnings`

## Local host blockers

- `cargo fmt --all -- --check` is blocked locally by Windows `os error 206`.
- `just ci-supported` is blocked locally by missing `cygpath`; hosted `CI / ci-supported` is authoritative.