### PR TITLE
docs: define source-of-truth scaffolding

### DIFF
--- a/.adze/goals/README.md
+++ b/.adze/goals/README.md
@@ -1,0 +1,83 @@
+# Active Goals
+
+This directory is for machine-readable execution state used by Droid, Codex, and
+other automation. It answers "what is being worked now?" rather than "why does
+this work exist?" or "what behavior is required?"
+
+Use:
+
+```text
+active.toml
+archive/
+```
+
+Do not put long prose plans here. Link to proposals, specs, ADRs, plans, issues,
+and PRs.
+
+## Source Of Truth
+
+Goal manifests own:
+
+- current campaign ID and title
+- active/paused/complete status
+- current owner or execution lane
+- end-state checklist
+- work item state
+- commands automation should run
+- links to specs, plans, issues, and PRs
+
+Other artifacts own:
+
+- why the campaign exists: `../../docs/proposals/`
+- behavior contracts: `../../docs/specs/`
+- durable architecture decisions: `../../docs/adr/`
+- PR sequencing and proof rationale: `../../plans/<milestone>/`
+- product claim proof mapping: `../../docs/status/SUPPORT_TIERS.md`
+- policy ledgers: `../../policy/*.toml`
+
+## `active.toml` Shape
+
+```toml
+id = "adze-0-9-contract-convergence"
+title = "Adze 0.9.0 contract convergence"
+status = "active"
+owner = "droid-factory"
+created = "2026-05-11"
+
+objective = """
+Collapse the workspace surface, update Rust/MSRV/lints, recalibrate CI
+economics, and promote product claims only where support-tier proof exists.
+"""
+
+end_state = [
+  "No production workspace crate is unclassified.",
+  "No unpublished production crate exists.",
+  "CI lane whitelist reflects the post-collapse workspace.",
+  "Support tiers map every README stable claim to proof.",
+]
+
+[[work_item]]
+id = "package-boundary-audit"
+status = "ready"
+spec = "ADZE-SPEC-0001-package-surface-boundary"
+plan = "plans/0.9.0/microcrate-collapse.md"
+commands = [
+  "cargo metadata --format-version 1 --no-deps",
+  "cargo run -q -p xtask -- check-package-boundary",
+  "just ci-supported",
+]
+```
+
+## Status Values
+
+Use a small status vocabulary:
+
+```text
+ready
+active
+blocked
+complete
+superseded
+```
+
+Archive completed manifests under `archive/` with a dated filename.

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,10 +64,14 @@ Welcome to the Adze documentation. Adze (formerly `rust-sitter`) is a Rust-nativ
 ## Project Status
 
 - [**Roadmap**](../ROADMAP.md) - Milestones for 0.8.0, 0.9.0, and 1.0.
+- [**Proposals**](./proposals/README.md) - PRD-style "why" documents for product and repo-governance campaigns.
+- [**Specs**](./specs/README.md) - Behavior contracts, acceptance criteria, and proof requirements.
+- [**Architecture Decisions**](./adr/README.md) - Durable architecture decisions and their consequences.
+- [**0.9.0 Plans**](../plans/0.9.0/README.md) - PR-sized implementation sequencing and proof commands.
+- [**Active Goals**](../.adze/goals/README.md) - Machine-readable Droid/Codex execution state conventions.
 - [**Correctness Push Plan**](./status/CORRECTNESS_PUSH.md) - Current merge/proof sequence for parser, GLR, tablegen ABI, CLI, and product-proof convergence.
 - [**Support Tiers**](./status/SUPPORT_TIERS.md) - Feature claims mapped to proof commands and CI lanes.
 - [**Friction Log**](./status/FRICTION_LOG.md) - Current developer pain points we are burning down.
 - [**Now / Next / Later**](./status/NOW_NEXT_LATER.md) - Rolling execution plan.
 - [**Known Red**](./status/KNOWN_RED.md) - Exclusions from the supported CI lane.
-- [**Support Tiers**](./status/SUPPORT_TIERS.md) - Feature support level, proof command, CI lane, and limitations.
 - [**PR Template**](./PR_TEMPLATE.md) - Checklist for contributors.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,86 @@
