### PR TITLE
docs(spec): add package surface boundary

### DIFF
--- a/.adze/goals/README.md
+++ b/.adze/goals/README.md
@@ -1,0 +1,83 @@
+# Active Goals
+
+This directory is for machine-readable execution state used by Droid, Codex, and
+other automation. It answers "what is being worked now?" rather than "why does
+this work exist?" or "what behavior is required?"
+
+Use:
+
+```text
+active.toml
+archive/
+```
+
+Do not put long prose plans here. Link to proposals, specs, ADRs, plans, issues,
+and PRs.
+
+## Source Of Truth
+
+Goal manifests own:
+
+- current campaign ID and title
+- active/paused/complete status
+- current owner or execution lane
+- end-state checklist
+- work item state
+- commands automation should run
+- links to specs, plans, issues, and PRs
+
+Other artifacts own:
+
+- why the campaign exists: `../../docs/proposals/`
+- behavior contracts: `../../docs/specs/`
+- durable architecture decisions: `../../docs/adr/`
+- PR sequencing and proof rationale: `../../plans/<milestone>/`
+- product claim proof mapping: `../../docs/status/SUPPORT_TIERS.md`
+- policy ledgers: `../../policy/*.toml`
+
+## `active.toml` Shape
+
+```toml
+id = "adze-0-9-contract-convergence"
+title = "Adze 0.9.0 contract convergence"
+status = "active"
+owner = "droid-factory"
+created = "2026-05-11"
+
+objective = """
+Collapse the workspace surface, update Rust/MSRV/lints, recalibrate CI
+economics, and promote product claims only where support-tier proof exists.
+"""
+
+end_state = [
+  "No production workspace crate is unclassified.",
+  "No unpublished production crate exists.",
+  "CI lane whitelist reflects the post-collapse workspace.",
+  "Support tiers map every README stable claim to proof.",
+]
+
+[[work_item]]
+id = "package-boundary-audit"
+status = "ready"
+spec = "ADZE-SPEC-0001-package-surface-boundary"
+plan = "plans/0.9.0/microcrate-collapse.md"
+commands = [
+  "cargo metadata --format-version 1 --no-deps",
+  "cargo run -q -p xtask -- check-package-boundary",
+  "just ci-supported",
+]
+```
+
+## Status Values
+
+Use a small status vocabulary:
+
+```text
+ready
+active
+blocked
+complete
+superseded
+```
+
+Archive completed manifests under `archive/` with a dated filename.

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,10 +64,14 @@ Welcome to the Adze documentation. Adze (formerly `rust-sitter`) is a Rust-nativ
 ## Project Status
 
 - [**Roadmap**](../ROADMAP.md) - Milestones for 0.8.0, 0.9.0, and 1.0.
+- [**Proposals**](./proposals/README.md) - PRD-style "why" documents for product and repo-governance campaigns.
+- [**Specs**](./specs/README.md) - Behavior contracts, acceptance criteria, and proof requirements.
+- [**Architecture Decisions**](./adr/README.md) - Durable architecture decisions and their consequences.
+- [**0.9.0 Plans**](../plans/0.9.0/README.md) - PR-sized implementation sequencing and proof commands.
+- [**Active Goals**](../.adze/goals/README.md) - Machine-readable Droid/Codex execution state conventions.
 - [**Correctness Push Plan**](./status/CORRECTNESS_PUSH.md) - Current merge/proof sequence for parser, GLR, tablegen ABI, CLI, and product-proof convergence.
 - [**Support Tiers**](./status/SUPPORT_TIERS.md) - Feature claims mapped to proof commands and CI lanes.
 - [**Friction Log**](./status/FRICTION_LOG.md) - Current developer pain points we are burning down.
 - [**Now / Next / Later**](./status/NOW_NEXT_LATER.md) - Rolling execution plan.
 - [**Known Red**](./status/KNOWN_RED.md) - Exclusions from the supported CI lane.
