### PR TITLE
docs(ci): reconcile CI economics rollout

### DIFF
--- a/.github/CI_LANES.md
+++ b/.github/CI_LANES.md
@@ -1,6 +1,6 @@
 # CI Lane Map
 
-**Last updated:** 2026-05-08
+**Last updated:** 2026-05-12
 **Purpose:** Classify every CI check so contributors can immediately tell
 whether a red mark means "must fix before merge" or "inspect at your leisure."
 
@@ -13,9 +13,23 @@ whether a red mark means "must fix before merge" or "inspect at your leisure."
 | **Push / scheduled** | Runs on `main` pushes or schedules. Not PR-blocking. | Inspect trend; fix in a follow-up. |
 | **Advisory** | Uses nightly / unstable toolchains, `continue-on-error`, or non-blocking labels. May be red due to toolchain drift. | Inspect if curious. Not actionable for most PRs. |
 
-Branch protection requires exactly one check: **`CI / ci-supported`** (via `pr-gate.yml`).
+Branch protection currently requires exactly one check: **`CI / ci-supported`**. The target required context is **`PR Gate / PR Gate Success`** after the documented stability window.
 
 ---
+
+## Target ordinary PR shape
+
+| Lane | Blocking | Target LEM | Notes |
+| --- | ---: | ---: | --- |
+| PR Plan | no | ~1 | Changed surfaces and budget band |
+| Supported Rust Gate | yes | ~18-22 | `just ci-supported` |
+| PR Gate Success | yes | ~1 | Stable aggregate and future required check |
+| CI lane whitelist | advisory | ~1-2 | Workflow-sprawl guard |
+| ripr advisory | advisory | ~3-5 | Static oracle-gap signal; skip docs-only |
+| test-policy smoke | advisory or yes | ~1-3 | Hygiene-only smoke |
+
+macOS and Windows must not be ordinary PR defaults. Expensive lanes should be
+path-routed, label-triggered, scheduled, manual, release-only, or main-only.
 
 ## Complete lane inventory
 
