### PR TITLE
runtime: snapshot native document json alpha

### DIFF
--- a/docs/design/adze-document.md
+++ b/docs/design/adze-document.md
@@ -314,7 +314,8 @@ The current alpha implements only `AdzeDocument::to_json_value()` under the
 `serialization` feature. It emits an experimental `adze.document.v1` envelope
 for the selected generic CST, source byte length, language name, metadata,
 structured diagnostics, and ambiguity summaries. This is a document canary for
-future output work, not a stable CLI/WASM `adze-json` contract.
+future output work; snapshot fixtures pin representative clean and diagnostic
+documents, but this is not a stable CLI/WASM `adze-json` contract.
 
 No JSON schema should be treated as stable until it has a fixture, snapshot, and
 support-tier entry.

--- a/docs/status/CORRECTNESS_PUSH.md
+++ b/docs/status/CORRECTNESS_PUSH.md
@@ -85,9 +85,10 @@ Keep implementation slices small:
    `ts_compat::Tree::from_document()` over the same parse data. It now also
    has an experimental `AdzeDocument::to_json_value()` projection under
    `serialization` that emits schema-tagged `adze.document.v1` facts for the
-   selected generic CST, diagnostics, metadata, and ambiguity summaries. Keep
-   expanding it in small proof-backed slices, and do not treat this as a stable
-   CLI/WASM `adze-json` contract.
+   selected generic CST, diagnostics, metadata, and ambiguity summaries, with
+   representative clean and diagnostic document snapshots. Keep expanding it in
+   small proof-backed slices, and do not treat this as a stable CLI/WASM
+   `adze-json` contract.
 2. A typed CST arithmetic spike now proves a generated-style fixture module,
    the runtime `SyntaxNode` handle contract, typed field accessors, spans,
    text, and recovery flags over document node IDs. Tablegen also has an alpha

--- a/docs/status/SUPPORT_TIERS.md
+++ b/docs/status/SUPPORT_TIERS.md
@@ -20,7 +20,8 @@ node used as the extraction root. This remains experimental document-level
 provenance, not per-AST-node provenance or a typed CST support promotion.
 `AdzeDocument::to_json_value()` now emits an experimental
 `adze.document.v1` envelope under the `serialization` feature for the same
-selected generic CST, diagnostics, metadata, and ambiguity summary facts. Proof:
+selected generic CST, diagnostics, metadata, and ambiguity summary facts, with
+snapshot fixtures for clean and diagnostic documents. Proof:
 `cargo test -p adze --features "pure-rust,serialization" --test adze_document_json -- --nocapture`.
 This is not a stable CLI/WASM `adze-json` contract.
 

--- a/runtime/tests/adze_document_json.rs
+++ b/runtime/tests/adze_document_json.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 fn parse_document_json_has_schema_and_tree_facts() {
     use adze_example::fielded_precedence_typed_cst_contract::grammar;
 
-    let source = "1+2*3";
+    let source = "1+2";
     let document = grammar::parse_document(source)
         .expect("generated parse_document helper should return an AdzeDocument");
     let json = document.to_json_value();
@@ -56,6 +56,11 @@ fn parse_document_json_has_schema_and_tree_facts() {
             .iter()
             .all(|edge| edge["node"]["id"].as_u64().is_some()),
         "fielded edges should serialize nested child nodes: {children:?}"
+    );
+
+    insta::assert_snapshot!(
+        "adze_document_json_fielded_precedence",
+        serde_json::to_string_pretty(&json).expect("document JSON should render as pretty JSON")
     );
 }
 
@@ -113,6 +118,12 @@ fn parse_document_json_serializes_diagnostics_and_error_flags() {
             .as_str()
             .is_some_and(|message| message.contains("expected one of:")),
         "diagnostic JSON should preserve the diagnostic summary: {diagnostic:?}"
+    );
+
+    insta::assert_snapshot!(
+        "adze_document_json_diagnostic",
+        serde_json::to_string_pretty(&json)
+            .expect("diagnostic document JSON should render as pretty JSON")
     );
 }
 