-- [**Support Tiers**](./status/SUPPORT_TIERS.md) - Feature support level, proof command, CI lane, and limitations.
 - [**PR Template**](./PR_TEMPLATE.md) - Checklist for contributors.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,86 @@
+# Architecture Decision Records
+
+ADRs record durable architecture decisions. Use an ADR when a choice should keep
+guiding future work after the immediate PR sequence is complete.
+
+Do not use ADRs for ordinary tasks, status updates, or temporary execution
+state. Those belong in implementation plans, handoffs, or active goal manifests.
+
+## Source Of Truth
+
+ADRs own:
+
+- the durable decision
+- context that made the decision necessary
+- consequences and constraints
+- rejected alternatives
+- follow-up specs and implementation plans
+
+Other artifacts own:
+
+- product or repo motivation: `docs/proposals/`
+- behavior contracts: `docs/specs/`
+- implementation sequencing: `plans/<milestone>/`
+- current agent/operator state: `.adze/goals/active.toml`
+- product claim proof mapping: `docs/status/SUPPORT_TIERS.md`
+
+## Naming
+
+The repository currently has both legacy ADR names and newer `ADZE-ADR-*`
+names. New ADRs should use:
+
+```text
+ADZE-ADR-0001-short-kebab-title.md
+```
+
+Example:
+
+```text
+ADZE-ADR-0001-adze-document-one-parse-truth.md
+```
+
+## Header
+
+Every ADR should start with:
+
+```md
+Status: proposed | accepted | superseded
+Date:
+Owner:
+Linked proposal:
+Linked specs:
+Linked plan:
+```
+
+## Template
+
+```md
+# ADZE-ADR-0001: Title
+
+Status:
+Date:
+Owner:
+Linked proposal:
+Linked specs:
+Linked plan:
+
+## Decision
+
+State the durable architecture decision.
+
+## Context
+
+Why this decision exists.
+
+## Consequences
+
+What this enables and constrains.
+
+## Alternatives Considered
+
+What did we reject?
+
+## Follow-Up Specs And Plans
+
+What must be specified or implemented next?
+```