+# Architecture Decision Records
+
+ADRs record durable architecture decisions. Use an ADR when a choice should keep
+guiding future work after the immediate PR sequence is complete.
+
+Do not use ADRs for ordinary tasks, status updates, or temporary execution
+state. Those belong in implementation plans, handoffs, or active goal manifests.
+
+## Source Of Truth
+
+ADRs own:
+
+- the durable decision
+- context that made the decision necessary
+- consequences and constraints
+- rejected alternatives
+- follow-up specs and implementation plans
+
+Other artifacts own:
+
+- product or repo motivation: `docs/proposals/`
+- behavior contracts: `docs/specs/`
+- implementation sequencing: `plans/<milestone>/`
+- current agent/operator state: `.adze/goals/active.toml`
+- product claim proof mapping: `docs/status/SUPPORT_TIERS.md`
+
+## Naming
+
+The repository currently has both legacy ADR names and newer `ADZE-ADR-*`
+names. New ADRs should use:
+
+```text
+ADZE-ADR-0001-short-kebab-title.md
+```
+
+Example:
+
+```text
+ADZE-ADR-0001-adze-document-one-parse-truth.md
+```
+
+## Header
+
+Every ADR should start with:
+
+```md
+Status: proposed | accepted | superseded
+Date:
+Owner:
+Linked proposal:
+Linked specs:
+Linked plan:
+```
+
+## Template
+
+```md
+# ADZE-ADR-0001: Title
+
+Status:
+Date:
+Owner:
+Linked proposal:
+Linked specs:
+Linked plan:
+
+## Decision
+
+State the durable architecture decision.
+
+## Context
+
+Why this decision exists.
+
+## Consequences
+
+What this enables and constrains.
+
+## Alternatives Considered
+
+What did we reject?
+
+## Follow-Up Specs And Plans
+
+What must be specified or implemented next?
+```

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -1,0 +1,128 @@
+# Proposals
+
+Proposals are the product and repo-governance "why" layer. Use them when work
+needs a problem statement, user or maintainer value, alternatives, success
+criteria, and an evidence loop before implementation starts.
+
+Proposals are not behavior specs and are not PR queues. A proposal can link to
+many specs, ADRs, and implementation plans, but it should not duplicate their
+contracts or task lists.
+
+## Source Of Truth
+
+Proposals own:
+
+- the problem or opportunity
+- affected users and repo surfaces
+- success criteria
+- alternatives considered
+- risks and non-goals
+- the evidence plan at a product level
+
+Other artifacts own:
+
+- behavior contracts: `docs/specs/`
+- durable architecture decisions: `docs/adr/`
+- PR sequencing and proof commands: `plans/<milestone>/`
+- current agent/operator state: `.adze/goals/active.toml`
+- product claim proof mapping: `docs/status/SUPPORT_TIERS.md`
+- policy exceptions and CI ledgers: `policy/*.toml`
+
+## Naming
+
+Use stable IDs:
+
+```text
+ADZE-PROP-0001-short-kebab-title.md
+```
+
+Example:
+
+```text
+ADZE-PROP-0001-0.9-contract-convergence.md
+```
+
+## Header
+
+Every proposal should start with:
+
+```md
+Status: proposed | accepted | implemented | superseded
+Owner:
+Created:
+Target milestone:
+Linked specs:
+Linked ADRs:
+Linked plan:
+Linked issues:
+Linked PRs:
+Support-tier impact:
+Policy impact:
+```
+
+## Template
+
+```md
+# ADZE-PROP-0001: Title
+
+Status:
+Owner:
+Created:
+Target milestone:
+Linked specs:
+Linked ADRs:
+Linked plan:
+Linked issues:
+Linked PRs:
+Support-tier impact:
+Policy impact:
+
+## Problem
+
+What risk, user pain, or product gap exists?
+
+## Users And Surfaces
+
+Who benefits and which repo/product surfaces are affected?
+
+## Success Criteria
+
+What must be true when this proposal is done?
+
+## Proposed Shape
+
+What direction are we taking?
+
+## Alternatives Considered
+
+What did we reject and why?
+
+## Specs To Create Or Update
+
+Which `ADZE-SPEC-*` documents define the behavior?
+
+## Architecture Decisions Needed
+
+Which `ADZE-ADR-*` records are required?
+
+## Implementation Campaign Shape
+
+What are the major PR-sized phases?
+
+## Evidence Plan
+
+Which proof commands, fixtures, support-tier updates, or policy receipts will
+show the proposal worked?
+
+## Risks
+
+What can go wrong?
+
+## Non-Goals
+
+What is explicitly out of scope?
+
+## Exit Criteria
+
+When is this proposal complete?
+```

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,121 @@
+# Specs
+
+Specs are the behavior-contract layer. They define what must be true, what is
+out of scope, how the behavior is accepted, and which proof commands establish
+the contract.
+
+Specs are not proposals, ADRs, or task plans. They should link to those layers
+instead of copying their contents.
+
+## Source Of Truth
+
+Specs own:
+
+- behavior requirements
+- non-goals
+- acceptance examples
+- required evidence
+- implementation ownership boundaries
+- test and CI proof mapping
+- support-tier promotion criteria
+
+Other artifacts own:
+
+- why the work exists: `docs/proposals/`
+- durable architecture decisions: `docs/adr/`
+- PR-sized sequencing: `plans/<milestone>/`
+- active agent/operator state: `.adze/goals/active.toml`
+- product claim proof mapping: `docs/status/SUPPORT_TIERS.md`
+- exception ledgers: `policy/*.toml`
+
+## Naming
+
+Use stable IDs:
+
+```text
+ADZE-SPEC-0001-short-kebab-title.md
+```
+
+Examples:
+
+```text
+ADZE-SPEC-0001-package-surface-boundary.md
+ADZE-SPEC-0002-ci-economics.md
+ADZE-SPEC-0003-canonical-parse-document.md
+```
+
+## Header
+
+Every spec should start with:
+
+```md
+Status: proposed | accepted | implemented | superseded
+Owner:
+Created:
+Linked proposal:
+Linked ADRs:
+Linked plan:
+Linked issues:
+Linked PRs:
+Support-tier impact:
+Policy impact:
+```
+
+## Template
+
+```md
+# ADZE-SPEC-0001: Title
+
+Status:
+Owner:
+Created:
+Linked proposal:
+Linked ADRs:
+Linked plan:
+Linked issues:
+Linked PRs:
+Support-tier impact:
+Policy impact:
+
+## Problem
+
+What behavior or contract gap exists?
+
+## Behavior
+
+What must be true?
+
+## Non-Goals
+
+What is out of scope?
+
+## Required Evidence
+
+What proof is required?
+
+## Acceptance Examples
+
+Concrete examples of accepted and rejected behavior.
+
+## Test Mapping
+
+Which tests, fixtures, or snapshots cover this contract?
+
+## Implementation Mapping
+
+Which crates, modules, docs, or policy files own the implementation?
+
+## CI Proof
+
+Which commands and CI lanes prove the contract?
+
+## Metrics And Promotion Rule
+
+What moves this from experimental/advisory to stable?
+```
+
+## Duplication Rule
+
+Specs may reference product claims in `docs/status/SUPPORT_TIERS.md`, but must
+not copy the full feature-to-proof table. Specs may reference CI economics and
+exceptions in `policy/*.toml`, but must not copy policy ledgers into prose.

