### PR TITLE
docs(ci): codify CI economics rollout

### DIFF
--- a/.github/CI_LANES.md
+++ b/.github/CI_LANES.md
@@ -1,6 +1,6 @@
 # CI Lane Map
 
-**Last updated:** 2026-05-08
+**Last updated:** 2026-05-12
 **Purpose:** Classify every CI check so contributors can immediately tell
 whether a red mark means "must fix before merge" or "inspect at your leisure."
 
@@ -13,7 +13,7 @@ whether a red mark means "must fix before merge" or "inspect at your leisure."
 | **Push / scheduled** | Runs on `main` pushes or schedules. Not PR-blocking. | Inspect trend; fix in a follow-up. |
 | **Advisory** | Uses nightly / unstable toolchains, `continue-on-error`, or non-blocking labels. May be red due to toolchain drift. | Inspect if curious. Not actionable for most PRs. |
 
-Branch protection requires exactly one check: **`CI / ci-supported`** (via `pr-gate.yml`).
+Branch protection currently requires exactly one check: **`CI / ci-supported`**. The planned stable aggregate context is **`PR Gate / PR Gate Success`** after the promotion criteria in `docs/ci/branch-protection.md` are met.
 
 ---
 
@@ -27,7 +27,26 @@ Branch protection requires exactly one check: **`CI / ci-supported`** (via `pr-g
 | `pr-gate.yml` | `PR Gate Success` | PR + merge_group | Aggregate: plan + supported/docs gate must pass |
 | `pr-gate.yml` | `PR Plan` | PR | Computes docs_only, estimated LEM, budget band |
 
-Required branch protection context: `CI / ci-supported` (maps to the `ci-supported` job in `ci.yml`, also exercised via `pr-gate.yml`).
+Required branch protection context today: `CI / ci-supported`. Target required context after the dedicated promotion PR: `PR Gate / PR Gate Success`. Do not require raw matrix leaves.
+
+### Target ordinary PR shape
+
+Ordinary PRs should normally stay within 25–35 LEM and select one cheap
+required proof plus routed/advisory signal:
+
+| Lane | Blocking | Target LEM |
+| --- | ---: | ---: |
+| PR Plan | no | ~1 |
+| Supported Rust Gate | yes | ~18–22 |
+| PR Gate Success | yes, after promotion | ~1 |
+| CI Lane Whitelist | advisory | ~1–2 |
+| ripr advisory | advisory | ~3–5 |
+| test-policy smoke | advisory or blocking | ~1–3 |
+
+Docs-only PRs should run PR Plan, Docs Gate, PR Gate Success, and cheap policy
+lint only. Platform matrices, full coverage, fuzzing, benchmark comparisons,
+ts-bridge parity, full test inventory, and release/API checks are routed by
+paths, labels, schedules, `main`, manual dispatch, or release events.
 
 ### PR-only signal (non-blocking)
 

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -81,3 +81,60 @@ labels:
   - name: good first issue
     color: "7057ff"
     description: Good for newcomers
+  - name: full-ci
+    color: "b60205"
+    description: Run the full routed CI suite for this PR
+  - name: ci-budget-ack
+    color: "fbca04"
+    description: Acknowledge elevated or high CI LEM budget
+  - name: ci-budget-override
+    color: "d93f0b"
+    description: Allow over-ceiling CI LEM budget with explicit approval
+  - name: platform-matrix
+    color: "5319e7"
+    description: Run full OS and toolchain matrix verification
+  - name: coverage
+    color: "1d76db"
+    description: Run coverage instrumentation and reporting
+  - name: ci:golden
+    color: "c5def5"
+    description: Run grammar golden/parity verification
+  - name: ci:perf
+    color: "c5def5"
+    description: Run performance comparison lanes
+  - name: ci:microcrate
+    color: "5319e7"
+    description: Run full microcrate verification
+  - name: ci:concurrency
+    color: "5319e7"
+    description: Run concurrency-focused microcrate verification
+  - name: wasm
+    color: "006b75"
+    description: Run WASM verification lanes
+  - name: fuzz
+    color: "d93f0b"
+    description: Run fuzzing lanes
+  - name: benchmarks
+    color: "c5def5"
+    description: Run full benchmark suite
+  - name: api
+    color: "0075ca"
+    description: Run public API and SemVer checks
+  - name: release-check
+    color: "006b75"
+    description: Run release readiness verification
+  - name: security-audit
+    color: "e11d21"
+    description: Run security audit verification
+  - name: mutation
+    color: "d93f0b"
+    description: Run mutation testing lanes
+  - name: property-tests
+    color: "1d76db"
+    description: Run property-test verification lanes
+  - name: skip-golden
+    color: "ededed"
+    description: Skip default golden checks when explicit opt-in is absent
+  - name: skip-perf
+    color: "ededed"
+    description: Skip default performance comparison when explicit opt-in is absent

--- a/docs/ci/adze-rollout-plan.md
+++ b/docs/ci/adze-rollout-plan.md
@@ -1,80 +1,127 @@
 # Adze CI economics rollout plan
 
-This document is the per-PR map for the rollout. It describes what each PR
-should do, what should not be combined, and what the rollback path looks like.
+This document is the status ledger for the CI economics rollout. The detailed
+agent contract and acceptance commands live in
+`docs/ci/implementation-sequence.md`.
 
-The rollout target:
+The rollout is CI infrastructure product work, not workflow cleanup. The
+product invariant is:
 
-```
-ordinary PR:        <35 LEM preferred, usually <$0.50
-elevated PR:        35–75 LEM, explicit risk surface
-high-cost PR:       75–125 LEM, explicit label/ack
-over ceiling:       >125 LEM requires override
-```
+> Every PR gets one cheap required proof. Everything else is advisory,
+> routed, scheduled, manual, release-only, or label-triggered.
+
+## Budget target
+
+| Rule | Value |
+| --- | ---: |
+| Preferred ordinary PR | <=25 LEM |
+| Ordinary PR ceiling | <=35 LEM |
+| Elevated PR | 36–75 LEM, explicit risk surface |
+| High-cost PR | 76–125 LEM, explicit label/ack |
+| Over ceiling | >125 LEM, requires `full-ci` or `ci-budget-override` |
+
+Linux is the unit runner (`1.0`), Windows is `2.0`, and macOS is `10.0`.
+Windows and macOS must not be ordinary PR defaults.
 
 ## Status legend
 
-- ✅ landed — change is in `main`
-- 🟡 in flight — open PR or partially merged on the rollout branch
+- ✅ landed — present on `main` and represented in the current control plane
+- 🟡 needs hardening — present, but still too broad, advisory-only, or waiting
+  for a dedicated hardening PR
+- 🔴 needs pruning — duplicate or too expensive for ordinary PR defaults
 - ⏳ planned — not yet started
-- ⏸ deferred — needs actuals data or coordination
+- ⏸ deferred — intentionally waiting on actuals or operator coordination
 
-## PRs
+## Already present
 
-| # | Title | Status | Notes |
-| --- | --- | --- | --- |
-| 01 | docs(ci): verification economics policy | 🟡 | This doc set |
-| 02 | chore(ci): add CI lane whitelist map | 🟡 | `policy/ci-lane-whitelist.toml` |
-| 03 | ci(policy): lint workflows against whitelist | 🟡 | `cargo xtask check-ci-lane-whitelist` |
-| 04 | feat(ci): advisory PR Plan with LEM estimates | 🟡 | `.github/workflows/pr-plan.yml` |
-| 05 | ci: add PR Gate Success summary | 🟡 | additive only |
-| 06 | perf(ci): make PR caches restore-only | 🟡 | save-if-main on bare rust-cache usages |
-| 07 | ci(ripr): advisory static exposure | 🟡 | non-blocking |
-| 08 | ci(policy): risk-pack routing map | 🟡 | `policy/ci-risk-packs.toml` |
-| 09 | feat(xtask): `xtask ci plan` | 🟡 | testable planner |
-| 10 | perf(ci): gate fuzzing to nightly and labels | 🟡 | label-gated, build-only smoke for parser PRs |
-| 11 | perf(ci): unify benchmark PR ownership | 🟡 | benchmarks.yml off PR default |
-| 12 | perf(ci): route golden tests by grammar risk | 🟡 | paths filter + label gate |
-| 13 | perf(ci): reduce pure-rust PR matrix | 🟡 | matrix-setup job + label gates |
-| 14 | perf(ci): route microcrate CI by risk pack | 🟡 | changes setup job + per-group gates |
-| 15 | ci: emit LEM actuals telemetry | 🟡 | additive only |
-| 16 | ci(plan): warn on elevated LEM | 🟡 | soft warnings only |
-| 17 | ci: make PR Gate Success the required check | ⏸ | needs ≥14 days stable data; see docs/ci/branch-protection.md |
-| 18 | ci(metrics): learned LEM estimates | ⏸ | needs ≥30 days of actuals; see docs/ci/learned-estimates.md |
+| Rail | Status | Notes |
+| --- | --- | --- |
+| LEM doctrine and bands | ✅ | `docs/ci/cost-and-verification-policy.md` defines LEM, runner multipliers, and the static budget bands. |
+| Lane registry | ✅ | `policy/ci-lane-whitelist.toml` records lane owner, cost, proof obligation, evidence, duplicate map, and review dates. |
+| Risk-pack vocabulary | ✅ | `policy/ci-risk-packs.toml` maps paths and labels to risk-routed verification. |
+| PR Plan | ✅ | `.github/workflows/pr-plan.yml` forecasts changed surfaces, selected lanes, and budget band. |
+| PR Gate workflow | ✅ | `.github/workflows/pr-gate.yml` contains Supported Rust Gate, Docs Gate, and PR Gate Success. |
+| CI actuals scaffold | ✅ | `ci-actuals.json` emission exists and is the input to future learned estimates. |
+| Coverage routing | ✅ | Coverage is non-default and selected by label, main, or manual dispatch. |
 
-## What this rollout branch contains
+## Needs hardening
 
-The rollout branch (`claude/adze-ci-economics-rollout-IxzNZ`) contains
-**PRs 01–16**, stacked. Branch-protection promotion (17) and learned
-estimates (18) are documented but intentionally deferred:
+| Rail | Status | Hardening needed |
+| --- | --- | --- |
+| Branch protection | 🟡 | Promote the required context from `CI / ci-supported` to `PR Gate / PR Gate Success` only after stability criteria in `docs/ci/branch-protection.md` are met. |
+| Lane whitelist lint | 🟡 | Keep advisory generally, but make blocking for workflow/policy/CI-doc changes. |
+| PR Plan budgets | 🟡 | Enforce static ceilings before learned estimates: warn for elevated/high and fail over ceiling unless `full-ci` or `ci-budget-override` is present. |
+| Test policy | 🟡 | Split cheap PR smoke from full inventory/runtime enforcement. |
+| CI labels | 🟡 | Keep repo settings synchronized with `docs/ci/labels.md` and `policy/ci-risk-packs.toml`. |
+| CI actuals | 🟡 | Normalize receipts to per-lane wall minutes, multiplier, selected-by reasons, result, and total LEM. |
 
-- **17** changes branch protection. It needs ≥14 days of `PR Gate
-  Success` history and explicit operator coordination. See
-  `docs/ci/branch-protection.md` for the promotion criteria.
-- **18** needs ≥30 days of `ci-actuals.json` data to compute meaningful
-  percentiles. Until then, static estimates are correct. See
-  `docs/ci/learned-estimates.md` for the model and promotion criteria.
+## Needs pruning
+
+| Lane/workflow | Status | Pruning objective |
+| --- | --- | --- |
+| Legacy `ci.yml` PR trigger | 🔴 | After PR Gate is required, remove ordinary `pull_request` execution so the old umbrella lane does not duplicate the supported proof. |
+| `pure-rust-ci.yml` | 🔴 | Make platform proof label/main/manual/scheduled only; no ordinary PR OS/toolchain matrix. |
+| `microcrate-ci.yml` | 🔴 | Keep path-matched crate-group tests; route docs, WASM, formatting, and strict-feature checks away from ordinary PR default. |
+| `performance.yml` / `benchmarks.yml` | 🔴 | Keep compile smoke path-routed; label-gate benchmark comparisons and full suites. |
+| `smoke-ts-bridge.yml` / `ts-bridge-smoke.yml` / `ts-bridge-parity.yml` | 🔴 | Keep one path-routed smoke lane; move parity to main/schedule/manual/label. |
+| API / SemVer checks | 🔴 | Route by public API paths or `api`/`release-check`/`breaking-change`/`full-ci` labels. |
+
+## Deferred until actuals
+
+| Item | Status | Promotion condition |
+| --- | --- | --- |
+| Learned LEM estimates | ⏸ | At least 30 days or enough per-lane samples with stable p50/p90/p95. |
+| Lane ledger ratchet | ⏸ | Update `base_lem` only after measured p90 evidence and owner review. |
+
+## Next implementation wave
+
+The next wave should proceed in this order. See
+`docs/ci/implementation-sequence.md` for the per-PR proof obligations and
+rollback paths.
+
+| Step | Title | Kind |
+| ---: | --- | --- |
+| 1 | `docs(ci): reconcile CI economics rollout status` | control plane |
+| 2 | `ci(labels): add CI routing labels` | operator interface |
+| 3 | `ci: require PR Gate Success as the stable merge gate` | branch protection |
+| 4 | `ci: stop running legacy ci.yml on ordinary PRs` | duplicate removal |
+| 5 | `ci(test-policy): split PR smoke from full inventory enforcement` | cost reduction |
+| 6 | `ci(pure-rust): make platform proof label and main only` | cost reduction |
+| 7 | `ci(microcrate): route docs wasm and strict features off ordinary PRs` | cost reduction |
+| 8 | `ci(perf): keep benchmark smoke default but label-gate comparisons` | cost reduction |
+| 9 | `ci(ts-bridge): consolidate smoke and move parity off default PR` | duplicate removal |
+| 10 | `ci(api): route public API checks by API risk` | routing |
+| 11 | `ci(policy): block undeclared workflow lanes` | guardrail |
+| 12 | `ci(plan): enforce static LEM ceilings with override labels` | guardrail |
+| 13 | `ci: split main smoke from nightly deep verification` | main cost control |
+| 14 | `ci(actuals): normalize per-lane LEM receipts` | metrics |
+| 15 | `ci(metrics): compute learned lane estimates from actuals` | deferred metrics |
+| 16 | `ci(metrics): update lane LEM baselines from measured actuals` | deferred ratchet |
 
 ## Per-PR contract
 
-Each PR body in this rollout must include:
+Each CI economics PR body must include:
 
-- estimated LEM impact
-- workflows touched
-- default PR effect
-- rollback path
-- proof obligation
-- cheaper signal considered
-- branch protection impact (almost always: none, until PR 17)
+- estimated LEM impact,
+- workflows touched,
+- default PR effect,
+- branch-protection impact,
+- rollback path,
+- proof obligation,
+- cheaper signal considered,
+- whether expensive runners were added, and
+- confirmation that macOS/windows are not ordinary PR defaults.
 
 ## Rollback paths
 
 | Layer | Rollback |
 | --- | --- |
-| docs | revert PR |
-| policy TOML | revert PR; advisory lints stop firing |
-| advisory workflow (PR Plan, ripr, whitelist lint) | delete the workflow file |
-| PR Gate Success | delete the workflow file; old required checks remain |
-| cache normalization | revert per-workflow `save-if` lines |
-| risk-pack routing | revert path filters; lanes go back to default-on |
-| branch protection promotion | switch the required check back |
+| docs | revert the docs-only PR |
+| labels | revert `.github/settings.yml` label entries |
+| policy TOML | revert the ledger change; advisory lint stops reporting the new rule |
+| advisory workflow | disable/delete the workflow or restore previous `if:` guard |
+| PR Gate Success promotion | switch required context back to `CI / ci-supported` |
+| legacy PR trigger pruning | restore the `pull_request` trigger |
+| risk-pack routing | restore old path filters and label conditions |
+| budget enforcement | return PR Plan to advisory-only mode |
+| actuals / learned estimates | fall back to static `base_lem` |

--- a/docs/ci/branch-protection.md
+++ b/docs/ci/branch-protection.md
@@ -2,9 +2,9 @@
 
 ## Today
 
-The required check today is the existing `ci-supported` job in `ci.yml`
-(see `docs/status/KNOWN_RED.md`). Branch protection has not been changed
-by the rollout.
+The required check today is the existing branch-protection context
+`CI / ci-supported` configured in `.github/settings.yml`. Branch protection
+has not been changed by the control-plane rollout.
 
 ## Future
 
@@ -18,13 +18,18 @@ The rollout introduces a new aggregated check called **PR Gate Success**
 `PR Gate Success` succeeds when exactly one of `Supported Rust Gate` /
 `Docs Gate` succeeded and the other was skipped. PR Plan must not fail.
 
-This is **additive only** in the rollout's foundation phase. Branch
-protection is *not* updated yet. PR 17 in `docs/ci/adze-rollout-plan.md`
-is the dedicated change that flips the required check to
-`PR Gate Success` once the workflow has been stable for a sufficient
-window of PRs.
+This is **additive only** until the dedicated promotion PR. The promotion PR
+changes only branch-protection settings and docs; it must not also prune
+legacy workflows. The target required context is:
 
-## PR 17 — promotion criteria
+```yaml
+required_status_checks:
+  strict: true
+  contexts:
+    - "PR Gate / PR Gate Success"
+```
+
+## Promotion criteria
 
 Branch protection promotion to `PR Gate Success` is gated on:
 
@@ -36,21 +41,30 @@ Branch protection promotion to `PR Gate Success` is gated on:
 | `ci-actuals.json` artifacts uploaded | ≥ 30 PRs |
 | Manual review of band/LEM accuracy | passes |
 
-When all five gates clear, PR 17 is opened. PR 17 itself only:
+When all five gates clear, open the promotion PR. That PR itself only updates
+`.github/settings.yml` (and any equivalent platform config) to require
+`PR Gate / PR Gate Success` and stop requiring the legacy `CI / ci-supported`
+context.
 
-1. updates `.github/settings.yml` (and any equivalent platform config) to
-   require `PR Gate Success` and stop requiring the legacy `ci-supported`
-   job, **and**
-2. removes the redundant `ci-supported` job from `ci.yml` if it is no
-   longer used by anything else (it is also reachable via the new
-   `pr-gate.yml`).
+Do not remove or prune legacy workflow execution in the same PR. The follow-up
+PR that removes ordinary `pull_request` execution from `ci.yml` is separate so
+branch-protection rollback remains simple.
 
 ## Rollback
 
 Removing `pr-gate.yml` reverts to the existing required check. No state
 needs migrating because PR Gate Success is a new, separate workflow.
 
-If PR 17 has landed and the new required check is causing problems, the
-rollback is to restore the previous required check name in
-`.github/settings.yml` and re-add the legacy `ci-supported` job
-configuration.
+If the promotion PR has landed and the new required check is causing problems,
+the rollback is to restore the previous required check name in
+`.github/settings.yml`:
+
+```yaml
+required_status_checks:
+  strict: true
+  contexts:
+    - "CI / ci-supported"
+```
+
+If the later legacy-PR-trigger pruning has also landed, restore that trigger in
+`.github/workflows/ci.yml` as a second, explicit rollback step.

--- a/docs/ci/ci-lane-whitelist.md
+++ b/docs/ci/ci-lane-whitelist.md
@@ -49,7 +49,7 @@ Run via:
 cargo xtask check-ci-lane-whitelist
 ```
 
-The lint warns (advisory) when:
+The lint currently warns (advisory) when:
 
 - a workflow file has jobs not listed in the whitelist,
 - a lane is `default_pr=true` and `expensive=true` without an exception id,
@@ -67,3 +67,23 @@ The lint warns (advisory) when:
    owner, an issue pointer, a `review_after`, and an `expires`.
 3. When the lane is later routed by risk pack or label, the exception is
    removed and the lane's `default_pr` is set to `false`.
+
+
+## Blocking mode rollout
+
+The blocking-mode rollout is intentionally scoped to CI-control-plane changes.
+It should fail only when files such as `.github/workflows/**`,
+`policy/ci-*.toml`, `docs/ci/**`, `scripts/ci/**`, or `xtask/**` change and
+the change introduces an undeclared or unsafe lane.
+
+Blocking-mode failure cases include:
+
+- a new PR-default job without a lane entry,
+- a new macOS or Windows default PR lane,
+- missing `owner`, `intent`, `failure_mode`, `proof_obligation`, or evidence,
+- `default_pr = true` with `base_lem > 35` and no active exception, and
+- omitted `duplicate_of` metadata when the lane intentionally duplicates an
+  existing proof.
+
+This keeps ordinary feature PRs from being blocked by policy-ledger churn while
+still preventing workflow sprawl when CI files are edited.

--- a/docs/ci/cost-and-verification-policy.md
+++ b/docs/ci/cost-and-verification-policy.md
@@ -40,45 +40,44 @@ the design center.
 
 | Tier | Trigger | Examples |
 | --- | --- | --- |
-| frontdoor | every PR, blocking | `just ci-supported`, test-policy |
-| advisory | every PR, non-blocking | PR Plan, ripr |
-| risk-routed | risk pack matches | parser fuzz build, golden, microcrate group |
+| frontdoor | every PR, blocking | `just ci-supported`, PR Gate Success after promotion |
+| advisory | every PR, non-blocking | PR Plan, ripr, CI lane whitelist |
+| risk-routed | risk pack or label matches | test-policy full, parser fuzz build, golden, microcrate group, API/SemVer |
 | deep | `main`, nightly, label | OS matrix, fuzz runtime, full benchmarks |
 | release | tag, manual | semver, MSRV, security audit |
 
-## How we get there
+## Implementation order
 
-The rollout is not "delete CI". It is, in order:
+The rollout is not "delete CI". It proceeds in this control-plane order:
 
-1. Document the policy (this doc).
-2. Inventory every existing CI lane in `policy/ci-lane-whitelist.toml`.
-3. Lint workflows against that whitelist (advisory).
-4. Forecast each PR's cost with PR Plan (advisory).
-5. Stand up `PR Gate Success` as the future required check.
-6. Normalize cache save semantics so PRs restore but only `main` saves.
-7. Add `ripr` as cheap oracle-gap detection.
-8. Encode risk packs so routing has a vocabulary.
-9. Make planning testable with `xtask ci plan`.
-10. Route the heavy lanes (fuzz, OS matrix, benchmarks, golden, microcrate) by
-    risk pack and label.
-11. Calibrate from actuals.
-12. Promote `PR Gate Success` to the required branch protection.
+1. Stabilize docs/control plane.
+2. Make PR Gate authoritative.
+3. Remove duplicate ordinary-PR execution.
+4. Route expensive lanes harder.
+5. Enforce lane metadata.
+6. Add labels and branch-protection rails.
+7. Collect actuals.
+8. Ratchet budgets from measured data.
 
-See `docs/ci/adze-rollout-plan.md` for the per-PR breakdown.
+The next implementation wave is specified in
+`docs/ci/implementation-sequence.md`. `docs/ci/adze-rollout-plan.md` is the
+current status ledger.
 
 ## What we will not do
 
 - Weaken the supported product proof lane (`just ci-supported`).
 - Make `ripr` blocking.
 - Enforce learned LEM budgets before actuals exist.
-- Combine docs, policy, and routing changes into a single PR.
-- Remove broad validation from `main`/nightly/label paths.
+- Combine docs, branch protection, and workflow pruning into a single PR.
+- Remove broad validation from `main`/nightly/manual/label/release paths.
+- Add macOS or Windows as ordinary default PR lanes.
 
 ## Related
 
 - `docs/ci/lem-budgeting.md` – how LEM is computed and budgeted
 - `docs/ci/verification-ladder.md` – tiers and what they prove
-- `docs/ci/adze-rollout-plan.md` – per-PR rollout plan and status
+- `docs/ci/adze-rollout-plan.md` – rollout status ledger
+- `docs/ci/implementation-sequence.md` – ordered implementation contract
 - `docs/ci/labels.md` – label vocabulary used by routing
 - `policy/ci-lane-whitelist.toml` – lane registry
 - `policy/ci-risk-packs.toml` – risk pack routing map

--- a/docs/ci/implementation-sequence.md
+++ b/docs/ci/implementation-sequence.md
@@ -1,0 +1,135 @@
+# CI economics implementation sequence
+
+This is the agent-facing implementation contract for the next CI economics
+wave. Treat the work as CI infrastructure product work, not workflow cleanup.
+The product invariant is:
+
+> Every PR gets one cheap required proof. Everything else is advisory,
+> routed, scheduled, manual, release-only, or label-triggered.
+
+## Default PR shape
+
+Ordinary Rust PRs should normally select this shape:
+
+| Lane | Blocking | Target LEM | Notes |
+| --- | ---: | ---: | --- |
+| PR Plan | no | ~1 | Changed surfaces, selected lanes, budget band |
+| Supported Rust Gate | yes | ~18–22 | `just ci-supported` |
+| PR Gate Success | yes | ~1 | Stable required aggregate after promotion |
+| CI lane whitelist | advisory | ~1–2 | Prevent workflow sprawl |
+| ripr advisory | advisory | ~3–5 | Static oracle-gap signal; skip docs-only |
+| test-policy smoke | advisory or blocking | ~1–3 | Disabled-test and inventory hygiene only |
+
+Docs-only PRs should normally select this shape:
+
+| Lane | Blocking | Target LEM |
+| --- | ---: | ---: |
+| PR Plan | no | ~1 |
+| Docs Gate | yes | ~1–2 |
+| PR Gate Success | yes | ~1 |
+| policy lint | advisory | ~1 |
+
+Everything else is non-default for ordinary PRs unless a changed path, label,
+manual dispatch, schedule, `main`, release, or merge-queue rule selects it.
+
+## Static budget contract
+
+The rollout uses static `base_lem` estimates until enough actuals exist.
+The current ordinary PR contract is:
+
+| Budget rule | Value |
+| --- | ---: |
+| Preferred ordinary PR | <=25 LEM |
+| Ordinary PR ceiling | <=35 LEM |
+| Elevated warning | 36–75 LEM |
+| High-cost warning / explicit label recommendation | 76–125 LEM |
+| Hard ceiling without `full-ci` or `ci-budget-override` | >125 LEM |
+
+Linux is the unit runner (`1.0`), Windows is `2.0`, and macOS is `10.0`.
+Do not add Windows or macOS as default ordinary-PR lanes.
+
+## Source-of-truth files
+
+| File | Role |
+| --- | --- |
+| `docs/ci/cost-and-verification-policy.md` | Doctrine: LEM, budget bands, verification ladder |
+| `docs/ci/implementation-sequence.md` | This executable rollout order and per-PR contract |
+| `docs/ci/adze-rollout-plan.md` | Status table and implementation wave ledger |
+| `docs/ci/branch-protection.md` | Required-check migration criteria and rollback |
+| `docs/ci/labels.md` | Operator label vocabulary for expensive lanes |
+| `.github/CI_LANES.md` | Contributor-facing lane map and required/advisory semantics |
+| `policy/ci-lane-whitelist.toml` | Machine-readable lane registry and static LEM ledger |
+| `policy/ci-risk-packs.toml` | Path/label routing vocabulary |
+| `policy/ci-whitelist-exceptions.toml` | Temporary exceptions for expensive default lanes |
+
+When a PR changes user-facing CI semantics, update the docs and the lane
+ledger together. When a PR only documents a future phase, do not change
+workflow behavior.
+
+## Ordered implementation backlog
+
+The sequence is intentionally SRP. Do not combine branch-protection changes
+with workflow pruning, and do not combine docs-only reconciliation with large
+routing changes.
+
+| Step | Title | Purpose | Default PR effect | Branch protection impact | Acceptance |
+| ---: | --- | --- | --- | --- | --- |
+| 1 | `docs(ci): reconcile CI economics rollout status` | Normalize the control-plane docs and status tables. | None. | None. | `cargo xtask check-ci-lane-whitelist --mode advisory || true`; `cargo xtask policy-report || true`; `git diff --check` |
+| 2 | `ci(labels): add CI routing labels` | Add stable operator labels in repo settings. | None unless workflows already consume labels. | None. | `git diff --check` |
+| 3 | `ci: require PR Gate Success as the stable merge gate` | Make the aggregate check the single required context. | Required check name changes; proof stays `just ci-supported` or Docs Gate. | Required context becomes `PR Gate / PR Gate Success`. | `git diff --check` |
+| 4 | `ci: stop running legacy ci.yml on ordinary PRs` | Stop duplicate ordinary-PR execution after PR Gate is authoritative. | Removes legacy duplicate PR cost. | None if step 3 already landed. | `cargo xtask check-ci-lane-whitelist --mode advisory || true`; `git diff --check` |
+| 5 | `ci(test-policy): split PR smoke from full inventory enforcement` | Keep cheap hygiene on PRs and route full inventory to main/nightly/manual/labels. | Saves ~9–10 LEM. | Smoke can be advisory or blocking; full lane not required. | `cargo xtask test-policy-smoke`; `cargo xtask test-policy-full || true`; whitelist advisory; `git diff --check` |
+| 6 | `ci(pure-rust): make platform proof label and main only` | Remove Ubuntu/stable pure-rust duplicate from ordinary PRs. | Saves ~18 LEM. | None. | whitelist advisory; `git diff --check` |
+| 7 | `ci(microcrate): route docs wasm and strict features off ordinary PRs` | Keep matched crate-group tests; move docs/WASM/strict features to labels/main/manual. | Variable savings. | None. | whitelist advisory; `git diff --check` |
+| 8 | `ci(perf): keep benchmark smoke default but label-gate comparisons` | Leave compile smoke path-routed; move comparisons to labels/main/manual. | Saves up to ~35 LEM on perf paths. | None. | whitelist advisory; `git diff --check` |
+| 9 | `ci(ts-bridge): consolidate smoke and move parity off default PR` | Keep one path-routed smoke; move parity to main/schedule/manual/label. | Removes duplicate ts-bridge default cost. | None. | whitelist advisory; `git diff --check` |
+| 10 | `ci(api): route public API checks by API risk` | Only run SemVer/API checks on public API surfaces or labels. | Removes docs/fixture/test-only API cost. | Advisory until release prep. | `cargo semver-checks check-release -p adze || true`; `cargo public-api -p adze || true`; `git diff --check` |
+| 11 | `ci(policy): block undeclared workflow lanes` | Make lane-whitelist failures blocking only for workflow/policy/CI-doc changes. | Prevents future workflow sprawl. | None. | `cargo xtask check-ci-lane-whitelist --mode blocking`; `git diff --check` |
+| 12 | `ci(plan): enforce static LEM ceilings with override labels` | Warn/fail by static budget band; do not use learned estimates yet. | Over-ceiling PRs fail unless explicitly overridden. | None. | `cargo run -q -p xtask -- ci-plan --base origin/main --head HEAD --json-out target/ci/ci-plan.json`; fallback script; `git diff --check` |
+| 13 | `ci: split main smoke from nightly deep verification` | Prevent `main` pushes from becoming the new cost sink. | None. | None. | whitelist advisory; `git diff --check` |
+| 14 | `ci(actuals): normalize per-lane LEM receipts` | Emit per-lane wall minutes, multipliers, LEM, selection reason, and result. | None. | None. | `python3 scripts/ci/emit-ci-actuals.py`; `python3 -m json.tool target/ci/ci-actuals.json`; `git diff --check` |
+| 15 | `ci(metrics): compute learned lane estimates from actuals` | Produce advisory p50/p90/p95 estimates after enough samples. | None; advisory only. | None. | Learned-estimate generator output validates as JSON/Markdown. |
+| 16 | `ci(metrics): update lane LEM baselines from measured actuals` | Ratchet static ledger after sufficient measured evidence. | Updates estimates, not routing. | None. | Docs and `policy/ci-lane-whitelist.toml` updated together. |
+
+## Per-PR operating contract
+
+Every CI economics PR body must include:
+
+```markdown
+## CI economics
+
+- Estimated LEM impact:
+- Workflows touched:
+- Default PR effect:
+- Branch protection impact:
+- Rollback path:
+- Proof obligation:
+- Cheaper signal considered:
+- Expensive runners added? yes/no
+- macOS/windows default PR? must be no
+
+## Verification
+
+- [ ] `cargo xtask check-ci-lane-whitelist --mode advisory`
+- [ ] `cargo xtask policy-report || true`
+- [ ] `git diff --check`
+
+## Claim boundary
+
+This PR changes CI routing/cost only. It does not weaken `just ci-supported`,
+remove deep verification from main/nightly/release/manual paths, or make
+advisory lanes required.
+```
+
+## Agent rules
+
+1. One CI intention per PR.
+2. Never combine branch protection change with large workflow pruning.
+3. Never introduce macOS or Windows as default PR lanes.
+4. Never add a workflow job without a lane entry.
+5. Never make a raw matrix leaf a required branch-protection check.
+6. Keep `PR Gate Success` as the stable required summary after promotion.
+7. Keep deep verification available through main/nightly/manual/label/release.
+8. If a job is `duplicate_of` another lane, justify it or remove/reroute it.
+9. If a lane is expensive and `default_pr=true`, it needs an exception and expiry.
+10. After each merge, refresh `main` and rerun the lane whitelist check.

--- a/docs/ci/labels.md
+++ b/docs/ci/labels.md
@@ -1,47 +1,60 @@
 # CI labels
 
-The label vocabulary used by PR Plan to opt in to deeper verification.
+Labels are the operator interface for expensive verification. They give agents
+and maintainers stable names for selecting non-default lanes without turning
+those lanes into ordinary PR defaults.
 
 ## Cost labels
 
 | Label | Meaning |
 | --- | --- |
-| `ci-budget-ack` | acknowledge elevated/high LEM (35–125) |
-| `ci-budget-override` | allow >125 LEM |
-| `full-ci` | run all heavy lanes; implies budget override |
+| `ci-budget-ack` | Acknowledge elevated/high LEM (35–125). |
+| `ci-budget-override` | Allow over-ceiling static LEM (>125) when justified. |
+| `full-ci` | Run all heavy lanes that are available for PR opt-in; implies budget override. |
 
-## Risk-pack opt-in
-
-| Label | Adds |
-| --- | --- |
-| `ci:perf` | full benchmark comparison |
-| `ci:golden` | golden tests for grammars |
-| `ci:microcrate` | full microcrate CI matrix |
-| `ci:concurrency` | concurrency microcrate group |
-| `platform-matrix` | full OS/toolchain matrix |
-| `fuzz` | fuzz runtime |
-| `coverage` | coverage instrumentation |
-| `wasm` | wasm-check |
-
-## Release / API
+## Risk-pack opt-in labels
 
 | Label | Adds |
 | --- | --- |
-| `release-check` | release-gate verification |
-| `security-audit` | dependency / RUSTSEC audit |
-| `mutation` | mutation testing on parser/glr core |
-| `property-tests` | property-test runs on parser |
+| `platform-matrix` | Full OS/toolchain matrix. Not an ordinary PR default. |
+| `coverage` | Coverage instrumentation and upload. |
+| `ci:golden` | Golden parse-tree tests for grammars. |
+| `ci:perf` | Full benchmark comparison. |
+| `ci:microcrate` | Full microcrate CI matrix. |
+| `ci:concurrency` | Concurrency microcrate group. |
+| `wasm` | WASM checks. |
+| `fuzz` | Runtime fuzzing. |
+| `benchmarks` | Full benchmark suite. |
+| `property-tests` | Property-test runs on parser surfaces. |
+| `mutation` | Mutation testing on parser/GLR core. |
+
+## Release / API / security labels
+
+| Label | Adds |
+| --- | --- |
+| `api` | Public API / SemVer checks on API-risk PRs. |
+| `release-check` | Release-gate verification. |
+| `security-audit` | Dependency / RUSTSEC audit. |
+| `breaking-change` | Explicitly marks breaking API or behavior changes. |
 
 ## Skip labels
 
 | Label | Effect |
 | --- | --- |
-| `skip-golden` | skip golden tests (only honored when no `ci:golden`) |
-| `skip-perf` | skip perf compare (only honored when no `ci:perf`) |
+| `skip-golden` | Skip golden tests when no explicit `ci:golden` opt-in is present. |
+| `skip-perf` | Skip perf comparison when no explicit `ci:perf` opt-in is present. |
 
-## Notes
+## Repo settings requirement
 
-- Labels are advisory until the routing PRs (10–14) land. Until then they
-  appear in the PR Plan summary but do not change which lanes run.
-- Labels never *raise* the hard ceiling. They explain a high LEM number; they
-  do not silence safety checks.
+The labels above should exist in `.github/settings.yml` so the same vocabulary
+is available to humans, PR Plan, and risk-pack routing. Adding a label does not
+by itself add CI cost; workflows must explicitly route on it.
+
+## Rules
+
+- Labels may select deeper verification, but must not make macOS or Windows an
+  ordinary PR default.
+- Labels explain high cost and select lanes; they do not weaken
+  `just ci-supported`.
+- `ci-budget-override` is the only label that can permit an over-ceiling static
+  PR Plan once budget enforcement lands, and it should be rare.

--- a/docs/ci/learned-estimates.md
+++ b/docs/ci/learned-estimates.md
@@ -1,57 +1,88 @@
-# Learned LEM estimates (PR 18)
+# Learned LEM estimates
 
-Static `base_lem` values in `policy/ci-lane-whitelist.toml` are the
-starting estimate. Once `ci-actuals.json` artifacts have accumulated,
-the planner can use observed durations instead.
+Static `base_lem` values in `policy/ci-lane-whitelist.toml` are the source of
+truth until enough actuals exist. Learned estimates are intentionally deferred
+and advisory-only at first; they must not make a new lane cheaper merely
+because it has too few samples.
+
+## Inputs
+
+`ci-actuals.json` receipts should converge on this schema before learned
+estimates are enabled:
+
+```json
+{
+  "schema_version": 1,
+  "pr": 123,
+  "head_sha": "...",
+  "lanes": [
+    {
+      "id": "ci-supported",
+      "workflow": "PR Gate",
+      "job": "Supported Rust Gate",
+      "runner": "ubuntu_latest",
+      "wall_minutes": 21.4,
+      "runner_multiplier": 1.0,
+      "lem": 21.4,
+      "selected_by": ["default_pr"],
+      "result": "success"
+    }
+  ],
+  "total_lem": 27.2,
+  "budget_band": "ordinary"
+}
+```
+
+Receipts should be emitted per lane, not only per workflow, so duplicate lanes
+and routed lanes can be compared against the ledger independently.
 
 ## Promotion criteria
 
-PR 18 is opened when:
+Learned estimates may be introduced only after:
 
-- `target/ci/ci-actuals.json` artifacts have been uploaded by ≥ 30 PRs,
-- the runner-multiplier × wall-clock time for each lane has a stable
-  p50 and p90 within ±15% across two consecutive weeks,
-- the band thresholds (`35` / `75` / `125`) still match the operator's
-  cost target after observing actuals (see `docs/ci/lem-budgeting.md`).
+- at least 30 days of `ci-actuals.json` artifacts, or enough samples to cover
+  the default and routed lanes with stable percentiles,
+- each learned lane has sample count, p50, p90, p95, last-seen timestamp, and
+  outlier metadata,
+- p50 and p90 are stable within ±15% across two consecutive weeks,
+- the static budget thresholds (`25` / `35` / `75` / `125`) still match the
+  operator cost target after observing actuals, and
+- every expensive default lane has owner review before lowering an estimate.
 
-## Model
+## Advisory model
 
-```
-estimate(lane) = max(static_floor(lane), p50_recent_actual(lane) × 1.15)
-warning(lane)  = p90_recent_actual(lane)
-hard(lane)     = p95_recent_actual(lane)
-```
+The first learned-estimate PR only generates advisory artifacts:
 
-`static_floor` is the `base_lem` from the whitelist. The `× 1.15` factor
-keeps the estimate slightly pessimistic, so a normal PR's actuals stay
-under the estimate.
+- `target/ci/learned-estimates.json`
+- `docs/ci/learned-estimates.md` updates or generated tables
 
-## Implementation outline
+The advisory model should track:
 
-PR 18 will:
+| Field | Meaning |
+| --- | --- |
+| `p50_lem` | Median observed LEM for the lane |
+| `p90_lem` | Conservative planning baseline candidate |
+| `p95_lem` | Hard-warning candidate |
+| `sample_count` | Number of usable receipts |
+| `last_seen` | Most recent receipt timestamp |
+| `outliers` | Runs excluded or separately reported with reason |
 
-1. Add a `learned_estimates` section to the planner that loads the
-   most recent `ci-actuals.json` artifacts (from the previous N runs on
-   `main` or any matching workflow).
-2. Replace the static `base_lem` lookup in `xtask ci plan` with
-   `max(static_floor, p50_recent × 1.15)`.
-3. Continue to fall back to `base_lem` whenever fewer than 5 actuals
-   exist for a lane.
-4. Add `--enforce-hard-ceiling` to the workflow only if the band
-   thresholds have been validated against actuals.
+Do not block PRs from learned estimates in the first metrics PR.
 
-## Why this is deferred
+## Ratchet rules
 
-Until enough actuals exist, learned estimates are noisier than static
-ones. Worse, they make PR planning depend on historical data that may
-not exist for new lanes (a new lane has zero actuals and would either
-fall back to `base_lem` or be silently underestimated). Static
-estimates are correct in the meantime.
+When enough samples exist, update `policy/ci-lane-whitelist.toml` and docs
+together. The ratchet rules are:
 
-## Privacy and stability
+1. Require enough samples for the lane and runner class.
+2. Do not lower `base_lem` below observed p90 without an explicit written
+   reason.
+3. Keep Windows (`2.0`) and macOS (`10.0`) multipliers explicit.
+4. Require owner signoff for expensive default lanes.
+5. Preserve the static ledger as the auditable source of truth.
 
-- The learned estimates only consume aggregated p50/p90/p95 numbers.
-- They are stored in the planner's working memory, not committed to
-  the repo.
-- Static `base_lem` remains the audit trail; learned estimates inform,
-  they do not replace.
+## Fallback behavior
+
+If a lane has too few samples, is new, or changed its routing recently, use the
+static `base_lem`. Learned data may explain why a future estimate should change;
+it does not replace the ledger automatically.

--- a/docs/ci/pr-plan.md
+++ b/docs/ci/pr-plan.md
@@ -18,8 +18,9 @@ For each PR, the workflow:
 6. writes `target/ci/ci-plan.json`,
 7. appends a Markdown summary to the GitHub step summary.
 
-It does not change which jobs run today. The routing PRs (10–14) wire the
-plan into job conditions.
+It does not change which jobs run by itself. Routing PRs wire plan outputs,
+path filters, and labels into job conditions. Budget enforcement should use
+static `base_lem` first; learned estimates wait for actuals.
 
 ## Outputs
 
@@ -63,10 +64,22 @@ Changed areas: docs
 Risk packs: (none)
 ```
 
+## Budget enforcement plan
+
+| Band | Static LEM | Behavior |
+| --- | ---: | --- |
+| ordinary | 0–35 | pass |
+| elevated | 36–75 | warning summary |
+| high | 76–125 | warning plus explicit label recommendation |
+| over ceiling | >125 | fail unless `full-ci` or `ci-budget-override` is present |
+
+Do not use learned estimates for enforcement until the actuals criteria in
+`docs/ci/learned-estimates.md` are met.
+
 ## Limitations
 
-- Static estimates only, until learned actuals land (PR 18).
-- Does not yet enforce the budget; that comes in PR 16 with soft warnings
-  and PR 17 with the branch protection promotion.
+- Static estimates only, until learned actuals are advisory and then ratcheted.
+- Budget enforcement is a later control-plane PR and should not be combined
+  with branch-protection or workflow-pruning changes.
 - The Python script does not consult `cargo metadata`, so transitive crate
   impacts are approximate. The xtask planner adds dependency-graph closure.


### PR DESCRIPTION
### Motivation

- Provide a stable control-plane and agent-facing contract for the CI economics rollout so subsequent small SRP PRs can change routing, branch protection, and budgets safely. 
- Make the intended ordinary PR shape, static LEM budget bands, and per-PR operating rules explicit so planners and agents can produce predictable `ci-plan` outputs. 
- Surface the operator label vocabulary in repo settings so label-gated heavy lanes have stable names and do not silently change CI behavior.

### Description

- Add `docs/ci/implementation-sequence.md` with an ordered, single-responsibility backlog, per-PR contract, default ordinary/docs-only PR shapes, and static budget rules. 
- Reconcile and update the rollout ledger and control-plane docs in `docs/ci/adze-rollout-plan.md`, `docs/ci/branch-protection.md`, `docs/ci/pr-plan.md`, `docs/ci/learned-estimates.md`, and `docs/ci/ci-lane-whitelist.md` to reflect the implementation sequence and promotion criteria for `PR Gate / PR Gate Success`. 
- Expand and document the CI label vocabulary in `docs/ci/labels.md` and add the label entries to `.github/settings.yml` so routing labels exist in repo settings without changing workflow triggers. 
- Tidy the contributor-facing lane map in `.github/CI_LANES.md` and update whitelist guidance and blocking-mode scope to limit blocking to CI-control-plane changes.

### Testing

- Ran `git diff --check`, which returned clean for the committed docs changes. 
- Built and executed the xtask lint: `cargo xtask check-ci-lane-whitelist --mode advisory`, which completed successfully and reported two advisory findings for undeclared workflow jobs (existing `golden-tests.yml` `paths` job and `droid-security-scan.yml` job). 
- Ran the policy report with `cargo xtask policy-report || true`, which completed and wrote `target/policy/policy-report.md` as part of verification. 
- Validated settings YAML parsing with `ruby -e 'require "yaml"; YAML.load_file(".github/settings.yml")'`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03b0a48948833380af054fd33583ee)