--- a/docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md
+++ b/docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md
@@ -1,0 +1,243 @@
+# ADZE-PROP-0001: 0.9 contract convergence
+
+Status: proposed
+Owner: Adze maintainers
+Created: 2026-05-12
+Target milestone: 0.9.0
+Linked specs: ADZE-SPEC-0001 package surface boundary; ADZE-SPEC-0002 CI economics; ADZE-SPEC-0003 canonical parse document; ADZE-SPEC-0004 product proof and support tiers
+Linked ADRs: ADZE-ADR-0001 AdzeDocument one parse truth; ADZE-ADR-0002 no durable unpublished production crates; ADZE-ADR-0003 summary-first GLR ambiguity
+Linked plan: ../../plans/0.9.0/implementation-plan.md
+Linked issues:
+Linked PRs:
+Support-tier impact: ../status/SUPPORT_TIERS.md
+Policy impact: ../../policy/package-boundary.toml; ../../policy/ci-lane-whitelist.toml; ../../policy/clippy-lints.toml; ../../policy/non-rust-allowlist.toml
+
+## Problem
+
+Adze 0.8 established a publishable Rust parser-generator baseline, but the repo
+surface is now wider than the product contract. The workspace contains many
+support crates and governance lanes, while the advertised product story depends
+on a smaller set of stable promises:
+
+- Rust types define grammar structure.
+- Generated parsers return typed ASTs directly.
+- The pure-Rust path is the ordinary supported path.
+- GLR behavior is honest about conflicts and ambiguity.
+- Parse errors are useful to downstream users.
+- Stable README claims map to concrete proof commands.
+
+The next release should not add more loosely connected surfaces before the
+existing contract is easier to reason about. The 0.9 milestone should converge
+the package surface, CI economics, lint policy, and product-proof map so
+maintainers can tell which parts of Adze are stable, which are developing, and
+which are intentionally advisory.
+
+## Users And Surfaces
+
+This proposal affects four groups:
+
+- Rust users who want `grammar::parse(source)` to produce typed values without
+  repo-specific setup.
+- Grammar authors who need GLR conflicts, tablegen output, diagnostics, and
+  typed extraction to fail clearly.
+- Maintainers and agents who need a bounded workspace, readable CI signal, and
+  machine-readable execution state.
+- Tooling adopters who need Tree-sitter compatibility, WASM, CLI output,
+  runtime2, and broader grammars to be labeled honestly until promoted.
+
+The affected repo surfaces are the workspace package graph, `just ci-supported`,
+CI policy ledgers, support-tier documentation, README feature claims, parser
+proof tests, and the native document and Tree-sitter compatibility roadmap.
+
+## Success Criteria
+
+0.9 contract convergence is successful when:
+
+- every workspace package is classified as a published crate, dev-only crate,
+  or temporary owner-module migration target;
+- no durable unpublished production crate category remains;
+- the supported CI lane stays green and remains the required proof for stable
+  core claims;
+- CI lane routing and LEM estimates reflect the post-collapse workspace shape;
+- Rust/MSRV, lint, and allowlist policy changes are represented in policy
+  ledgers instead of scattered prose;
+- every stable README claim maps to a row and proof command in
+  `../status/SUPPORT_TIERS.md`;
+- experimental surfaces remain explicitly labeled until promotion proof lands;
+- product-proof canaries cover the advertised typed AST quickstart, pure-Rust
+  parsing path, diagnostics, tablegen, GLR conflict behavior, and native
+  document projections at their claimed support tiers.
+
+## Proposed Shape
+
+Treat 0.9.0 as a contract-convergence release.
+
+The release should make the supported product smaller, clearer, and easier to
+prove before expanding the public surface again. The campaign has four parts:
+
+1. Collapse or classify the workspace package surface.
+2. Recalibrate CI economics and policy ledgers around that smaller surface.
+3. Promote only product claims that have support-tier proof.
+4. Keep native parser API design moving through specs and ADRs rather than
+   incidental implementation drift.
+
+This proposal does not make `AdzeDocument`, typed CST, Tree-sitter
+compatibility, WASM, runtime2, CLI output, or broader grammar support stable by
+declaration. Those surfaces can advance during the milestone, but each needs its
+own spec, proof lane, and support-tier update before being marketed as stable.
+
+## Alternatives Considered
+
+### Feature-first 0.9
+
+Adze could make 0.9 primarily about more parser features, more grammar
+coverage, or broader compatibility claims.
+
+Rejected because the current repo already has valuable developing surfaces, but
+the main risk is claim drift: users and maintainers need clearer proof of what
+is stable before more surfaces are promoted.
+
+### CI-only 0.9
+
+Adze could focus only on CI cost and workflow policy.
+
+Rejected because CI economics are tied to package boundaries and support tiers.
+Cheaper CI without a clarified product contract would hide the underlying
+maintenance problem.
+
+### Docs-only 0.9
+
+Adze could document the current state without changing package boundaries,
+policy, or proof lanes.
+
+Rejected because the workspace surface and support claims need executable
+policy, not just narrative cleanup.
+
+### Big-bang cleanup
+
+Adze could combine package collapse, MSRV, lint policy, CI economics, and
+product proof in one large PR.
+
+Rejected because the high-judgment parts need small reviewable artifacts and
+proof commands. The campaign should be a linked sequence, not a single opaque
+diff.
+
+## Specs To Create Or Update
+
+The milestone needs behavior specs for:
+
+- `ADZE-SPEC-0001-package-surface-boundary.md`: workspace package categories,
+  owner-module migration targets, and the rule that there is no durable
+  unpublished production crate category.
+- `ADZE-SPEC-0002-ci-economics.md`: blocking versus advisory lanes, LEM bands,
+  risk routing, and how policy ledgers own CI exceptions.
+- `ADZE-SPEC-0003-canonical-parse-document.md`: the native parse document as
+  the source of truth for generic CST, typed CST, typed AST, diagnostics,
+  Tree-sitter-compatible projection, and GLR ambiguity summaries.
+- `ADZE-SPEC-0004-product-proof-and-support-tiers.md`: the rule that stable
+  README claims require proof commands and support-tier mapping.
+
+Specs define behavior and acceptance evidence. They must link to
+`../status/SUPPORT_TIERS.md` and `../../policy/*.toml` instead of copying those
+ledgers.
+
+## Architecture Decisions Needed
+
+The milestone needs ADRs for durable choices that should outlive the 0.9 plan:
+
+- `ADZE-ADR-0001-adze-document-one-parse-truth.md`: `AdzeDocument` is the
+  canonical parse product; typed CST, typed AST, diagnostics, GLR summaries, and
+  Tree-sitter compatibility are projections.
+- `ADZE-ADR-0002-no-unpublished-production-crates.md`: production workspace
+  packages are either published public surfaces or explicitly temporary
+  migration targets.
+- `ADZE-ADR-0003-summary-first-glr-ambiguity.md`: native GLR output starts with
+  user-facing ambiguity summaries and selection reasons before raw forest
+  internals become a public contract.
+
+ADRs record architecture decisions. They should not own PR sequencing or policy
+exception lists.
+
+## Implementation Campaign Shape
+
+The campaign should proceed through small PRs:
+
+1. Define the source-of-truth scaffolding for proposals, specs, ADRs, plans, and
+   active goal manifests.
+2. Add this 0.9 contract-convergence proposal.
+3. Add the package surface boundary spec.
+4. Add the CI economics spec and link it to existing CI policy docs.
+5. Record the AdzeDocument one-parse-truth ADR.
+6. Add the 0.9 implementation plan and active goal manifest.
+7. Implement package-boundary audit tooling and policy.
+8. Collapse or reclassify microcrates in owner-sized batches.
+9. Apply Rust/MSRV and lint policy updates after the package graph is smaller.
+10. Refresh CI whitelist, LEM estimates, support tiers, and stable claim proof.
+11. Close the campaign with a handoff that records evidence and remaining work.
+
+Each implementation PR should name its linked proposal, spec, ADR if any, proof
+commands, policy impact, rollback path, and support-tier impact.
+
+## Evidence Plan
+
+Evidence for this proposal comes from linked specs, plans, policy ledgers, and
+support-tier rows. The expected proof surface includes:
+
+```bash
+cargo metadata --format-version 1 --no-deps
+cargo run -q -p xtask -- check-package-boundary
+cargo run -q -p xtask -- check-ci-lane-whitelist
+cargo run -q -p xtask -- check-lint-policy
+just check-msrv
+just ci-supported
+```
+
+Product proof should continue to use exact canaries listed in
+`../status/SUPPORT_TIERS.md`, including typed extraction, pure-Rust parser,
+structured parse errors, GLR conflict routing, tablegen ABI, `AdzeDocument`,
+typed CST, and Tree-sitter compatibility rows at their current tiers.
+
+CI economics proof should link to `../../policy/ci-lane-whitelist.toml`,
+`../../policy/ci-risk-packs.toml`, `../ci/cost-and-verification-policy.md`, and
+`../ci/learned-estimates.md` instead of duplicating those contents here.
+
+## Risks
+
+- Package collapse can accidentally remove useful isolation if the audit treats
+  every small crate as inherently wasteful.
+- CI economics work can be mistaken for weaker verification if support-tier
+  proof is not kept explicit.
+- MSRV and lint changes can churn too many files if they happen before the
+  package graph is reduced.
+- Product claims can drift if README updates are not tied to support-tier proof.
+- Native API design can sprawl if `AdzeDocument`, typed CST, and GLR output are
+  implemented without specs and ADRs.
+
+## Non-Goals
+
+This proposal does not:
+
+- implement parser or runtime behavior;
+- stabilize runtime2, WASM, Tree-sitter compatibility, CLI output, or broader
+  grammar crates by declaration;
+- define the full `AdzeDocument` API contract;
+- define the full typed CST API;
+- implement query support;
+- replace support tiers, policy TOMLs, or CI docs as their own sources of truth;
+- prescribe every PR in the campaign beyond the high-level sequence.
+
+## Exit Criteria
+
+This proposal is implemented when:
+
+- the linked package-boundary, CI-economics, canonical-document, and product-proof
+  specs exist or are explicitly superseded;
+- required ADRs for one parse truth and package-boundary policy are accepted or
+  explicitly superseded;
+- `plans/0.9.0/implementation-plan.md` and `.adze/goals/active.toml` reflect the
+  active campaign state;
+- package-boundary and CI-policy checks have concrete commands or tracked
+  follow-up items;
+- `../status/SUPPORT_TIERS.md` remains the feature-claim proof map;
+- a closeout or handoff records what landed, which proof commands passed, and
+  what remains outside 0.9.

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -1,0 +1,128 @@
+# Proposals
+
+Proposals are the product and repo-governance "why" layer. Use them when work
+needs a problem statement, user or maintainer value, alternatives, success
+criteria, and an evidence loop before implementation starts.
+
+Proposals are not behavior specs and are not PR queues. A proposal can link to
+many specs, ADRs, and implementation plans, but it should not duplicate their
+contracts or task lists.
+
+## Source Of Truth
+
+Proposals own:
+
+- the problem or opportunity
+- affected users and repo surfaces
+- success criteria
+- alternatives considered
+- risks and non-goals
+- the evidence plan at a product level
+
+Other artifacts own:
+
+- behavior contracts: `docs/specs/`
+- durable architecture decisions: `docs/adr/`
+- PR sequencing and proof commands: `plans/<milestone>/`
+- current agent/operator state: `.adze/goals/active.toml`
+- product claim proof mapping: `docs/status/SUPPORT_TIERS.md`
+- policy exceptions and CI ledgers: `policy/*.toml`
+
+## Naming
+
+Use stable IDs:
+
+```text
+ADZE-PROP-0001-short-kebab-title.md
+```
+
+Example:
+
+```text
+ADZE-PROP-0001-0.9-contract-convergence.md
+```
+
+## Header
+
+Every proposal should start with:
+
+```md
+Status: proposed | accepted | implemented | superseded
+Owner:
+Created:
+Target milestone:
+Linked specs:
+Linked ADRs:
+Linked plan:
+Linked issues:
+Linked PRs:
+Support-tier impact:
+Policy impact:
+```
+
+## Template
+
+```md
+# ADZE-PROP-0001: Title
+
+Status:
+Owner:
+Created:
+Target milestone:
+Linked specs:
+Linked ADRs:
+Linked plan:
+Linked issues:
+Linked PRs:
+Support-tier impact:
+Policy impact:
+
+## Problem
+
+What risk, user pain, or product gap exists?
+
+## Users And Surfaces
+
+Who benefits and which repo/product surfaces are affected?
+
+## Success Criteria
+
+What must be true when this proposal is done?
+
+## Proposed Shape
+
+What direction are we taking?
+
+## Alternatives Considered
+
+What did we reject and why?
+
+## Specs To Create Or Update
+
+Which `ADZE-SPEC-*` documents define the behavior?
+
+## Architecture Decisions Needed
+
+Which `ADZE-ADR-*` records are required?
+
+## Implementation Campaign Shape
+
+What are the major PR-sized phases?
+
+## Evidence Plan
+
+Which proof commands, fixtures, support-tier updates, or policy receipts will
+show the proposal worked?
+
+## Risks
+
+What can go wrong?
+
+## Non-Goals
+
+What is explicitly out of scope?
+
+## Exit Criteria
+
+When is this proposal complete?
+```