--- a/plans/0.9.0/README.md
+++ b/plans/0.9.0/README.md
@@ -1,0 +1,87 @@
+# Adze 0.9.0 Plans
+
+This directory is the operational planning layer for the 0.9.0 milestone.
+Implementation plans define PR-sized sequencing and proof commands. They do not
+own product motivation, behavior contracts, or durable architecture decisions.
+
+## Source Of Truth
+
+Plans own:
+
+- work item order
+- PR-sized production deltas
+- blockers and dependencies
+- proof commands
+- rollback notes
+- closeout or handoff status
+
+Other artifacts own:
+
+- release direction and milestone strategy: `../../ROADMAP.md`
+- why a campaign exists: `../../docs/proposals/`
+- behavior contracts: `../../docs/specs/`
+- durable architecture decisions: `../../docs/adr/`
+- active agent/operator state: `../../.adze/goals/active.toml`
+- product claim proof mapping: `../../docs/status/SUPPORT_TIERS.md`
+- policy ledgers: `../../policy/*.toml`
+
+## Expected Files
+
+Use `implementation-plan.md` for the milestone overview, then split substantial
+work into focused files:
+
+```text
+implementation-plan.md
+microcrate-collapse.md
+rust-1.95.md
+ci-economics-v2.md
+clippy-policy.md
+product-proof.md
+release-polish.md
+closeout.md
+```
+
+## Work Item Template
+
+````md
+## Work Item: short-kebab-id
+
+Status: ready | active | blocked | complete | superseded
+Linked proposal:
+Linked spec:
+Linked ADR:
+Blocks:
+Blocked by:
+
+### Goal
+
+What outcome does this PR-sized item produce?
+
+### Production Delta
+
+What files, crates, policy entries, or docs are expected to change?
+
+### Non-Goals
+
+What must stay out of this work item?
+
+### Acceptance
+
+What must be true when the item is complete?
+
+### Proof Commands
+
+```bash
+just ci-supported
+```
+
+### Rollback
+
+How should this be reverted or disabled if it fails?
+````
+
+## Duplication Rule
+
+Plans should link to specs for behavior and to `docs/status/SUPPORT_TIERS.md`
+for product-claim proof. They should not recreate the full support-tier table
+or policy TOML contents.


### PR DESCRIPTION
## Summary
- Add README scaffolding for proposals, specs, ADRs, 0.9.0 plans, and active goal manifests.
- Document the ownership split between why, what, durable decisions, PR sequencing, active execution state, support tiers, and policy ledgers.
- Link the new source-of-truth stack from `docs/README.md` and remove the duplicate Support Tiers entry.

## Validation
- `git diff --cached --check` before commit
- `git diff --check` before staging

## Remaining risk
- This PR only adds taxonomy scaffolding. It intentionally does not add the 0.9 proposal, package-boundary spec, CI economics spec, AdzeDocument ADR, or active goal manifest content.