### PR TITLE
ts-compat: expose EOF missing recovery child

### DIFF
--- a/runtime/src/parser_v4.rs
+++ b/runtime/src/parser_v4.rs
@@ -551,6 +551,38 @@ impl Parser {
         }
     }
 
+    fn synthetic_missing_node(position: usize) -> ParseNode {
+        ParseNode {
+            symbol: SymbolId(0),
+            symbol_id: SymbolId(0),
+            start_byte: position,
+            end_byte: position,
+            field_name: None,
+            alias_symbol_id: None,
+            children: vec![],
+        }
+    }
+
+    fn partial_error_tree(
+        node_stack: &mut Vec<ParseNode>,
+        lookahead: SymbolId,
+        current_position: usize,
+        input_len: usize,
+    ) -> ParseNode {
+        let had_partial_context = node_stack.len() > 1;
+        let Some(mut node) = node_stack.pop() else {
+            return Self::synthetic_missing_node(current_position);
+        };
+
+        if had_partial_context && lookahead.0 == 0 && current_position >= input_len {
+            node.end_byte = node.end_byte.max(current_position);
+            node.children
+                .push(Self::synthetic_missing_node(current_position));
+        }
+
+        node
+    }
+
     /// Internal parsing implementation shared by parse() and parse_tree()
     /// Returns (ParseNode, error_count)
     fn parse_internal(&mut self, input: &str, _return_tree: bool) -> Result<(ParseNode, usize)> {
@@ -811,21 +843,12 @@ impl Parser {
                     // A real implementation would do error recovery
                     error_count += 1;
 
-                    // Return a partial tree or error node
-                    let error_node = if let Some(node) = node_stack.pop() {
-                        node
-                    } else {
-                        // Create minimal error node
-                        ParseNode {
-                            symbol: SymbolId(0),
-                            symbol_id: SymbolId(0),
-                            start_byte: current_position,
-                            end_byte: current_position,
-                            field_name: None,
-                            alias_symbol_id: None,
-                            children: vec![],
-                        }
-                    };
+                    let error_node = Self::partial_error_tree(
+                        &mut node_stack,
+                        lookahead,
+                        current_position,
+                        input_bytes.len(),
+                    );
 
                     return Ok((error_node, error_count));
                 }
@@ -834,21 +857,12 @@ impl Parser {
                     // Handle Recover action - treat as error for now
                     error_count += 1;
 
-                    // Return a partial tree or recovery node
-                    let recovery_node = if let Some(node) = node_stack.pop() {
-                        node
-                    } else {
-                        // Create minimal recovery node
-                        ParseNode {
-                            symbol: SymbolId(0),
-                            symbol_id: SymbolId(0),
-                            start_byte: current_position,
-                            end_byte: current_position,
-                            field_name: None,
-                            alias_symbol_id: None,
-                            children: vec![],
-                        }
-                    };
+                    let recovery_node = Self::partial_error_tree(
+                        &mut node_stack,
+                        lookahead,
+                        current_position,
+                        input_bytes.len(),
+                    );
 
                     return Ok((recovery_node, error_count));
                 }
@@ -866,21 +880,12 @@ impl Parser {
                     // Unknown action type // Expected: V for Recover
                     error_count += 1;
 
-                    // Return a partial tree or error node
-                    let error_node = if let Some(node) = node_stack.pop() {
-                        node
-                    } else {
-                        // Create minimal error node
-                        ParseNode {
-                            symbol: SymbolId(0),
-                            symbol_id: SymbolId(0),
-                            start_byte: current_position,
-                            end_byte: current_position,
-                            field_name: None,
-                            alias_symbol_id: None,
-                            children: vec![],
-                        }
-                    };
+                    let error_node = Self::partial_error_tree(
+                        &mut node_stack,
+                        lookahead,
+                        current_position,
+                        input_bytes.len(),
+                    );
 
                     return Ok((error_node, error_count));
                 }

--- a/runtime/tests/ts_compat_node_error.rs
+++ b/runtime/tests/ts_compat_node_error.rs
@@ -27,6 +27,17 @@ fn assert_node_error_free(node: Node<'_>) {
     }
 }
 
+fn collect_missing_nodes<'tree>(node: Node<'tree>, missing: &mut Vec<Node<'tree>>) {
+    if node.is_missing() {
+        missing.push(node.clone());
+    }
+
+    for index in 0..node.child_count() {
+        let child = node.child(index).expect("child index should be valid");
+        collect_missing_nodes(child, missing);
+    }
+}
+
 #[test]
 fn generated_tree_reports_error_metadata_when_parser_recovers() {
     let mut parser = Parser::new();
@@ -73,6 +84,40 @@ fn generated_tree_reports_zero_width_error_root_as_missing() {
     assert!(root.is_missing());
     assert_eq!(root.byte_range(), 0..0);
     assert!(root.has_error());
+}
+
+#[test]
+fn generated_tree_reports_recovered_missing_child_for_truncated_expression() {
+    let mut parser = Parser::new();
+    parser
+        .set_language(adze_example::ts_langs::arithmetic())
+        .expect("Failed to set language");
+
+    let source = "1-";
+    let tree = parser
+        .parse(source, None)
+        .expect("parser should return an inspectable truncated-input error tree");
+    let root = tree.root_node();
+
+    assert!(tree.error_count() > 0);
+    assert!(tree.has_errors());
+    assert!(!root.is_error());
+    assert!(!root.is_missing());
+    assert!(root.has_error());
+
+    let mut missing_nodes = Vec::new();
+    collect_missing_nodes(root, &mut missing_nodes);
+    assert!(
+        !missing_nodes.is_empty(),
+        "truncated expression should expose at least one recovered missing node"
+    );
+
+    for missing in missing_nodes {
+        assert!(missing.is_error());
+        assert!(missing.has_error());
+        assert_eq!(missing.start_byte(), missing.end_byte());
+        assert_eq!(missing.start_byte(), source.len());
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Attach a zero-width synthetic symbol-0 child when parser_v4 returns a partial tree for EOF/truncated recovery.
- Add a `ts_compat` canary for `Node::is_missing()` on a recovered missing child in `1-`.
- Keep `is_error()` node-local and `has_error()` aggregate/root-aware.

## Validation
- `cargo test -p adze --features "pure-rust,ts-compat" --test ts_compat_node_error generated_tree_reports_recovered_missing_child_for_truncated_expression -- --exact --nocapture`
- `cargo test -p adze --features "pure-rust,ts-compat" --test ts_compat_node_error -- --nocapture`
- `cargo test -p adze --features "pure-rust,ts-compat" --test adze_document_alpha parse_document_exposes_recovery_metadata_and_diagnostics -- --exact --nocapture`
- `cargo test -p adze --features pure-rust --test typed_cst_generated_document generated_parse_document_diagnostics_preserve_expected_tokens -- --exact --nocapture`
- `cargo fmt -p adze -- --check`
- `git diff --check`
- `cargo clippy -p adze --all-targets --features "pure-rust,ts-compat" -- -D warnings`

## Remaining risk
- This only covers EOF/truncated recovery on parser_v4 partial trees. Broader Tree-sitter error-tree parity, query behavior, imported grammar corpus parity, and non-EOF recovery shapes remain advisory.