--- a/docs/specs/ADZE-SPEC-0001-package-surface-boundary.md
+++ b/docs/specs/ADZE-SPEC-0001-package-surface-boundary.md
@@ -1,0 +1,185 @@
+# ADZE-SPEC-0001: Package surface boundary
+
+Status: proposed
+Owner: Adze maintainers
+Created: 2026-05-12
+Linked proposal: ../proposals/ADZE-PROP-0001-0.9-contract-convergence.md
+Linked ADRs: ADZE-ADR-0002 no durable unpublished production crates
+Linked plan: ../../plans/0.9.0/microcrate-collapse.md
+Linked issues:
+Linked PRs:
+
+## Problem
+
+The Adze workspace has grown beyond the stable product surface. Some packages
+are published user-facing crates, some are test or governance support, and some
+are temporary seams created while parser, policy, CI, and product-proof work was
+being split into small changes.
+
+That distinction is useful only if it is explicit. A workspace package that is
+neither publishable nor clearly dev-only becomes a hidden production surface:
+it affects CI cost, MSRV and lint migration effort, release confidence, and
+maintainer reasoning, but it has no stable user contract.
+
+Adze needs a package-boundary contract before 0.9 work changes MSRV, lint
+policy, CI routing, or public support claims.
+
+## Behavior
+
+Every workspace package must be classified as exactly one of these categories:
+
+| Category | Meaning | Allowed durability |
+| --- | --- | --- |
+| Published crate | A public package intended for crates.io or an equivalent stable user surface. | Durable when support-tier and release metadata agree. |
+| Dev-only crate | A package used only for tests, examples, benchmarks, fixtures, xtask support, or internal repo automation. | Durable only while it has a current dev/test/tooling owner and is excluded from production claims. |
+| Owner-module migration target | A temporary package scheduled to move into the public crate, dev-only crate, or xtask module that owns it. | Temporary; must name its target owner and removal condition. |
+
+There is no durable unpublished production crate category.
+
+If a package is used by production code but is not intended to be published as a
+public surface, it must either become an owner-module migration target or be
+reclassified with an explicit ADR and support-tier impact.
+
+## Required Package Metadata
+
+The package-boundary ledger must record enough data for automation and review:
+
+- package name;
+- package path;
+- category;
+- owner surface or owning module;
+- publish intent;
+- support-tier impact;
+- CI lane or risk-pack impact;
+- migration target when category is owner-module migration target;
+- removal or promotion condition;
+- date and PR that last changed the classification.
+
+The future ledger location is expected to be `../../policy/package-boundary.toml`.
+Until that file exists, this spec is the behavior contract and implementation
+plans must not invent conflicting category names.
+
+## Non-Goals
+
+This spec does not:
+
+- move, merge, publish, or delete any package;
+- decide which current packages belong in each category;
+- change Cargo metadata by itself;
+- change branch protection or CI routing by itself;
+- define support-tier promotion rules beyond requiring links to
+  `../status/SUPPORT_TIERS.md`;
+- require every dev-only crate to be collapsed immediately.
+
+## Required Evidence
+
+A package-boundary implementation must provide:
+
+- a machine-readable package-boundary ledger;
+- a verifier that checks every workspace package has exactly one category;
+- a verifier failure when a package is production-used, unpublished, and not a
+  migration target;
+- a verifier failure when an owner-module migration target has no owner or no
+  exit condition;
+- a docs update for any change that alters stable product claims;
+- a CI or local proof command that can be run before package-collapse PRs land.
+
+## Acceptance Examples
+
+### Published crate
+
+`adze` is a published crate because it is a user-facing runtime package and has
+stable product claims in `../status/SUPPORT_TIERS.md`.
+
+A published crate must have release metadata, support-tier mapping for stable
+claims, and a supported proof path.
+
+### Dev-only crate
+
+A benchmark, fixture, or repo-policy helper package can be dev-only when it is
+not part of the advertised runtime or generated-parser API and exists to support
+tests, measurement, examples, or automation.
+
+A dev-only crate must not be cited as a stable production surface unless it is
+reclassified.
+
+### Owner-module migration target
+
+A single-use helper crate consumed by one public crate can be a migration target
+when its desired end state is an internal module under that owner.
+
+The classification must name the target owner and the condition that closes the
+migration.
+
+### Invalid durable category
+
+A package cannot remain indefinitely classified as:
+
+```text
+unpublished production crate
+```
+
+That state hides a production dependency from release, support-tier, and CI
+economics decisions. It must be converted to a published crate, dev-only crate,
+or owner-module migration target.
+
+## Test Mapping
+
+The package-boundary verifier should include tests for:
+
+- every workspace member appears in the ledger;
+- unknown package names fail validation;
+- duplicate package entries fail validation;
+- each package has exactly one category;
+- published packages have publish intent and release metadata checks;
+- dev-only packages cannot be marked as stable product proof surfaces;
+- migration targets have owner and exit-condition fields;
+- production-used unpublished packages fail unless they are migration targets;
+- policy changes produce stable diagnostics that identify the package and field.
+
+These tests may live in xtask or a dedicated policy-check crate, but the command
+must be documented in the implementation plan.
+
+## Implementation Mapping
+
+Expected implementation surfaces:
+
+- `policy/package-boundary.toml` for package classification;
+- an xtask verifier such as `cargo run -q -p xtask -- check-package-boundary`;
+- `Cargo.toml` workspace metadata only when a later implementation PR changes
+  package membership or release metadata;
+- `docs/status/SUPPORT_TIERS.md` when stable product claims change;
+- `policy/ci-lane-whitelist.toml` and `policy/ci-risk-packs.toml` when package
+  classification changes CI routing.
+
+Specs and proposals must link to those ledgers instead of duplicating their
+contents.
+
+## CI Proof
+
+The intended proof sequence for package-boundary changes is:
+
+```bash
+cargo metadata --format-version 1 --no-deps
+cargo run -q -p xtask -- check-package-boundary
+just ci-supported
+```
+
+Implementation PRs may add narrower tests for the verifier. Package-collapse PRs
+must run the verifier and the supported gate after any workspace membership or
+Cargo metadata change.
+
+## Metrics / Promotion Rule
+
+This spec is satisfied for 0.9 when:
+
+- every workspace member is classified in the package-boundary ledger;
+- the verifier is part of the documented 0.9 proof sequence;
+- no package is classified as a durable unpublished production crate;
+- every migration target has an owner and exit condition;
+- support-tier and CI policy docs are updated when package classification
+  changes stable claims or CI routing.
+
+The package-boundary policy can be promoted from proposal-level guidance to an
+accepted repo contract after the ledger and verifier have both landed and
+`just ci-supported` is green with the verifier in the 0.9 proof sequence.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,121 @@
+# Specs
+
+Specs are the behavior-contract layer. They define what must be true, what is
+out of scope, how the behavior is accepted, and which proof commands establish
+the contract.
+
+Specs are not proposals, ADRs, or task plans. They should link to those layers
+instead of copying their contents.
+
+## Source Of Truth
+
+Specs own:
+
+- behavior requirements
+- non-goals
+- acceptance examples
+- required evidence
+- implementation ownership boundaries
+- test and CI proof mapping
+- support-tier promotion criteria
+
+Other artifacts own:
+
+- why the work exists: `docs/proposals/`
+- durable architecture decisions: `docs/adr/`
+- PR-sized sequencing: `plans/<milestone>/`
+- active agent/operator state: `.adze/goals/active.toml`
+- product claim proof mapping: `docs/status/SUPPORT_TIERS.md`
+- exception ledgers: `policy/*.toml`
+
+## Naming
+
+Use stable IDs:
+
+```text
+ADZE-SPEC-0001-short-kebab-title.md
+```
+
+Examples:
+
+```text
+ADZE-SPEC-0001-package-surface-boundary.md
+ADZE-SPEC-0002-ci-economics.md
+ADZE-SPEC-0003-canonical-parse-document.md
+```
+
+## Header
+
+Every spec should start with:
+
+```md
+Status: proposed | accepted | implemented | superseded
+Owner:
+Created:
+Linked proposal:
+Linked ADRs:
+Linked plan:
+Linked issues:
+Linked PRs:
+Support-tier impact:
+Policy impact:
+```
+
+## Template
+
+```md
+# ADZE-SPEC-0001: Title
+
+Status:
+Owner:
+Created:
+Linked proposal:
+Linked ADRs:
+Linked plan:
+Linked issues:
+Linked PRs:
+Support-tier impact:
+Policy impact:
+
+## Problem
+
+What behavior or contract gap exists?
+
+## Behavior
+
+What must be true?
+
+## Non-Goals
+
+What is out of scope?
+
+## Required Evidence
+
+What proof is required?
+
+## Acceptance Examples
+
+Concrete examples of accepted and rejected behavior.
+
+## Test Mapping
+
+Which tests, fixtures, or snapshots cover this contract?
+
+## Implementation Mapping
+
+Which crates, modules, docs, or policy files own the implementation?
+
+## CI Proof
+
+Which commands and CI lanes prove the contract?
+
+## Metrics And Promotion Rule
+
+What moves this from experimental/advisory to stable?
+```
+
+## Duplication Rule
+
+Specs may reference product claims in `docs/status/SUPPORT_TIERS.md`, but must
+not copy the full feature-to-proof table. Specs may reference CI economics and
+exceptions in `policy/*.toml`, but must not copy policy ledgers into prose.

