### PR TITLE
runtime: snapshot document json diagnostic spans

### DIFF
--- a/docs/design/adze-document.md
+++ b/docs/design/adze-document.md
@@ -314,9 +314,9 @@ The current alpha implements only `AdzeDocument::to_json_value()` under the
 `serialization` feature. It emits an experimental `adze.document.v1` envelope
 for the selected generic CST, source byte length, language name, metadata,
 structured diagnostics, and ambiguity summaries. This is a document canary for
-future output work; snapshot fixtures pin representative clean, diagnostic,
-and ambiguous GLR documents, but this is not a stable CLI/WASM `adze-json`
-contract.
+future output work; snapshot fixtures pin representative clean, EOF diagnostic,
+multibyte diagnostic, multiline diagnostic, and ambiguous GLR documents, but
+this is not a stable CLI/WASM `adze-json` contract.
 
 No JSON schema should be treated as stable until it has a fixture, snapshot, and
 support-tier entry.

--- a/docs/status/CORRECTNESS_PUSH.md
+++ b/docs/status/CORRECTNESS_PUSH.md
@@ -1,6 +1,6 @@
 # Correctness Push Plan
 
-**Last updated:** 2026-05-11
+**Last updated:** 2026-05-12
 **Scope:** current parser/runtime, GLR, tablegen ABI, CLI, and product-proof convergence.
 
 This is the execution playbook for moving Adze from "bounded core lane is green" to "the product claims are behavior-proven." It is intentionally narrower than a roadmap: keep the required lane bounded, land focused correctness work only when it has receipts, and track remaining product gaps without hiding them inside broad policy or infrastructure PRs.
@@ -86,9 +86,10 @@ Keep implementation slices small:
    has an experimental `AdzeDocument::to_json_value()` projection under
    `serialization` that emits schema-tagged `adze.document.v1` facts for the
    selected generic CST, diagnostics, metadata, and ambiguity summaries, with
-   representative clean, diagnostic, and ambiguous GLR document snapshots. Keep
-   expanding it in small proof-backed slices, and do not treat this as a stable
-   CLI/WASM `adze-json` contract.
+   representative clean, EOF diagnostic, multibyte diagnostic, multiline
+   diagnostic, and ambiguous GLR document snapshots. Keep expanding it in small
+   proof-backed slices, and do not treat this as a stable CLI/WASM `adze-json`
+   contract.
 2. A typed CST arithmetic spike now proves a generated-style fixture module,
    the runtime `SyntaxNode` handle contract, typed field accessors, spans,
    text, and recovery flags over document node IDs. Tablegen also has an alpha

--- a/docs/status/SUPPORT_TIERS.md
+++ b/docs/status/SUPPORT_TIERS.md
@@ -1,6 +1,6 @@
 # Support Tiers and Proof Surface
 
-**Last updated:** 2026-05-11
+**Last updated:** 2026-05-12
 **Source of truth for:** README feature claims, `docs/status/KNOWN_RED.md`, and CI expectations.
 
 This document maps major Adze surfaces to five tiers:
@@ -21,7 +21,8 @@ provenance, not per-AST-node provenance or a typed CST support promotion.
 `AdzeDocument::to_json_value()` now emits an experimental
 `adze.document.v1` envelope under the `serialization` feature for the same
 selected generic CST, diagnostics, metadata, and ambiguity summary facts, with
-snapshot fixtures for clean, diagnostic, and GLR ambiguity documents. Proof:
+snapshot fixtures for clean, EOF diagnostic, multibyte diagnostic, multiline
+diagnostic, and GLR ambiguity documents. Proof:
 `cargo test -p adze --features "pure-rust,serialization" --test adze_document_json -- --nocapture`;
 GLR ambiguity JSON proof:
 `cargo test -p adze --features "pure-rust,serialization,glr" --test adze_document_json parse_document_json_serializes_glr_ambiguity_summary -- --exact --nocapture`.

--- a/runtime/tests/adze_document_json.rs
+++ b/runtime/tests/adze_document_json.rs
@@ -128,6 +128,130 @@ fn parse_document_json_serializes_diagnostics_and_error_flags() {
 }
 
 #[test]
