### PR TITLE
runtime: count ambiguity summary nodes

### DIFF
--- a/docs/design/adze-document.md
+++ b/docs/design/adze-document.md
@@ -267,8 +267,8 @@ the user opts in through explicit parse options.
 
 The true-GLR runtime now has an alpha parser-level summary for retained complete
 alternatives: it reports the alternative count, selected alternative, root spans,
-and whether selection came from dynamic-precedence/error-cost version comparison
-or the stable structural tie-break. Generated `parse_document()` now routes
+structural node counts, and whether selection came from dynamic-precedence/error-cost
+version comparison or the stable structural tie-break. Generated `parse_document()` now routes
 conflicted parse tables through that true-GLR runtime and records the same
 summary on `AdzeDocument::ambiguities()`. GLR lexing and finish errors on this
 document route are converted into structured diagnostics with a synthetic error

--- a/runtime/src/glr_parser.rs
+++ b/runtime/src/glr_parser.rs
@@ -156,7 +156,7 @@ pub struct AlternativeSummary {
     pub in_error: bool,
     /// Error/recovery cost for this parse version.
     pub cost: usize,
-    /// Error node count for this parse version.
+    /// Structural node count for this retained alternative tree.
     pub node_count: usize,
 }
 
@@ -408,6 +408,14 @@ fn append_subtree_selection_key(node: &Subtree, key: &mut SubtreeSelectionKey) {
         key.push((usize::MAX, usize::MAX, edge.field_id, 0, 0));
         append_subtree_selection_key(&edge.subtree, key);
     }
+}
+
+fn subtree_node_count(node: &Subtree) -> usize {
+    1 + node
+        .children
+        .iter()
+        .map(|edge| subtree_node_count(&edge.subtree))
+        .sum::<usize>()
 }
 
 fn version_selection_reason(left: &ParseStack, right: &ParseStack) -> SelectionReason {
@@ -2167,7 +2175,7 @@ impl GLRParser {
                     dynamic_precedence: stack.version.dynamic_prec,
                     in_error: stack.version.in_error,
                     cost: stack.version.cost,
-                    node_count: stack.version.node_count,
+                    node_count: subtree_node_count(node),
                 }
             })
             .collect();

--- a/runtime/tests/adze_document_json.rs
+++ b/runtime/tests/adze_document_json.rs
@@ -187,8 +187,10 @@ fn parse_document_json_serializes_glr_ambiguity_summary() {
     assert!(selected_alternative["root_symbol"].as_u64().is_some());
     assert_eq!(selected_alternative["in_error"].as_bool(), Some(false));
     assert!(
-        selected_alternative["node_count"].as_u64().is_some(),
-        "selected alternative should preserve the runtime node-count summary field: {selected_alternative:?}"
+        selected_alternative["node_count"]
+            .as_u64()
+            .is_some_and(|count| count > 0),
+        "selected alternative should preserve a structural node count: {selected_alternative:?}"
     );
 
     let mut snapshot_json = json;

--- a/runtime/tests/snapshots/adze_document_json__adze_document_json_ambiguity.snap
+++ b/runtime/tests/snapshots/adze_document_json__adze_document_json_ambiguity.snap
@@ -33,7 +33,7 @@ expression: "serde_json::to_string_pretty(&snapshot_json).expect(\"ambiguous doc
           "dynamic_precedence": 0,
           "in_error": false,
           "cost": 0,
-          "node_count": 0
+          "node_count": 11
         },
         {
           "index": 1,
@@ -45,7 +45,7 @@ expression: "serde_json::to_string_pretty(&snapshot_json).expect(\"ambiguous doc
           "dynamic_precedence": 0,
           "in_error": false,
           "cost": 0,
-          "node_count": 0
+          "node_count": 11
         }
       ]
     }


### PR DESCRIPTION
## Summary

- count retained GLR ambiguity alternative nodes from the alternative subtree instead of exposing the parse-version error-cost counter
- tighten the document JSON ambiguity canary so `node_count` must be positive for the selected alternative
- refresh the ambiguity JSON snapshot and design note

## Validation

- `$env:INSTA_UPDATE='always'; cargo test -p adze --features "pure-rust,serialization,glr" --test adze_document_json parse_document_json_serializes_glr_ambiguity_summary -- --exact --nocapture`
- `cargo fmt -p adze -- --check`
- `cargo test -p adze --features "pure-rust,serialization,glr" --test adze_document_json -- --nocapture`
- `git diff --check`
- `cargo clippy -p adze --features "pure-rust,serialization,glr" --all-targets -- -D warnings`

## Risk

Low. This does not change GLR selection or `VersionInfo` error-cost comparison. It only makes the public ambiguity summary report structural node counts for retained alternatives.