--- a/runtime/tests/snapshots/adze_document_json__adze_document_json_diagnostic.snap
+++ b/runtime/tests/snapshots/adze_document_json__adze_document_json_diagnostic.snap
@@ -1,0 +1,115 @@
+---
+source: runtime/tests/adze_document_json.rs
+expression: "serde_json::to_string_pretty(&json).expect(\"diagnostic document JSON should render as pretty JSON\")"
+---
+{
+  "schema": "adze.document.v1",
+  "source": {
+    "byte_len": 3
+  },
+  "language": {
+    "name": "typed_ast_contract"
+  },
+  "metadata": {
+    "error_count": 1
+  },
+  "diagnostics": [
+    {
+      "start_byte": 3,
+      "end_byte": 3,
+      "point_range": {
+        "start": {
+          "row": 0,
+          "column": 3
+        },
+        "end": {
+          "row": 0,
+          "column": 3
+        }
+      },
+      "found": "end",
+      "expected": [
+        "/\\d+/"
+      ],
+      "related_nodes": [
+        1
+      ],
+      "message": "end; expected one of: /\\d+/"
+    }
+  ],
+  "ambiguities": [],
+  "tree": {
+    "root": {
+      "id": 0,
+      "kind": "Whitespace__ws",
+      "kind_id": 4,
+      "grammar_kind": "Whitespace__ws",
+      "grammar_id": 4,
+      "alias_symbol_id": null,
+      "has_alias": false,
+      "range": {
+        "start_byte": 0,
+        "end_byte": 3,
+        "start_point": {
+          "row": 0,
+          "column": 0
+        },
+        "end_point": {
+          "row": 0,
+          "column": 3
+        }
+      },
+      "flags": {
+        "named": true,
+        "visible": true,
+        "extra": false,
+        "terminal": false,
+        "supertype": false,
+        "error": false,
+        "missing": false,
+        "has_error": true
+      },
+      "text": null,
+      "children": [
+        {
+          "child_index": 0,
+          "field_name": null,
+          "field_id": null,
+          "node": {
+            "id": 1,
+            "kind": "end",
+            "kind_id": 0,
+            "grammar_kind": "end",
+            "grammar_id": 0,
+            "alias_symbol_id": null,
+            "has_alias": false,
+            "range": {
+              "start_byte": 3,
+              "end_byte": 3,
+              "start_point": {
+                "row": 0,
+                "column": 3
+              },
+              "end_point": {
+                "row": 0,
+                "column": 3
+              }
+            },
+            "flags": {
+              "named": false,
+              "visible": true,
+              "extra": false,
+              "terminal": true,
+              "supertype": false,
+              "error": true,
+              "missing": true,
+              "has_error": true
+            },
+            "text": "",
+            "children": []
+          }
+        }
+      ]
+    }
+  }
+}