+fn parse_document_json_serializes_multibyte_diagnostic_span() {
+    use adze_example::typed_ast_contract::grammar;
+
+    let source = "1 + \u{03bb}";
+    let document = grammar::parse_document(source)
+        .expect("generated parse_document helper should return multibyte partial parse facts");
+    let json = document.to_json_value();
+
+    assert_eq!(json["schema"].as_str(), Some(ADZE_DOCUMENT_JSON_SCHEMA));
+    assert_eq!(
+        json["source"]["byte_len"].as_u64(),
+        Some(source.len() as u64)
+    );
+    assert_eq!(
+        json["tree"]["root"]["flags"]["has_error"].as_bool(),
+        Some(true)
+    );
+
+    let diagnostic = json["diagnostics"]
+        .as_array()
+        .and_then(|diagnostics| diagnostics.first())
+        .expect("multibyte bad token should serialize a diagnostic");
+    assert_eq!(diagnostic["start_byte"].as_u64(), Some(4));
+    assert_eq!(diagnostic["end_byte"].as_u64(), Some(6));
+    assert_eq!(diagnostic["point_range"]["start"]["row"].as_u64(), Some(0));
+    assert_eq!(
+        diagnostic["point_range"]["start"]["column"].as_u64(),
+        Some(4)
+    );
+    assert_eq!(diagnostic["point_range"]["end"]["row"].as_u64(), Some(0));
+    assert_eq!(diagnostic["point_range"]["end"]["column"].as_u64(), Some(6));
+    assert!(
+        diagnostic["expected"]
+            .as_array()
+            .expect("diagnostic should serialize expected tokens")
+            .iter()
+            .any(|value| value.as_str() == Some(r"/\d+/")),
+        "multibyte diagnostic JSON should preserve expected-token names: {diagnostic:?}"
+    );
+
+    let snapshot_json = serde_json::json!({
+        "schema": json["schema"].clone(),
+        "source": json["source"].clone(),
+        "language": json["language"].clone(),
+        "root_has_error": json["tree"]["root"]["flags"]["has_error"].clone(),
+        "first_diagnostic": {
+            "start_byte": diagnostic["start_byte"].clone(),
+            "end_byte": diagnostic["end_byte"].clone(),
+            "point_range": diagnostic["point_range"].clone(),
+            "expected": diagnostic["expected"].clone(),
+            "related_nodes": diagnostic["related_nodes"].clone(),
+        },
+    });
+
+    insta::assert_snapshot!(
+        "adze_document_json_multibyte_diagnostic",
+        serde_json::to_string_pretty(&snapshot_json)
+            .expect("multibyte diagnostic JSON summary should render as pretty JSON")
+    );
+}
+
+#[test]
+fn parse_document_json_serializes_multiline_diagnostic_point_range() {
+    use adze_example::typed_ast_contract::grammar;
+
+    let source = "1 +\n@";
+    let document = grammar::parse_document(source)
+        .expect("generated parse_document helper should return multiline partial parse facts");
+    let json = document.to_json_value();
+
+    assert_eq!(json["schema"].as_str(), Some(ADZE_DOCUMENT_JSON_SCHEMA));
+    assert_eq!(
+        json["source"]["byte_len"].as_u64(),
+        Some(source.len() as u64)
+    );
+    assert_eq!(
+        json["tree"]["root"]["flags"]["has_error"].as_bool(),
+        Some(true)
+    );
+
+    let diagnostic = json["diagnostics"]
+        .as_array()
+        .and_then(|diagnostics| diagnostics.first())
+        .expect("multiline bad token should serialize a diagnostic");
+    assert_eq!(diagnostic["start_byte"].as_u64(), Some(4));
+    assert_eq!(diagnostic["end_byte"].as_u64(), Some(5));
+    assert_eq!(diagnostic["point_range"]["start"]["row"].as_u64(), Some(1));
+    assert_eq!(
+        diagnostic["point_range"]["start"]["column"].as_u64(),
+        Some(0)
+    );
+    assert_eq!(diagnostic["point_range"]["end"]["row"].as_u64(), Some(1));
+    assert_eq!(diagnostic["point_range"]["end"]["column"].as_u64(), Some(1));
+    assert!(
+        diagnostic["expected"]
+            .as_array()
+            .expect("diagnostic should serialize expected tokens")
+            .iter()
+            .any(|value| value.as_str() == Some(r"/\d+/")),
+        "multiline diagnostic JSON should preserve expected-token names: {diagnostic:?}"
+    );
+
+    let snapshot_json = serde_json::json!({
+        "schema": json["schema"].clone(),
+        "source": json["source"].clone(),
+        "language": json["language"].clone(),
+        "root_has_error": json["tree"]["root"]["flags"]["has_error"].clone(),
+        "first_diagnostic": {
+            "start_byte": diagnostic["start_byte"].clone(),
+            "end_byte": diagnostic["end_byte"].clone(),
+            "point_range": diagnostic["point_range"].clone(),
+            "expected": diagnostic["expected"].clone(),
+            "related_nodes": diagnostic["related_nodes"].clone(),
+        },
+    });
+
+    insta::assert_snapshot!(
+        "adze_document_json_multiline_diagnostic",
+        serde_json::to_string_pretty(&snapshot_json)
+            .expect("multiline diagnostic JSON summary should render as pretty JSON")
+    );
+}
+
+#[test]
 #[cfg(feature = "glr")]
 fn parse_document_json_serializes_glr_ambiguity_summary() {
     use adze_example::ambiguous_expr::grammar;

--- a/runtime/tests/snapshots/adze_document_json__adze_document_json_multibyte_diagnostic.snap
+++ b/runtime/tests/snapshots/adze_document_json__adze_document_json_multibyte_diagnostic.snap
@@ -1,0 +1,34 @@
+---
+source: runtime/tests/adze_document_json.rs
+expression: "serde_json::to_string_pretty(&snapshot_json).expect(\"multibyte diagnostic JSON summary should render as pretty JSON\")"
+---
+{
+  "schema": "adze.document.v1",
+  "source": {
+    "byte_len": 6
+  },
+  "language": {
+    "name": "typed_ast_contract"
+  },
+  "root_has_error": true,
+  "first_diagnostic": {
+    "start_byte": 4,
+    "end_byte": 6,
+    "point_range": {
+      "start": {
+        "row": 0,
+        "column": 4
+      },
+      "end": {
+        "row": 0,
+        "column": 6
+      }
+    },
+    "expected": [
+      "/\\d+/"
+    ],
+    "related_nodes": [
+      1
+    ]
+  }
+}

--- a/runtime/tests/snapshots/adze_document_json__adze_document_json_multiline_diagnostic.snap
+++ b/runtime/tests/snapshots/adze_document_json__adze_document_json_multiline_diagnostic.snap
@@ -1,0 +1,34 @@
+---
+source: runtime/tests/adze_document_json.rs
+expression: "serde_json::to_string_pretty(&snapshot_json).expect(\"multiline diagnostic JSON summary should render as pretty JSON\")"
+---
+{
+  "schema": "adze.document.v1",
+  "source": {
+    "byte_len": 5
+  },
+  "language": {
+    "name": "typed_ast_contract"
+  },
+  "root_has_error": true,
+  "first_diagnostic": {
+    "start_byte": 4,
+    "end_byte": 5,
+    "point_range": {
+      "start": {
+        "row": 1,
+        "column": 0
+      },
+      "end": {
+        "row": 1,
+        "column": 1
+      }
+    },
+    "expected": [
+      "/\\d+/"
+    ],
+    "related_nodes": [
+      1
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- add focused `AdzeDocument::to_json_value()` canaries for multibyte and multiline diagnostic spans
- assert serialized byte ranges, point ranges, expected-token names, related nodes, and root `has_error`
- update native document/status docs to list clean, EOF diagnostic, multibyte diagnostic, multiline diagnostic, and GLR ambiguity JSON snapshots

## Notes

The new snapshots intentionally summarize the first diagnostic instead of freezing the full diagnostic array. This keeps the proof focused on serialized span/point/expected-token facts without promoting incidental recovery artifacts into a stable JSON contract.

## Validation

- `cargo fmt -p adze -- --check`
- `cargo test -p adze --features "pure-rust,serialization" --test adze_document_json -- --nocapture`
- `cargo test -p adze --features "pure-rust,serialization,glr" --test adze_document_json -- --nocapture`
- `cargo clippy -p adze --features "pure-rust,serialization,glr" --all-targets -- -D warnings`
- `git diff --check`