--- a/plans/0.9.0/README.md
+++ b/plans/0.9.0/README.md
@@ -1,0 +1,87 @@
+# Adze 0.9.0 Plans
+
+This directory is the operational planning layer for the 0.9.0 milestone.
+Implementation plans define PR-sized sequencing and proof commands. They do not
+own product motivation, behavior contracts, or durable architecture decisions.
+
+## Source Of Truth
+
+Plans own:
+
+- work item order
+- PR-sized production deltas
+- blockers and dependencies
+- proof commands
+- rollback notes
+- closeout or handoff status
+
+Other artifacts own:
+
+- release direction and milestone strategy: `../../ROADMAP.md`
+- why a campaign exists: `../../docs/proposals/`
+- behavior contracts: `../../docs/specs/`
+- durable architecture decisions: `../../docs/adr/`
+- active agent/operator state: `../../.adze/goals/active.toml`
+- product claim proof mapping: `../../docs/status/SUPPORT_TIERS.md`
+- policy ledgers: `../../policy/*.toml`
+
+## Expected Files
+
+Use `implementation-plan.md` for the milestone overview, then split substantial
+work into focused files:
+
+```text
+implementation-plan.md
+microcrate-collapse.md
+rust-1.95.md
+ci-economics-v2.md
+clippy-policy.md
+product-proof.md
+release-polish.md
+closeout.md
+```
+
+## Work Item Template
+
+````md
+## Work Item: short-kebab-id
+
+Status: ready | active | blocked | complete | superseded
+Linked proposal:
+Linked spec:
+Linked ADR:
+Blocks:
+Blocked by:
+
+### Goal
+
+What outcome does this PR-sized item produce?
+
+### Production Delta
+
+What files, crates, policy entries, or docs are expected to change?
+
+### Non-Goals
+
+What must stay out of this work item?
+
+### Acceptance
+
+What must be true when the item is complete?
+
+### Proof Commands
+
+```bash
+just ci-supported
+```
+
+### Rollback
+
+How should this be reverted or disabled if it fails?
+````
+
+## Duplication Rule
+
+Plans should link to specs for behavior and to `docs/status/SUPPORT_TIERS.md`
+for product-claim proof. They should not recreate the full support-tier table
+or policy TOML contents.


### PR DESCRIPTION
## Summary
- adds `ADZE-SPEC-0001` for the package surface boundary contract
- defines the allowed package categories and the rule that there is no durable unpublished production crate category
- maps required evidence, acceptance examples, test coverage, implementation surfaces, and CI proof without changing code or package membership

## Stack
- stacked on #682 (`docs(proposal): add 0.9 contract convergence`)
- base branch: `codex/prop-0001-contract-convergence`

## Validation
- `git diff --cached --check`