--- a/runtime/tests/snapshots/adze_document_json__adze_document_json_fielded_precedence.snap
+++ b/runtime/tests/snapshots/adze_document_json__adze_document_json_fielded_precedence.snap
@@ -1,0 +1,324 @@
+---
+source: runtime/tests/adze_document_json.rs
+expression: "serde_json::to_string_pretty(&json).expect(\"document JSON should render as pretty JSON\")"
+---
+{
+  "schema": "adze.document.v1",
+  "source": {
+    "byte_len": 3
+  },
+  "language": {
+    "name": "fielded_precedence_typed_cst_contract"
+  },
+  "metadata": {
+    "error_count": 0
+  },
+  "diagnostics": [],
+  "ambiguities": [],
+  "tree": {
+    "root": {
+      "id": 0,
+      "kind": "source_file",
+      "kind_id": 1,
+      "grammar_kind": "source_file",
+      "grammar_id": 1,
+      "alias_symbol_id": null,
+      "has_alias": false,
+      "range": {
+        "start_byte": 0,
+        "end_byte": 3,
+        "start_point": {
+          "row": 0,
+          "column": 0
+        },
+        "end_point": {
+          "row": 0,
+          "column": 3
+        }
+      },
+      "flags": {
+        "named": true,
+        "visible": true,
+        "extra": false,
+        "terminal": false,
+        "supertype": false,
+        "error": false,
+        "missing": false,
+        "has_error": false
+      },
+      "text": null,
+      "children": [
+        {
+          "child_index": 0,
+          "field_name": null,
+          "field_id": null,
+          "node": {
+            "id": 1,
+            "kind": "Expr",
+            "kind_id": 4,
+            "grammar_kind": "Expr",
+            "grammar_id": 4,
+            "alias_symbol_id": null,
+            "has_alias": false,
+            "range": {
+              "start_byte": 0,
+              "end_byte": 3,
+              "start_point": {
+                "row": 0,
+                "column": 0
+              },
+              "end_point": {
+                "row": 0,
+                "column": 3
+              }
+            },
+            "flags": {
+              "named": true,
+              "visible": true,
+              "extra": false,
+              "terminal": false,
+              "supertype": false,
+              "error": false,
+              "missing": false,
+              "has_error": false
+            },
+            "text": null,
+            "children": [
+              {
+                "child_index": 0,
+                "field_name": null,
+                "field_id": null,
+                "node": {
+                  "id": 2,
+                  "kind": "Expr_Add",
+                  "kind_id": 2,
+                  "grammar_kind": "Expr_Add",
+                  "grammar_id": 2,
+                  "alias_symbol_id": null,
+                  "has_alias": false,
+                  "range": {
+                    "start_byte": 0,
+                    "end_byte": 3,
+                    "start_point": {
+                      "row": 0,
+                      "column": 0
+                    },
+                    "end_point": {
+                      "row": 0,
+                      "column": 3
+                    }
+                  },
+                  "flags": {
+                    "named": true,
+                    "visible": true,
+                    "extra": false,
+                    "terminal": false,
+                    "supertype": false,
+                    "error": false,
+                    "missing": false,
+                    "has_error": false
+                  },
+                  "text": null,
+                  "children": [
+                    {
+                      "child_index": 0,
+                      "field_name": "left",
+                      "field_id": 2,
+                      "node": {
+                        "id": 3,
+                        "kind": "Expr",
+                        "kind_id": 4,
+                        "grammar_kind": "Expr",
+                        "grammar_id": 4,
+                        "alias_symbol_id": null,
+                        "has_alias": false,
+                        "range": {
+                          "start_byte": 0,
+                          "end_byte": 1,
+                          "start_point": {
+                            "row": 0,
+                            "column": 0
+                          },
+                          "end_point": {
+                            "row": 0,
+                            "column": 1
+                          }
+                        },
+                        "flags": {
+                          "named": true,
+                          "visible": true,
+                          "extra": false,
+                          "terminal": false,
+                          "supertype": false,
+                          "error": false,
+                          "missing": false,
+                          "has_error": false
+                        },
+                        "text": null,
+                        "children": [
+                          {
+                            "child_index": 0,
+                            "field_name": null,
+                            "field_id": null,
+                            "node": {
+                              "id": 4,
+                              "kind": "/\\d+/",
+                              "kind_id": 9,
+                              "grammar_kind": "/\\d+/",
+                              "grammar_id": 9,
+                              "alias_symbol_id": null,
+                              "has_alias": false,
+                              "range": {
+                                "start_byte": 0,
+                                "end_byte": 1,
+                                "start_point": {
+                                  "row": 0,
+                                  "column": 0
+                                },
+                                "end_point": {
+                                  "row": 0,
+                                  "column": 1
+                                }
+                              },
+                              "flags": {
+                                "named": true,
+                                "visible": true,
+                                "extra": false,
+                                "terminal": true,
+                                "supertype": false,
+                                "error": false,
+                                "missing": false,
+                                "has_error": false
+                              },
+                              "text": "1",
+                              "children": []
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "child_index": 1,
+                      "field_name": "operator",
+                      "field_id": 3,
+                      "node": {
+                        "id": 5,
+                        "kind": "\"+\"",
+                        "kind_id": 7,
+                        "grammar_kind": "\"+\"",
+                        "grammar_id": 7,
+                        "alias_symbol_id": null,
+                        "has_alias": false,
+                        "range": {
+                          "start_byte": 1,
+                          "end_byte": 2,
+                          "start_point": {
+                            "row": 0,
+                            "column": 1
+                          },
+                          "end_point": {
+                            "row": 0,
+                            "column": 2
+                          }
+                        },
+                        "flags": {
+                          "named": false,
+                          "visible": true,
+                          "extra": false,
+                          "terminal": true,
+                          "supertype": false,
+                          "error": false,
+                          "missing": false,
+                          "has_error": false
+                        },
+                        "text": "+",
+                        "children": []
+                      }
+                    },
+                    {
+                      "child_index": 2,
+                      "field_name": "right",
+                      "field_id": 4,
+                      "node": {
+                        "id": 6,
+                        "kind": "Expr",
+                        "kind_id": 4,
+                        "grammar_kind": "Expr",
+                        "grammar_id": 4,
+                        "alias_symbol_id": null,
+                        "has_alias": false,
+                        "range": {
+                          "start_byte": 2,
+                          "end_byte": 3,
+                          "start_point": {
+                            "row": 0,
+                            "column": 2
+                          },
+                          "end_point": {
+                            "row": 0,
+                            "column": 3
+                          }
+                        },
+                        "flags": {
+                          "named": true,
+                          "visible": true,
+                          "extra": false,
+                          "terminal": false,
+                          "supertype": false,
+                          "error": false,
+                          "missing": false,
+                          "has_error": false
+                        },
+                        "text": null,
+                        "children": [
+                          {
+                            "child_index": 0,
+                            "field_name": null,
+                            "field_id": null,
+                            "node": {
+                              "id": 7,
+                              "kind": "/\\d+/",
+                              "kind_id": 9,
+                              "grammar_kind": "/\\d+/",
+                              "grammar_id": 9,
+                              "alias_symbol_id": null,
+                              "has_alias": false,
+                              "range": {
+                                "start_byte": 2,
+                                "end_byte": 3,
+                                "start_point": {
+                                  "row": 0,
+                                  "column": 2
+                                },
+                                "end_point": {
+                                  "row": 0,
+                                  "column": 3
+                                }
+                              },
+                              "flags": {
+                                "named": true,
+                                "visible": true,
+                                "extra": false,
+                                "terminal": true,
+                                "supertype": false,
+                                "error": false,
+                                "missing": false,
+                                "has_error": false
+                              },
+                              "text": "2",
+                              "children": []
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add insta snapshots for the experimental `adze.document.v1` native document JSON projection
- pin both a clean fielded CST document and a diagnostic/error document
- update native document/status docs to describe the snapshot fixtures while keeping CLI/WASM `adze-json` explicitly experimental

## Validation

- `cargo test -p adze --features "pure-rust,serialization" --test adze_document_json -- --nocapture`
- `cargo fmt -p adze -- --check`
- `git diff --check`
- `cargo clippy -p adze --features "pure-rust,serialization" --all-targets -- -D warnings`

## Notes

This is still an experimental native-document proof fixture. It does not promote stable JSON output, CLI output, WASM bindings, or typed-CST JSON.