@@ -27,7 +41,7 @@ Branch protection requires exactly one check: **`CI / ci-supported`** (via `pr-g
 | `pr-gate.yml` | `PR Gate Success` | PR + merge_group | Aggregate: plan + supported/docs gate must pass |
 | `pr-gate.yml` | `PR Plan` | PR | Computes docs_only, estimated LEM, budget band |
 
-Required branch protection context: `CI / ci-supported` (maps to the `ci-supported` job in `ci.yml`, also exercised via `pr-gate.yml`).
+Current required branch protection context: `CI / ci-supported`. Target context after promotion: `PR Gate / PR Gate Success`.
 
 ### PR-only signal (non-blocking)
 
@@ -142,8 +156,15 @@ required_status_checks:
     - "CI / ci-supported"
 ```
 
-This is correct and intentionally single-gated. All other checks are optional
-signal.
+This remains the rollback anchor. The planned promotion is to require only:
+
+```yaml
+required_status_checks:
+  contexts:
+    - "PR Gate / PR Gate Success"
+```
+
+The promotion must be a dedicated PR and must not be combined with workflow pruning. All raw matrix leaves and advisory lanes remain optional signal.
 
 ---
 
@@ -171,5 +192,6 @@ signal.
 When adding a new CI job:
 1. Add it to the appropriate table above.
 2. If advisory, use `continue-on-error: true` and the `Advisory / ` name prefix.
-3. If required, update `.github/settings.yml` branch protection contexts **and** this file.
+3. If required, update `.github/settings.yml` branch protection contexts **and** this file, and do not require raw matrix leaves.
 4. If push-only, ensure it does not trigger on PRs (use `if:` guards).
+5. If label-triggered, add the label to `.github/settings.yml` and `docs/ci/labels.md`.

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -81,3 +81,66 @@ labels:
   - name: good first issue
     color: "7057ff"
     description: Good for newcomers
+  - name: full-ci
+    color: "5319e7"
+    description: Run broad deep CI lanes; high-cost opt-in
+  - name: ci-budget-ack
+    color: "fbca04"
+    description: Acknowledge elevated or high CI LEM estimate
+  - name: ci-budget-override
+    color: "b60205"
+    description: Explicitly allow over-ceiling CI LEM estimate
+  - name: platform-matrix
+    color: "1d76db"
+    description: Run full OS and toolchain platform matrix
+  - name: pure-rust
+    color: "1d76db"
+    description: Run pure-Rust platform proof lanes
+  - name: coverage
+    color: "0e8a16"
+    description: Run coverage instrumentation and upload coverage artifacts
+  - name: ci:golden
+    color: "f9d0c4"
+    description: Run grammar golden and parity lanes
+  - name: ci:perf
+    color: "c5def5"
+    description: Run performance comparison lanes
+  - name: ci:microcrate
+    color: "bfd4f2"
+    description: Run full microcrate governance CI
+  - name: ci:concurrency
+    color: "bfd4f2"
+    description: Run concurrency-focused CI lanes
+  - name: wasm
+    color: "1d76db"
+    description: Run WASM proof lanes
+  - name: fuzz
+    color: "d93f0b"
+    description: Run fuzzing lanes
+  - name: benchmarks
+    color: "c5def5"
+    description: Run benchmark suites
+  - name: api
+    color: "0075ca"
+    description: Run public API and SemVer checks
+  - name: release-check
+    color: "006b75"
+    description: Run release readiness checks
+  - name: security-audit
+    color: "e11d21"
+    description: Run dependency and supply-chain security audit lanes
+  - name: mutation
+    color: "d93f0b"
+    description: Run mutation testing lanes
+  - name: property-tests
+    color: "0e8a16"
+    description: Run property-test lanes
+  - name: ts-bridge
+    color: "1d76db"
+    description: Run ts-bridge parity and deep checks
+  - name: skip-golden
+    color: "ededed"
+    description: Skip optional golden lanes when no explicit golden opt-in is present
+  - name: skip-perf
+    color: "ededed"
+    description: Skip optional performance lanes when no explicit performance opt-in is present

--- a/docs/ci/adze-rollout-plan.md
+++ b/docs/ci/adze-rollout-plan.md
@@ -1,80 +1,225 @@
 # Adze CI economics rollout plan
 
-This document is the per-PR map for the rollout. It describes what each PR
-should do, what should not be combined, and what the rollback path looks like.
+This document is the agent-readable control plane for the CI economics rollout.
+Treat the rollout as **CI infrastructure product work**, not workflow cleanup.
+The product principle is:
 
-The rollout target:
+> Every PR gets one cheap required proof. Everything else is advisory, routed,
+> scheduled, manual, release-only, or label-triggered.
 
+## Budget doctrine
+
+Adze budgets CI in Linux-equivalent minutes (LEM):
+
+```text
+LEM = wall-clock job minutes × runner multiplier
+Linux = 1.0, Windows = 2.0, macOS = 10.0
 ```
-ordinary PR:        <35 LEM preferred, usually <$0.50
-elevated PR:        35–75 LEM, explicit risk surface
-high-cost PR:       75–125 LEM, explicit label/ack
-over ceiling:       >125 LEM requires override
+
+Ordinary PRs should normally fit this shape:
+
+| Budget | Target |
+| --- | ---: |
+| preferred ordinary PR | <=25 LEM |
+| ordinary ceiling | <=35 LEM |
+| elevated | 36-75 LEM, warning and explicit risk surface |
+| high | 76-125 LEM, label/ack recommended |
+| over ceiling | >125 LEM, requires `full-ci` or `ci-budget-override` |
+
+The operating target is sub-$0.50 ordinary PRs. A $1 PR is a ceiling, not the
+product design center.
+
+## Target default PR shape
+
+For ordinary Rust PRs:
+
+| Lane | Blocking | Target LEM | Notes |
+| --- | ---: | ---: | --- |
+| PR Plan | no | ~1 | Changed surfaces, selected lanes, budget band |
+| Supported Rust Gate | yes | ~18-22 | `just ci-supported` |
+| PR Gate Success | yes | ~1 | Stable aggregate, future branch-protection context |
+| CI lane whitelist | advisory | ~1-2 | Prevent workflow sprawl |
+| ripr advisory | advisory | ~3-5 | Static oracle-gap signal; skip docs-only |
+| test-policy smoke | advisory or blocking | ~1-3 | Disabled-test and hygiene smoke only |
+
+For docs-only PRs:
+
+| Lane | Blocking | Target LEM |
+| --- | ---: | ---: |
+| PR Plan | no | ~1 |
+| Docs Gate | yes | ~1-2 |
+| PR Gate Success | yes | ~1 |
+| Policy lint | advisory | ~1 |
+
+Everything else is outside the ordinary default and must be routed by path,
+label, schedule, manual dispatch, main, merge queue, or release.
+
+## Implementation order
+
+```text
+stabilize docs/control plane
+-> make PR Gate authoritative
+-> remove duplicate PR execution
+-> route expensive lanes harder
+-> enforce lane metadata
+-> add labels / branch-protection rails
+-> collect actuals
+-> ratchet budgets from measured data
+```
+
+## Source-of-truth split
+
+| Source | Role |
+| --- | --- |
+| `docs/ci/cost-and-verification-policy.md` | Doctrine, budget bands, and non-goals |
+| `docs/ci/adze-rollout-plan.md` | Ordered rollout sequence and per-PR contract |
+| `docs/ci/adze-rollout-status.md` | Current snapshot of present / hardening / pruning / deferred work |
+| `docs/ci/branch-protection.md` | Required-check migration criteria and rollback |
+| `docs/ci/labels.md` | Operator label vocabulary for expensive verification |
+| `docs/ci/learned-estimates.md` | Future actuals-driven estimate model |
+| `.github/CI_LANES.md` | Contributor-facing check semantics |
+| `policy/ci-lane-whitelist.toml` | Lane registry: owner, LEM, evidence, duplicate map |
+| `policy/ci-risk-packs.toml` | Path and label routing vocabulary |
+
+## Queue discipline
+
+Do not edit source-of-truth scaffolding, policy ledgers, or the CI economics
+docs while a conflicting docs stack is still open unless the stack has landed,
+been closed, or this branch has been explicitly rebased over it.
+
+Before touching CI rollout files, run:
+
+```bash
+git diff --check
+python -c "import pathlib, tomllib; p=pathlib.Path('.adze/goals/active.toml'); p.exists() and tomllib.load(p.open('rb'))"
 ```
 
 ## Status legend
 
-- ✅ landed — change is in `main`
-- 🟡 in flight — open PR or partially merged on the rollout branch
-- ⏳ planned — not yet started
-- ⏸ deferred — needs actuals data or coordination
+- ✅ landed — present in the current branch and intended as active policy
+- 🟡 needs hardening — present but too broad, advisory-only, or still carrying an exception
+- 🧹 needs pruning — duplicate or expensive default execution to reroute/remove
+- ⏳ planned — not yet implemented
+- ⏸ deferred — blocked on actuals or coordination
 
-## PRs
+## Current control-plane status
 
-| # | Title | Status | Notes |
-| --- | --- | --- | --- |
-| 01 | docs(ci): verification economics policy | 🟡 | This doc set |
-| 02 | chore(ci): add CI lane whitelist map | 🟡 | `policy/ci-lane-whitelist.toml` |
-| 03 | ci(policy): lint workflows against whitelist | 🟡 | `cargo xtask check-ci-lane-whitelist` |
-| 04 | feat(ci): advisory PR Plan with LEM estimates | 🟡 | `.github/workflows/pr-plan.yml` |
-| 05 | ci: add PR Gate Success summary | 🟡 | additive only |
-| 06 | perf(ci): make PR caches restore-only | 🟡 | save-if-main on bare rust-cache usages |
-| 07 | ci(ripr): advisory static exposure | 🟡 | non-blocking |
-| 08 | ci(policy): risk-pack routing map | 🟡 | `policy/ci-risk-packs.toml` |
-| 09 | feat(xtask): `xtask ci plan` | 🟡 | testable planner |
-| 10 | perf(ci): gate fuzzing to nightly and labels | 🟡 | label-gated, build-only smoke for parser PRs |
-| 11 | perf(ci): unify benchmark PR ownership | 🟡 | benchmarks.yml off PR default |
-| 12 | perf(ci): route golden tests by grammar risk | 🟡 | paths filter + label gate |
-| 13 | perf(ci): reduce pure-rust PR matrix | 🟡 | matrix-setup job + label gates |
-| 14 | perf(ci): route microcrate CI by risk pack | 🟡 | changes setup job + per-group gates |
-| 15 | ci: emit LEM actuals telemetry | 🟡 | additive only |
-| 16 | ci(plan): warn on elevated LEM | 🟡 | soft warnings only |
-| 17 | ci: make PR Gate Success the required check | ⏸ | needs ≥14 days stable data; see docs/ci/branch-protection.md |
-| 18 | ci(metrics): learned LEM estimates | ⏸ | needs ≥30 days of actuals; see docs/ci/learned-estimates.md |
+### Already present
 
-## What this rollout branch contains
+| Rail | Status | Notes |
+| --- | --- | --- |
+| LEM doctrine and budget bands | ✅ | `<=25` preferred, `<=35` ordinary ceiling |
+| CI lane whitelist | ✅ | Lane registry exists with owner, evidence, duplicate map |
+| CI risk packs | ✅ | Path/label routing vocabulary exists |
+| PR Plan | ✅ | Emits static estimate, docs-only signal, and budget band |
+| PR Gate Success | ✅ | Aggregates supported/docs gate shape |
+| ci-actuals scaffold | ✅ | Artifact scaffold exists for future learned estimates |
+| coverage label gate | ✅ | Coverage is non-default and label/main/manual routed |
 
-The rollout branch (`claude/adze-ci-economics-rollout-IxzNZ`) contains
-**PRs 01–16**, stacked. Branch-protection promotion (17) and learned
-estimates (18) are documented but intentionally deferred:
+### Needs hardening
 
-- **17** changes branch protection. It needs ≥14 days of `PR Gate
-  Success` history and explicit operator coordination. See
-  `docs/ci/branch-protection.md` for the promotion criteria.
-- **18** needs ≥30 days of `ci-actuals.json` data to compute meaningful
-  percentiles. Until then, static estimates are correct. See
-  `docs/ci/learned-estimates.md` for the model and promotion criteria.
+| Rail | Status | Required hardening |
+| --- | --- | --- |
+| PR Gate Success | 🟡 | Promote to the single required branch-protection context after stability window |
+| CI lane whitelist | 🟡 | Make blocking only for workflow/policy/doc changes |
+| PR Plan budgets | 🟡 | Warn/fail static over-budget PRs with override labels |
+| test-policy | 🟡 | Split cheap PR smoke from full inventory enforcement |
+| ci-actuals | 🟡 | Normalize per-lane receipts with runner multiplier and selected-by metadata |
 
-## Per-PR contract
+### Needs pruning or stronger routing
 
-Each PR body in this rollout must include:
+| Rail | Status | Required pruning/routing |
+| --- | --- | --- |
+| legacy `ci.yml` PR execution | 🧹 | Stop ordinary PR trigger after PR Gate is authoritative |
+| pure-rust platform proof | 🧹 | Make PR execution label/manual/main/schedule only |
+| microcrate CI | 🧹 | Keep path-routed crate groups; move docs/WASM/strict features off default PR |
+| performance comparison | 🧹 | Keep compile smoke path-routed; label-gate comparisons |
+| ts-bridge | 🧹 | Consolidate smoke and move parity off ordinary default |
+| API/SemVer checks | 🧹 | Route by API-risk paths and release/API labels |
+| main-push deep verification | 🧹 | Keep main smoke cheap; move OS matrix/fuzz/coverage/benchmarks to nightly/manual/release |
 
-- estimated LEM impact
-- workflows touched
-- default PR effect
-- rollback path
-- proof obligation
-- cheaper signal considered
-- branch protection impact (almost always: none, until PR 17)
+### Deferred until actuals
+
+| Rail | Status | Deferral condition |
+| --- | --- | --- |
+| learned estimates | ⏸ | Wait for >=30 days or enough `ci-actuals.json` samples |
+| ledger ratchet | ⏸ | Update static `base_lem` from measured p90/p95 only after sufficient samples |
+
+## Next implementation wave
+
+These PRs are intentionally small and single-purpose. Do not combine branch
+protection changes with workflow pruning.
+
+| PR | Title | Status | Files / surfaces | Acceptance |
+| ---: | --- | --- | --- | --- |
+| 1 | `docs(ci): reconcile CI economics rollout status` | ✅ | CI docs and ledgers | `git diff --check`; advisory policy commands when available |
+| 2 | `ci(labels): add CI routing labels` | ⏳ | `.github/settings.yml`, `docs/ci/labels.md` | `git diff --check` |
+| 3 | `ci: require PR Gate Success as the stable merge gate` | ⏳ | `.github/settings.yml`, branch-protection docs, lane docs | `git diff --check` |
+| 4 | `ci: stop running legacy ci.yml on ordinary PRs` | ⏳ | `.github/workflows/ci.yml`, lane docs/ledger | whitelist advisory; `git diff --check` |
+| 5 | `ci(test-policy): split PR smoke from full inventory enforcement` | ⏳ | `test-policy.yml`, xtask/scripts, lane ledger | smoke/full policy commands; whitelist advisory |
+| 6 | `ci(pure-rust): make platform proof label and main only` | ⏳ | `pure-rust-ci.yml`, lane ledger/docs | whitelist advisory; no macOS/Windows default PR |
+| 7 | `ci(microcrate): route docs wasm and strict features off ordinary PRs` | ⏳ | `microcrate-ci.yml`, lane ledger/docs | whitelist advisory |
+| 8 | `ci(perf): keep benchmark smoke default but label-gate comparisons` | ⏳ | `performance.yml`, `benchmarks.yml`, lane ledger/docs | whitelist advisory |
+| 9 | `ci(ts-bridge): consolidate smoke and move parity off default PR` | ⏳ | ts-bridge workflows, lane ledger/docs | whitelist advisory |
+| 10 | `ci(api): route public API checks by API risk` | ⏳ | API/SemVer jobs and docs | semver/public-api advisory; `git diff --check` |
+| 11 | `ci(policy): block undeclared workflow lanes` | ⏳ | policy workflow, xtask, docs | whitelist blocking for workflow changes |
+| 12 | `ci(plan): enforce static LEM ceilings with override labels` | ⏳ | PR Plan/xtask/scripts | static planner receipts; `git diff --check` |
+| 13 | `ci: split main smoke from nightly deep verification` | ⏳ | main/schedule/manual workflow routing | whitelist advisory; no routine macOS main-push spend |
+| 14 | `ci(actuals): normalize per-lane LEM receipts` | ⏳ | `scripts/ci/emit-ci-actuals.py`, docs | JSON schema validates |
+| 15 | `ci(metrics): compute learned lane estimates from actuals` | ⏸ | metrics scripts/docs | advisory only after enough samples |
+| 16 | `ci(metrics): update lane LEM baselines from measured actuals` | ⏸ | lane ledger/docs | owner signoff; estimates not below p90 without reason |
+
+## Per-PR operating contract
+
+Every CI economics PR body must include:
+
+```markdown
+## CI economics
+
+- Estimated LEM impact:
+- Workflows touched:
+- Default PR effect:
+- Branch protection impact:
+- Rollback path:
+- Proof obligation:
+- Cheaper signal considered:
+- Expensive runners added? yes/no
+- macOS/windows default PR? must be no
+
+## Verification
+
+- [ ] `cargo xtask check-ci-lane-whitelist --mode advisory`
+- [ ] `cargo xtask policy-report || true`
+- [ ] `git diff --check`
+
+## Claim boundary
+
+This PR changes CI routing/cost only. It does not weaken `just ci-supported`,
+remove deep verification from main/nightly/release/manual paths, or make
+advisory lanes required.
+```
+
+## Agent rules
+
+1. One CI intention per PR.
+2. Never combine branch protection change with large workflow pruning.
+3. Never introduce macOS or Windows as default PR lanes.
+4. Never add a workflow job without a lane entry.
+5. Never make a raw matrix leaf a required branch-protection check.
+6. Keep PR Gate Success as the stable required summary.
+7. Keep deep verification available through main/nightly/manual/label/release.
+8. If a job is `duplicate_of` another lane, justify it or reroute/remove it.
+9. If a lane is expensive and `default_pr = true`, it needs an exception and expiry.
+10. After each merge, refresh `main` and rerun the lane whitelist check.
 
 ## Rollback paths
 
 | Layer | Rollback |
 | --- | --- |
-| docs | revert PR |
-| policy TOML | revert PR; advisory lints stop firing |
-| advisory workflow (PR Plan, ripr, whitelist lint) | delete the workflow file |
-| PR Gate Success | delete the workflow file; old required checks remain |
-| cache normalization | revert per-workflow `save-if` lines |
-| risk-pack routing | revert path filters; lanes go back to default-on |
-| branch protection promotion | switch the required check back |
+| docs/specs | revert the PR |
+| labels | remove the added labels from `.github/settings.yml` |
+| policy TOML | revert the lane/risk-pack diff; advisory lints stop firing |
+| advisory workflow | revert/delete workflow change; required gate remains unchanged |
+| PR Gate Success promotion | switch required context back to `CI / ci-supported` |
+| routing changes | restore prior triggers; deep lanes remain available through labels/manual/main |
+| learned estimates | fall back to static `base_lem` values |

--- a/docs/ci/adze-rollout-status.md
+++ b/docs/ci/adze-rollout-status.md
@@ -1,102 +1,76 @@
 # CI Economics Rollout Status
 
-Last review: 2026-05-08.
+Last review: 2026-05-12.
 
-This file is a status snapshot, not a live source of truth. Before using it for
-execution, refresh with `gh pr list` and the current workflow state.
+This file is the current status snapshot for operators and agents. The ordered
+execution plan lives in `docs/ci/adze-rollout-plan.md`; this document answers
+"what is already present, what still needs hardening, what needs pruning, and
+what is deferred?" before an implementation PR starts.
 
 ## Status legend
 
-- ✅ landed — present on `main` and working
-- 🟡 in progress — open PR or active follow-up
-- ⏳ planned — not yet started
+- ✅ landed — present in the current branch and intended as active policy
+- 🟡 needs hardening — present but advisory-only, too broad, or still carrying an exception
+- 🧹 needs pruning — duplicate or expensive default execution to reroute/remove
+- ⏳ planned — not yet implemented
 - ⏸ deferred — waiting on actuals or coordination
 
-## Foundation layer
+## Already present
 
-| # | Item | Status | Notes |
+| # | Rail | Status | Notes |
 | --- | --- | --- | --- |
-| F01 | CI lane whitelist (`policy/ci-lane-whitelist.toml`) | ✅ | All workflows mapped with owner, LEM, triggers |
-| F02 | CI risk packs (`policy/ci-risk-packs.toml`) | ✅ | 10 risk packs: core_runtime, macro_tool, glr_core, tablegen, grammar_golden, microcrate_governance, concurrency, wasm, performance, manifest_release |
-| F03 | PR Plan workflow (`pr-plan.yml`) | ✅ | Calls `xtask ci-plan`, emits `ci-plan.json` with outputs `docs_only`, `estimated_lem`, `band` |
-| F04 | PR Gate Success workflow (`pr-gate.yml`) | ✅ | Supported Gate + Docs Gate + `PR Gate Success` aggregator |
-| F05 | ci-actuals telemetry scaffold | ✅ | `scripts/ci/emit-ci-actuals.py` emits plan vs actual; uploaded as artifact |
-| F06 | ripr advisory (`ripr.yml`) | ✅ | Advisory install attempts run on an isolated Rust 1.93 toolchain and fall back to a stub report on install failure |
+| A01 | Cost doctrine | ✅ | `docs/ci/cost-and-verification-policy.md` defines LEM, multipliers, bands, and non-goals. |
+| A02 | Lane whitelist | ✅ | `policy/ci-lane-whitelist.toml` registers workflow lanes with owner, LEM, evidence, and duplicate metadata. |
+| A03 | Risk packs | ✅ | `policy/ci-risk-packs.toml` maps paths and labels to lane vocabulary. |
+| A04 | PR Plan | ✅ | `.github/workflows/pr-plan.yml` emits docs-only, estimated LEM, and budget-band outputs. |
+| A05 | PR Gate Success | ✅ | `.github/workflows/pr-gate.yml` exposes Supported Rust Gate, Docs Gate, and aggregate success shape. |
+| A06 | ci-actuals scaffold | ✅ | `scripts/ci/emit-ci-actuals.py` gives the future learned-estimates pipeline a receipt path. |
+| A07 | coverage routing | ✅ | `coverage.yml` is label/main/manual routed, not an ordinary default lane. |
+| A08 | routing label spec | ✅ | `docs/ci/labels.md` defines the operator vocabulary for expensive lanes. |
 
-## Control plane
+## Needs hardening
 
-| # | Item | Status | Notes |
+| # | Rail | Status | Next implementation PR |
 | --- | --- | --- | --- |
-| C01 | CI policy workflow (`ci-policy.yml`) | ✅ | Runs `check-ci-lane-whitelist --mode advisory` on every PR |
-| C02 | Synchronize-only cancellation | ✅ | PR #563 merged — prevents label events from killing running jobs |
-| C03 | Lane whitelist cost alignment | ✅ | PR #564 merged — corrects stale LEM for already-gated lanes |
-| C04 | Real ripr provisioning | ✅ | PR #565 merged — isolated Rust 1.93 install with graceful stub fallback |
-| C05 | Benchmark deduplication | ✅ | PR #566 merged — `performance-check` gated to `ci:perf` label |
+| H01 | Branch protection | 🟡 | Promote `PR Gate / PR Gate Success` after stability criteria; keep rollback to `CI / ci-supported`. |
+| H02 | Lane whitelist enforcement | 🟡 | Make blocking only when workflows, CI policy, CI docs, scripts, or xtask change. |
+| H03 | PR Plan budget behavior | 🟡 | Warn/fail from static estimates: ordinary passes; elevated/high warn; over-ceiling requires override labels. |
+| H04 | Test policy | 🟡 | Split `test-policy-smoke` for ordinary PRs from `test-policy-full` for main/nightly/manual/`full-ci`. |
+| H05 | ci-actuals schema | 🟡 | Record per-lane id, workflow, job, runner, wall minutes, multiplier, LEM, selected-by, result, and total LEM. |
 
-## Routing
+## Needs pruning or stronger routing
 
-| # | Item | Status | Notes |
+| # | Lane / workflow | Status | Intended default-PR effect |
 | --- | --- | --- | --- |
-| R01 | Fuzz gating (label/push only) | ✅ | `fuzz.yml` — runtime fuzz requires `fuzz`/`full-ci` label or push/schedule |
-| R02 | Pure-Rust PR matrix reduction | ✅ | `pure-rust-ci.yml` — ubuntu/stable default; full matrix on `platform-matrix`/`full-ci`/main |
-| R03 | Golden tests grammar routing | ✅ | `golden-tests.yml` — paths + `ci:golden`/`full-ci` label gates |
-| R04 | Microcrate CI risk-pack routing | ✅ | `microcrate-ci.yml` — per-group path detection (concurrency/governance/bdd/parser/core/runtime) |
-| R05 | Benchmark PR ownership cleanup | ✅ | PR #566 merged — removes duplicate baseline+comparison from default PR path |
+| P01 | legacy `ci.yml` PR trigger | 🧹 | Remove ordinary `pull_request` execution once PR Gate is required. |
+| P02 | `pure-rust-ci.yml` | 🧹 | No ordinary default platform proof; run by `platform-matrix`, `pure-rust`, `full-ci`, main, schedule, or manual. |
+| P03 | `microcrate-ci.yml` | 🧹 | Keep path-matched crate-group tests; move docs/WASM/strict features to labels/main/manual. |
+| P04 | `performance.yml` and `benchmarks.yml` | 🧹 | Keep compile smoke path-routed; label-gate baseline comparisons and full suite. |
+| P05 | ts-bridge workflows | 🧹 | Keep one path-routed smoke; move parity to main/schedule/manual/label. |
+| P06 | API/SemVer checks | 🧹 | Route by public API risk paths or `api` / `release-check` / `breaking-change` / `full-ci` labels. |
+| P07 | main-push deep verification | 🧹 | Keep main smoke cheap; move OS matrix, fuzz, full coverage, and benchmarks to nightly/manual/release. |
 
-## Policy ledgers
+## Deferred until actuals
 
-| # | Item | Status | Notes |
+| # | Item | Status | Start condition |
 | --- | --- | --- | --- |
-| P01 | Clippy lint policy (`policy/clippy-lints.toml`) | ✅ | Schema, active, staged, and planned lints documented |
-| P02 | No-panic allowlist (`policy/no-panic-allowlist.toml`) | ✅ | Schema in place; intentionally empty until `cargo xtask no-panic-propose --baseline` run |
-| P03 | Non-Rust file policy (`policy/non-rust-allowlist.toml`) | ✅ | All non-Rust surfaces registered |
-| P04 | ripr suppressions (`policy/ripr-suppressions.toml`) | ✅ | Schema in place; empty baseline |
-| P05 | Workspace rust lints (`[workspace.lints.rust]`) | ✅ | `unsafe_op_in_unsafe_fn`, `unused_must_use`, `missing_docs`, `unused_extern_crates` |
-| P06 | Strict Clippy Stage A (`[workspace.lints.clippy]`) | 🟡 | PR #567: `policy/clippy-stage-a` — `allow_attributes_without_reason` + stage-A rust lints |
+| D01 | Learned estimates | ⏸ | >=30 days or enough per-lane actual samples with stable p50/p90/p95. |
+| D02 | LEM ledger ratchet | ⏸ | Enough samples to update `base_lem`; owner signoff for expensive/default lanes. |
 
-## MSRV and toolchain
+## Effective default PR lane cost (current target)
 
-| # | Item | Status | Notes |
-| --- | --- | --- | --- |
-| T01 | MSRV 1.93 | ⏳ | PR: `policy/msrv-1-93` — dedicated policy PR, prerequisite for ripr simplification |
+| Lane | Target default PR cost | Blocking |
+| --- | ---: | ---: |
+| PR Plan | ~1 LEM | no |
+| Supported Rust Gate | ~18-22 LEM | yes |
+| PR Gate Success | ~1 LEM | yes |
+| CI Lane Whitelist | ~1-2 LEM | advisory |
+| ripr advisory | ~3-5 LEM | advisory |
+| test-policy smoke | ~1-3 LEM | advisory or yes |
+| **Preferred ordinary PR target** | **<=25 LEM** | — |
+| **Ordinary ceiling** | **<=35 LEM** | — |
 
-## Branch protection
-
-| # | Item | Status | Notes |
-| --- | --- | --- | --- |
-| B01 | Branch protection migration docs | ✅ | `docs/ci/branch-protection.md` — criteria for promoting required check |
-| B02 | `PR Gate Success` stable run history | ⏸ | Needs ≥14 days and ≥5 distinct PRs per path before promotion |
-| B03 | Migrate required check to `PR Gate Success` | ⏸ | After B02 — see `docs/ci/branch-protection.md` |
-
-## Learned estimates
-
-| # | Item | Status | Notes |
-| --- | --- | --- | --- |
-| L01 | ci-actuals collection | ✅ | Artifact upload on every PR Gate run |
-| L02 | Learned LEM model | ⏸ | Needs ≥30 days of actuals; see `docs/ci/learned-estimates.md` |
-
-## Effective default PR lane cost (current)
-
-With all routing already in place, the effective default PR cost estimate:
-
-| Lane | Effective default PR cost |
-| --- | --- |
-| PR Plan | ~1 LEM |
-| Supported Rust Gate | ~20 LEM |
-| PR Gate Success | ~1 LEM |
-| CI Lane Whitelist | ~2 LEM |
-| ripr advisory | ~4 LEM (isolated install attempted; stub report on toolchain/binary failure) |
-| Test Policy | ~12 LEM |
-| Pure Rust (ubuntu/stable only) | ~18 LEM |
-| Microcrate CI (routed by risk pack) | ~5–20 LEM depending on changed surface |
-| Fuzz build smoke (parser/glr paths only) | ~3 LEM |
-| Criterion smoke | ~6 LEM |
-| ts-bridge lanes | ~8 LEM |
-| Clippy quarantine report | ~4 LEM |
-| **Estimated total (typical runtime PR)** | **~65–80 LEM** |
-
-Target is ≤35 LEM for ordinary PRs. The gap comes from `pure-rust-ci` (18 LEM)
-and `microcrate-ci` (variable) running broadly on every PR. Active exceptions in
-`policy/ci-whitelist-exceptions.toml` track these while tightening continues.
-
-See `docs/ci/lem-budgeting.md` for budget bands and override labels.
+Until the pruning/hardening PRs land, some existing lanes may still run more
+broadly than this target. Those exceptions must remain visible in
+`policy/ci-lane-whitelist.toml` or `policy/ci-whitelist-exceptions.toml` and
+should be retired by the numbered rollout PRs in `docs/ci/adze-rollout-plan.md`.

--- a/docs/ci/branch-protection.md
+++ b/docs/ci/branch-protection.md
@@ -1,56 +1,84 @@
 # Branch protection
 
-## Today
+Branch protection is part of the CI economics control plane. It must expose one
+stable required proof instead of requiring raw matrix leaves or duplicate jobs.
 
-The required check today is the existing `ci-supported` job in `ci.yml`
-(see `docs/status/KNOWN_RED.md`). Branch protection has not been changed
-by the rollout.
+## Current required context
 
-## Future
+The current repository setting still requires the legacy supported context:
 
-The rollout introduces a new aggregated check called **PR Gate Success**
-(see `.github/workflows/pr-gate.yml`). It depends on:
+```yaml
+required_status_checks:
+  strict: true
+  contexts:
+    - "CI / ci-supported"
+```
 
-- `PR Plan` (advisory)
-- `Supported Rust Gate` (= `just ci-supported`)
-- `Docs Gate` (fmt only, runs only on docs-only PRs)
+That context remains the rollback anchor until the dedicated branch-protection
+PR lands.
 
-`PR Gate Success` succeeds when exactly one of `Supported Rust Gate` /
-`Docs Gate` succeeded and the other was skipped. PR Plan must not fail.
+## Target required context
 
-This is **additive only** in the rollout's foundation phase. Branch
-protection is *not* updated yet. PR 17 in `docs/ci/adze-rollout-plan.md`
-is the dedicated change that flips the required check to
-`PR Gate Success` once the workflow has been stable for a sufficient
-window of PRs.
+After `PR Gate / PR Gate Success` has demonstrated stability, branch protection
+should require only:
 
-## PR 17 — promotion criteria
+```yaml
+required_status_checks:
+  strict: true
+  contexts:
+    - "PR Gate / PR Gate Success"
+```
 
-Branch protection promotion to `PR Gate Success` is gated on:
+Do **not** require individual matrix leaves, platform jobs, benchmark jobs,
+advisory lanes, or label-triggered deep lanes.
+
+## PR Gate Success shape
+
+`PR Gate Success` is the stable aggregate from `.github/workflows/pr-gate.yml`.
+It depends on:
+
+- `PR Plan` (control-plane planner; non-product proof),
+- `Supported Rust Gate` (`just ci-supported`) for non-docs PRs,
+- `Docs Gate` for docs-only PRs.
+
+The aggregate succeeds when the applicable gate passes and the non-applicable
+gate is skipped. This gives branch protection one stable status name while
+allowing the internal implementation to evolve.
+
+## Promotion criteria
+
+Open the dedicated promotion PR only after:
 
 | Criterion | Target |
 | --- | --- |
-| `PR Gate Success` job has run on every PR for | ≥ 14 calendar days |
-| `PR Gate Success` flake rate | < 1% |
-| Number of distinct PRs that exercised both `Supported Rust Gate` and `Docs Gate` paths | ≥ 5 each |
-| `ci-actuals.json` artifacts uploaded | ≥ 30 PRs |
-| Manual review of band/LEM accuracy | passes |
+| `PR Gate Success` has run on every PR for | >=14 calendar days |
+| `PR Gate Success` flake rate | <1% |
+| Supported Rust Gate path coverage | >=5 distinct PRs |
+| Docs Gate path coverage | >=5 distinct PRs |
+| `ci-actuals.json` artifacts uploaded | >=30 PRs, if artifact collection is already enabled |
+| Manual review of docs-only and Rust PR behavior | passes |
 
-When all five gates clear, PR 17 is opened. PR 17 itself only:
+## Dedicated promotion PR scope
 
-1. updates `.github/settings.yml` (and any equivalent platform config) to
-   require `PR Gate Success` and stop requiring the legacy `ci-supported`
-   job, **and**
-2. removes the redundant `ci-supported` job from `ci.yml` if it is no
-   longer used by anything else (it is also reachable via the new
-   `pr-gate.yml`).
+The branch-protection PR may change:
+
+1. `.github/settings.yml` required status checks, and
+2. the user-facing docs that describe the required context.
+
+It must **not** also prune workflows, reroute expensive lanes, or split test
+policy. Those are separate rollout PRs.
 
 ## Rollback
 
-Removing `pr-gate.yml` reverts to the existing required check. No state
-needs migrating because PR Gate Success is a new, separate workflow.
+If the aggregate required context causes merge blockage, restore the previous
+required check in `.github/settings.yml`:
 
-If PR 17 has landed and the new required check is causing problems, the
-rollback is to restore the previous required check name in
-`.github/settings.yml` and re-add the legacy `ci-supported` job
-configuration.
+```yaml
+required_status_checks:
+  strict: true
+  contexts:
+    - "CI / ci-supported"
+```
+
+No data migration is required because `PR Gate Success` is an aggregate check,
+not an owner of product artifacts.

--- a/docs/ci/cost-and-verification-policy.md
+++ b/docs/ci/cost-and-verification-policy.md
@@ -36,13 +36,31 @@ external services (Docker build farms, AI review) carry their own multipliers.
 The target is sub-`$0.50` ordinary PRs when possible. `$1` is a ceiling, not
 the design center.
 
+
+## Default PR contract
+
+The target ordinary PR has one cheap required proof and routed advisory signal:
+
+| Lane | Blocking | Target LEM |
+| --- | ---: | ---: |
+| PR Plan | no | ~1 |
+| Supported Rust Gate (`just ci-supported`) | yes | ~18-22 |
+| PR Gate Success | yes | ~1 |
+| CI lane whitelist | advisory | ~1-2 |
+| ripr advisory | advisory | ~3-5 |
+| test-policy smoke | advisory or yes | ~1-3 |
+
+Docs-only PRs should use PR Plan, Docs Gate, PR Gate Success, and lightweight
+policy lint only. macOS and Windows must not be ordinary PR defaults; they are
+manual, scheduled, release, main-smoke-exception, or label-triggered proof.
+
 ## What gets verified, where
 
 | Tier | Trigger | Examples |
 | --- | --- | --- |
-| frontdoor | every PR, blocking | `just ci-supported`, test-policy |
-| advisory | every PR, non-blocking | PR Plan, ripr |
-| risk-routed | risk pack matches | parser fuzz build, golden, microcrate group |
+| frontdoor | every PR, blocking | `just ci-supported`, docs gate, PR Gate Success |
+| advisory | every PR, non-blocking | PR Plan, ripr, lane whitelist |
+| risk-routed | risk pack or label matches | parser fuzz build smoke, golden, microcrate group, API/SemVer checks |
 | deep | `main`, nightly, label | OS matrix, fuzz runtime, full benchmarks |
 | release | tag, manual | semver, MSRV, security audit |
 
@@ -50,19 +68,14 @@ the design center.
 
 The rollout is not "delete CI". It is, in order:
 
-1. Document the policy (this doc).
-2. Inventory every existing CI lane in `policy/ci-lane-whitelist.toml`.
-3. Lint workflows against that whitelist (advisory).
-4. Forecast each PR's cost with PR Plan (advisory).
-5. Stand up `PR Gate Success` as the future required check.
-6. Normalize cache save semantics so PRs restore but only `main` saves.
-7. Add `ripr` as cheap oracle-gap detection.
-8. Encode risk packs so routing has a vocabulary.
-9. Make planning testable with `xtask ci plan`.
-10. Route the heavy lanes (fuzz, OS matrix, benchmarks, golden, microcrate) by
-    risk pack and label.
-11. Calibrate from actuals.
-12. Promote `PR Gate Success` to the required branch protection.
+1. Stabilize the docs/control plane.
+2. Make PR Gate authoritative.
+3. Remove duplicate PR execution.
+4. Route expensive lanes harder.
+5. Enforce lane metadata.
+6. Add labels and branch-protection rails.
+7. Collect actuals.
+8. Ratchet budgets from measured data.
 
 See `docs/ci/adze-rollout-plan.md` for the per-PR breakdown.
 

--- a/docs/ci/labels.md
+++ b/docs/ci/labels.md
@@ -1,47 +1,51 @@
 # CI labels
 
-The label vocabulary used by PR Plan to opt in to deeper verification.
+Labels are the operator interface for expensive verification. They let a PR opt
+into deep proof without making that proof an ordinary default for everyone.
 
-## Cost labels
+## Budget labels
 
 | Label | Meaning |
 | --- | --- |
-| `ci-budget-ack` | acknowledge elevated/high LEM (35–125) |
-| `ci-budget-override` | allow >125 LEM |
-| `full-ci` | run all heavy lanes; implies budget override |
+| `ci-budget-ack` | Acknowledge elevated/high LEM (36-125) without changing the hard ceiling. |
+| `ci-budget-override` | Allow an over-ceiling PR (>125 LEM) when the cost is intentional. |
+| `full-ci` | Run broad deep verification; implies the operator accepts high CI spend. |
 
-## Risk-pack opt-in
-
-| Label | Adds |
-| --- | --- |
-| `ci:perf` | full benchmark comparison |
-| `ci:golden` | golden tests for grammars |
-| `ci:microcrate` | full microcrate CI matrix |
-| `ci:concurrency` | concurrency microcrate group |
-| `platform-matrix` | full OS/toolchain matrix |
-| `fuzz` | fuzz runtime |
-| `coverage` | coverage instrumentation |
-| `wasm` | wasm-check |
-
-## Release / API
+## Routing labels
 
 | Label | Adds |
 | --- | --- |
-| `release-check` | release-gate verification |
-| `security-audit` | dependency / RUSTSEC audit |
-| `mutation` | mutation testing on parser/glr core |
-| `property-tests` | property-test runs on parser |
+| `platform-matrix` | Full OS/toolchain proof. Windows and macOS remain opt-in, scheduled, manual, or release-only. |
+| `pure-rust` | Pure-Rust/platform proof without requesting every unrelated deep lane. |
+| `coverage` | Coverage instrumentation and Codecov artifacts. |
+| `ci:golden` | Grammar golden/parity validation. |
+| `ci:perf` | Performance comparison lanes. |
+| `benchmarks` | Full benchmark suite where supported. |
+| `ci:microcrate` | Full microcrate/governance matrix. |
+| `ci:concurrency` | Concurrency/rayon/bootstrap risk pack. |
+| `wasm` | WASM checks and browser/playground surfaces. |
+| `fuzz` | Runtime fuzzing lanes. |
+| `ts-bridge` | ts-bridge parity/deep checks. |
+| `api` | Public API and SemVer checks. |
+| `release-check` | Release readiness lanes. |
+| `security-audit` | Dependency/RUSTSEC/supply-chain audit lanes. |
+| `mutation` | Mutation testing on parser/GLR surfaces. |
+| `property-tests` | Property-test runs on parser/GLR surfaces. |
 
 ## Skip labels
 
 | Label | Effect |
 | --- | --- |
-| `skip-golden` | skip golden tests (only honored when no `ci:golden`) |
-| `skip-perf` | skip perf compare (only honored when no `ci:perf`) |
+| `skip-golden` | Skip golden tests when no explicit `ci:golden`/`full-ci` opt-in is present. |
+| `skip-perf` | Skip performance comparison when no explicit `ci:perf`/`benchmarks`/`full-ci` opt-in is present. |
 
-## Notes
+## Rules
 
-- Labels are advisory until the routing PRs (10–14) land. Until then they
-  appear in the PR Plan summary but do not change which lanes run.
-- Labels never *raise* the hard ceiling. They explain a high LEM number; they
-  do not silence safety checks.
+- Labels may select deeper verification; they must not make macOS or Windows an
+  ordinary PR default.
+- Labels explain and route cost; they do not weaken `just ci-supported`.
+- `full-ci` and `ci-budget-override` are the only labels that can authorize an
+  over-ceiling static plan.
+- When a workflow starts honoring a label, update this file,
+  `.github/settings.yml`, `.github/CI_LANES.md`, and the CI lane whitelist or
+  risk-pack ledger in the same PR.

--- a/docs/ci/learned-estimates.md
+++ b/docs/ci/learned-estimates.md
@@ -1,57 +1,78 @@
-# Learned LEM estimates (PR 18)
+# Learned LEM estimates
 
-Static `base_lem` values in `policy/ci-lane-whitelist.toml` are the
-starting estimate. Once `ci-actuals.json` artifacts have accumulated,
-the planner can use observed durations instead.
+Static `base_lem` values in `policy/ci-lane-whitelist.toml` are the current
+source of truth. Learned estimates are intentionally deferred until actual CI
+receipts exist in enough volume to make percentiles meaningful.
 
-## Promotion criteria
+## Deferral rule
 
-PR 18 is opened when:
+Do not use learned estimates for gating until at least one of these is true:
 
-- `target/ci/ci-actuals.json` artifacts have been uploaded by ≥ 30 PRs,
-- the runner-multiplier × wall-clock time for each lane has a stable
-  p50 and p90 within ±15% across two consecutive weeks,
-- the band thresholds (`35` / `75` / `125`) still match the operator's
-  cost target after observing actuals (see `docs/ci/lem-budgeting.md`).
+- >=30 days of `ci-actuals.json` artifacts are available, or
+- each lane being learned has enough samples to produce stable p50, p90, and
+  p95 values across two consecutive review windows.
 
-## Model
+Until then, PR Plan and the lane whitelist must use static estimates.
 
+## Receipt schema target
+
+The actuals pipeline should normalize receipts to this shape:
+
+```json
+{
+  "schema_version": 1,
+  "pr": 123,
+  "head_sha": "...",
+  "lanes": [
+    {
+      "id": "ci-supported",
+      "workflow": "PR Gate",
+      "job": "Supported Rust Gate",
+      "runner": "ubuntu_latest",
+      "wall_minutes": 21.4,
+      "runner_multiplier": 1.0,
+      "lem": 21.4,
+      "selected_by": ["default_pr"],
+      "result": "success"
+    }
+  ],
+  "total_lem": 27.2,
+  "budget_band": "ordinary"
+}
 ```
-estimate(lane) = max(static_floor(lane), p50_recent_actual(lane) × 1.15)
+
+## Advisory model
+
+Once receipts exist, compute and publish advisory lane summaries with:
+
+| Field | Meaning |
+| --- | --- |
+| `p50_lem` | median observed LEM for the lane |
+| `p90_lem` | conservative planning estimate candidate |
+| `p95_lem` | hard-warning candidate |
+| `sample_count` | number of usable receipts |
+| `last_seen` | newest receipt timestamp |
+| `outliers` | receipts excluded or flagged for review |
+
+An implementation may use this formula for advisory estimates:
+
+```text
+estimate(lane) = max(static_floor(lane), p50_recent_actual(lane) * 1.15)
 warning(lane)  = p90_recent_actual(lane)
 hard(lane)     = p95_recent_actual(lane)
 ```
 
-`static_floor` is the `base_lem` from the whitelist. The `× 1.15` factor
-keeps the estimate slightly pessimistic, so a normal PR's actuals stay
-under the estimate.
+`static_floor` is the lane's `base_lem`. Learned estimates must not silently
+lower an expensive default lane below p90 without an owner-approved reason.
 
-## Implementation outline
+## Ratchet rules
 
-PR 18 will:
+When enough samples exist, update `policy/ci-lane-whitelist.toml` only if:
 
-1. Add a `learned_estimates` section to the planner that loads the
-   most recent `ci-actuals.json` artifacts (from the previous N runs on
-   `main` or any matching workflow).
-2. Replace the static `base_lem` lookup in `xtask ci plan` with
-   `max(static_floor, p50_recent × 1.15)`.
-3. Continue to fall back to `base_lem` whenever fewer than 5 actuals
-   exist for a lane.
-4. Add `--enforce-hard-ceiling` to the workflow only if the band
-   thresholds have been validated against actuals.
+1. the lane has enough samples for stable p90/p95,
+2. macOS and Windows multipliers remain explicit,
+3. expensive default lanes have owner signoff,
+4. docs and ledger changes land together, and
+5. rollback is to restore the previous static `base_lem`.
 
-## Why this is deferred
-
-Until enough actuals exist, learned estimates are noisier than static
-ones. Worse, they make PR planning depend on historical data that may
-not exist for new lanes (a new lane has zero actuals and would either
-fall back to `base_lem` or be silently underestimated). Static
-estimates are correct in the meantime.
-
-## Privacy and stability
-
-- The learned estimates only consume aggregated p50/p90/p95 numbers.
-- They are stored in the planner's working memory, not committed to
-  the repo.
-- Static `base_lem` remains the audit trail; learned estimates inform,
-  they do not replace.
+Learned estimates inform the ledger; they do not replace the ledger audit trail.


### PR DESCRIPTION
### Motivation

- Provide a single agent-readable control plane for the CI-economics rollout so later PRs can be small, single-purpose, and follow the documented per-PR contract. 
- Reduce PR default CI spend by documenting the target ordinary PR shape (one cheap required proof plus routed advisory signals) and the staged implementation order for rerouting expensive lanes. 
- Record branch-protection promotion criteria and label vocabulary so operators and automation have a stable source of truth before making workflow/routing surgery.

### Description

- Reconciled and expanded the rollout control-plane docs by updating `docs/ci/adze-rollout-plan.md`, `docs/ci/adze-rollout-status.md`, `docs/ci/branch-protection.md`, `docs/ci/cost-and-verification-policy.md`, `docs/ci/labels.md`, and `docs/ci/learned-estimates.md` to encode the PR sequence, per-PR contract, agent rules, and rollout status. 
- Updated contributor-facing lane guidance in `.github/CI_LANES.md` to describe the target ordinary PR shape and the planned promotion to `PR Gate / PR Gate Success` while preserving the existing `CI / ci-supported` rollback anchor. 
- Added the routing/opt-in labels to `.github/settings.yml` (e.g. `full-ci`, `ci-budget-ack`, `ci-budget-override`, `platform-matrix`, `pure-rust`, `coverage`, `ci:golden`, `ci:perf`, `ci:microcrate`, `wasm`, `fuzz`, `benchmarks`, `api`, `release-check`, `security-audit`, `mutation`, `property-tests`, `ts-bridge`, `skip-golden`, `skip-perf`) and documented their semantics in `docs/ci/labels.md`. 
- Kept all runtime workflow triggers unchanged in this PR (this change is documentation/labeling and ledger alignment only) and aligned `docs/ci/learned-estimates.md` with a target `ci-actuals.json` receipt schema and ratchet rules for future learned estimates.

### Testing

- Ran `git diff --check` and found no formatting/errors in the changed files, which succeeded. 
- Ran `cargo xtask check-ci-lane-whitelist --mode advisory` which completed successfully in advisory mode and reported a small number of existing undeclared-workflow-job warnings (advisory findings, not blocking). 
- Ran `cargo xtask policy-report || true` which completed successfully and produced the policy report. 
- Verified label addition by parsing `.github/settings.yml` via a small YAML check (`ruby -e 'require "yaml"; data=YAML.load_file(".github/settings.yml"); puts "labels=#{data["labels"].length}"'`) which returned the expected label count and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03b0a48948833380af054fd33583ee)