### PR TITLE
docs(ci): reconcile CI economics rollout status and add routing labels

### DIFF
--- a/.github/CI_LANES.md
+++ b/.github/CI_LANES.md
@@ -30,11 +30,16 @@ Branch protection currently requires exactly one check: **`CI / ci-supported`**.
 Current required branch protection context: `CI / ci-supported`.
 Target required branch protection context: `PR Gate / PR Gate Success` after a dedicated migration PR. Do not require raw matrix leaves.
 
+### Legacy required (overlaps with PR Gate)
+
+| Workflow | Job name | Trigger | Lane | Notes |
+|----------|----------|---------|------|-------|
+| `ci.yml` | `ci-supported` | PR + push | **Required today** | Legacy required context; duplicates `pr-gate.yml` `Supported Rust Gate`. Should stop running on ordinary PRs after PR Gate is promoted. |
+
 ### PR-only signal (non-blocking)
 
 | Workflow | Job name | Trigger | Lane | Notes |
 |----------|----------|---------|------|-------|
-| `ci.yml` | `ci-supported` | PR + push | **Required today** | Legacy required context; should stop running on ordinary PRs after PR Gate is promoted |
 | `ci.yml` | `semver-checks` | PR only | PR-only | Detects breaking API changes |
 | `ci.yml` | `api-stability` | PR only | PR-only | `cargo-public-api` diff; `continue-on-error` |
 | `ci.yml` | `package-validation` | PR only | PR-only | Validates package manifests for release surface |

--- a/.github/CI_LANES.md
+++ b/.github/CI_LANES.md
@@ -1,6 +1,6 @@
 # CI Lane Map
 
-**Last updated:** 2026-05-08
+**Last updated:** 2026-05-12
 **Purpose:** Classify every CI check so contributors can immediately tell
 whether a red mark means "must fix before merge" or "inspect at your leisure."
 
@@ -13,7 +13,7 @@ whether a red mark means "must fix before merge" or "inspect at your leisure."
 | **Push / scheduled** | Runs on `main` pushes or schedules. Not PR-blocking. | Inspect trend; fix in a follow-up. |
 | **Advisory** | Uses nightly / unstable toolchains, `continue-on-error`, or non-blocking labels. May be red due to toolchain drift. | Inspect if curious. Not actionable for most PRs. |
 
-Branch protection requires exactly one check: **`CI / ci-supported`** (via `pr-gate.yml`).
+Branch protection currently requires exactly one check: **`CI / ci-supported`**. The rollout target is **`PR Gate / PR Gate Success`** after the stability criteria in `docs/ci/branch-protection.md` pass.
 
 ---
 
@@ -27,13 +27,14 @@ Branch protection requires exactly one check: **`CI / ci-supported`** (via `pr-g
 | `pr-gate.yml` | `PR Gate Success` | PR + merge_group | Aggregate: plan + supported/docs gate must pass |
 | `pr-gate.yml` | `PR Plan` | PR | Computes docs_only, estimated LEM, budget band |
 
-Required branch protection context: `CI / ci-supported` (maps to the `ci-supported` job in `ci.yml`, also exercised via `pr-gate.yml`).
+Current required branch protection context: `CI / ci-supported`.
+Target required branch protection context: `PR Gate / PR Gate Success` after a dedicated migration PR. Do not require raw matrix leaves.
 
 ### PR-only signal (non-blocking)
 
 | Workflow | Job name | Trigger | Lane | Notes |
 |----------|----------|---------|------|-------|
-| `ci.yml` | `ci-supported` | PR + push | **Required** (via pr-gate) | The canonical green gate; runs on every event |
+| `ci.yml` | `ci-supported` | PR + push | **Required today** | Legacy required context; should stop running on ordinary PRs after PR Gate is promoted |
 | `ci.yml` | `semver-checks` | PR only | PR-only | Detects breaking API changes |
 | `ci.yml` | `api-stability` | PR only | PR-only | `cargo-public-api` diff; `continue-on-error` |
 | `ci.yml` | `package-validation` | PR only | PR-only | Validates package manifests for release surface |
@@ -142,18 +143,27 @@ required_status_checks:
     - "CI / ci-supported"
 ```
 
-This is correct and intentionally single-gated. All other checks are optional
-signal.
+Target required status check after the dedicated migration PR:
+
+```yaml
+required_status_checks:
+  contexts:
+    - "PR Gate / PR Gate Success"
+```
+
+The repository must remain single-gated. All other checks are optional, routed,
+scheduled, manual, release-only, or advisory signal. Never add macOS/windows
+matrix leaves or broad expensive lanes as required branch-protection contexts.
 
 ---
 
 ## How to read the GitHub Checks panel
 
-1. **`CI / ci-supported` red?** — Stop. Fix before merge.
-2. **`PR Gate / PR Gate Success` red?** — Same thing (aggregate gate).
+1. **Current required context red (`CI / ci-supported` today; `PR Gate / PR Gate Success` after migration)?** — Stop. Fix before merge.
+2. **`PR Gate / PR Gate Success` red before it is required?** — Treat as a release/CI follow-up; it is the future aggregate gate.
 3. **Any `Advisory / *` red?** — Inspect when convenient. May be nightly drift.
 4. **Push-only jobs red on main?** — Create a follow-up issue. Not a PR blocker.
-5. **PR-only signal red?** — Worth reviewing, but not a merge blocker.
+5. **PR-only signal red?** — Worth reviewing, but not a merge blocker unless branch protection names it.
 
 ---
 
@@ -169,7 +179,8 @@ signal.
 ## Maintenance
 
 When adding a new CI job:
-1. Add it to the appropriate table above.
+1. Add it to the appropriate table above and to `policy/ci-lane-whitelist.toml`.
 2. If advisory, use `continue-on-error: true` and the `Advisory / ` name prefix.
-3. If required, update `.github/settings.yml` branch protection contexts **and** this file.
-4. If push-only, ensure it does not trigger on PRs (use `if:` guards).
+3. If required, keep the single aggregate context (`PR Gate / PR Gate Success` after migration); do not require matrix leaves.
+4. If push-only, ensure it does not trigger on ordinary PRs (use triggers or `if:` guards).
+5. If the job uses macOS/windows, confirm it is not an ordinary PR default.

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -60,6 +60,63 @@ labels:
   - name: tests
     color: "1d76db"
     description: Test suite changes
+  - name: full-ci
+    color: "0e8a16"
+    description: Run all heavy CI lanes that are safe for this event
+  - name: ci-budget-override
+    color: "b60205"
+    description: Allow CI plan over the hard LEM ceiling
+  - name: ci-budget-ack
+    color: "fbca04"
+    description: Acknowledge elevated or high CI LEM cost
+  - name: platform-matrix
+    color: "5319e7"
+    description: Run full OS and toolchain matrix verification
+  - name: coverage
+    color: "1d76db"
+    description: Run coverage instrumentation and reporting
+  - name: ci:golden
+    color: "d4c5f9"
+    description: Run grammar golden and parity verification
+  - name: ci:perf
+    color: "c5def5"
+    description: Run performance comparison lanes
+  - name: ci:microcrate
+    color: "bfd4f2"
+    description: Run full microcrate CI matrix
+  - name: ci:concurrency
+    color: "bfd4f2"
+    description: Run concurrency microcrate risk pack
+  - name: wasm
+    color: "5319e7"
+    description: Run WASM checks
+  - name: fuzz
+    color: "d93f0b"
+    description: Run fuzzing lanes
+  - name: benchmarks
+    color: "c5def5"
+    description: Run full benchmark suites
+  - name: api
+    color: "0075ca"
+    description: Run public API and SemVer checks
+  - name: release-check
+    color: "006b75"
+    description: Run release-preparation verification
+  - name: security-audit
+    color: "e11d21"
+    description: Run dependency and security audit lanes
+  - name: mutation
+    color: "fbca04"
+    description: Run mutation testing lanes
+  - name: property-tests
+    color: "fbca04"
+    description: Run property-test lanes
+  - name: pure-rust
+    color: "5319e7"
+    description: Run pure-Rust implementation proof
+  - name: ts-bridge
+    color: "5319e7"
+    description: Run ts-bridge parity or FFI validation
   - name: perf
     color: c5def5
     description: Performance improvements

--- a/docs/ci/adze-rollout-plan.md
+++ b/docs/ci/adze-rollout-plan.md
@@ -1,80 +1,175 @@
 # Adze CI economics rollout plan
 
-This document is the per-PR map for the rollout. It describes what each PR
-should do, what should not be combined, and what the rollback path looks like.
+This document is the authoritative implementation map for the CI economics
+rollout. Treat the rollout as **CI infrastructure product work**, not workflow
+cleanup: every change must preserve proof quality while making the default PR
+bill predictable.
 
-The rollout target:
+Core rule:
 
-```
-ordinary PR:        <35 LEM preferred, usually <$0.50
-elevated PR:        35–75 LEM, explicit risk surface
-high-cost PR:       75–125 LEM, explicit label/ack
-over ceiling:       >125 LEM requires override
-```
+> Every PR gets one cheap required proof. Everything else is advisory, routed,
+> scheduled, manual, release-only, or label-triggered.
+
+## Targets
+
+| Target | LEM | Notes |
+| --- | ---: | --- |
+| Preferred ordinary PR | <=25 | Design center for routine code and docs changes. |
+| Ordinary ceiling | <=35 | Above this, explain the risk surface and selected lanes. |
+| Elevated PR | 36-75 | Warn and recommend labels / explicit acknowledgement. |
+| High-cost PR | 76-125 | Warning plus explicit label recommendation. |
+| Over ceiling | >125 | Fail unless `full-ci` or `ci-budget-override` is present. |
+
+Linux is `1.0` LEM, Windows is `2.0`, and macOS is `10.0`. macOS and
+Windows must not be ordinary PR defaults.
+
+## Target default PR shape
+
+### Ordinary Rust PR
+
+| Lane | Blocking | Target LEM | Notes |
+| --- | ---: | ---: | --- |
+| PR Plan | no | ~1 | Changed surfaces, selected lanes, budget band. |
+| Supported Rust Gate | yes | ~18-22 | Runs `just ci-supported`. |
+| PR Gate Success | yes | ~1 | Stable required aggregate. |
+| CI lane whitelist | advisory | ~1-2 | Prevents workflow sprawl. |
+| ripr advisory | advisory | ~3-5 | Static oracle-gap signal; skip docs-only. |
+| Test-policy smoke | advisory or blocking | ~1-3 | Disabled-test / hygiene smoke only. |
+
+### Docs-only PR
+
+| Lane | Blocking | Target LEM | Notes |
+| --- | ---: | ---: | --- |
+| PR Plan | no | ~1 | Classifies docs-only safely. |
+| Docs Gate | yes | ~1-2 | Cheap formatting/doc hygiene proof. |
+| PR Gate Success | yes | ~1 | Stable required aggregate. |
+| Policy lint | advisory | ~1 | Optional workflow/policy hygiene. |
+
+Everything else is non-default: routed, advisory, scheduled, manual,
+release-only, or label-triggered.
 
 ## Status legend
 
-- ✅ landed — change is in `main`
-- 🟡 in flight — open PR or partially merged on the rollout branch
-- ⏳ planned — not yet started
-- ⏸ deferred — needs actuals data or coordination
+- ✅ **already present** — rail exists in this repository.
+- 🟨 **needs hardening** — rail exists but needs stricter metadata, enforcement,
+  or branch-protection coordination.
+- 🧹 **needs pruning** — rail exists but is still too broad or duplicative for
+  ordinary PRs.
+- ⏸ **deferred until actuals** — do not implement until enough `ci-actuals.json`
+  receipts exist.
 
-## PRs
+## Current control-plane inventory
 
-| # | Title | Status | Notes |
+| Rail | Status | Source of truth | Notes |
 | --- | --- | --- | --- |
-| 01 | docs(ci): verification economics policy | 🟡 | This doc set |
-| 02 | chore(ci): add CI lane whitelist map | 🟡 | `policy/ci-lane-whitelist.toml` |
-| 03 | ci(policy): lint workflows against whitelist | 🟡 | `cargo xtask check-ci-lane-whitelist` |
-| 04 | feat(ci): advisory PR Plan with LEM estimates | 🟡 | `.github/workflows/pr-plan.yml` |
-| 05 | ci: add PR Gate Success summary | 🟡 | additive only |
-| 06 | perf(ci): make PR caches restore-only | 🟡 | save-if-main on bare rust-cache usages |
-| 07 | ci(ripr): advisory static exposure | 🟡 | non-blocking |
-| 08 | ci(policy): risk-pack routing map | 🟡 | `policy/ci-risk-packs.toml` |
-| 09 | feat(xtask): `xtask ci plan` | 🟡 | testable planner |
-| 10 | perf(ci): gate fuzzing to nightly and labels | 🟡 | label-gated, build-only smoke for parser PRs |
-| 11 | perf(ci): unify benchmark PR ownership | 🟡 | benchmarks.yml off PR default |
-| 12 | perf(ci): route golden tests by grammar risk | 🟡 | paths filter + label gate |
-| 13 | perf(ci): reduce pure-rust PR matrix | 🟡 | matrix-setup job + label gates |
-| 14 | perf(ci): route microcrate CI by risk pack | 🟡 | changes setup job + per-group gates |
-| 15 | ci: emit LEM actuals telemetry | 🟡 | additive only |
-| 16 | ci(plan): warn on elevated LEM | 🟡 | soft warnings only |
-| 17 | ci: make PR Gate Success the required check | ⏸ | needs ≥14 days stable data; see docs/ci/branch-protection.md |
-| 18 | ci(metrics): learned LEM estimates | ⏸ | needs ≥30 days of actuals; see docs/ci/learned-estimates.md |
+| LEM doctrine and budget bands | ✅ already present | `docs/ci/cost-and-verification-policy.md` | Preferred <=25 LEM, ordinary ceiling <=35 LEM. |
+| Lane whitelist ledger | 🟨 needs hardening | `policy/ci-lane-whitelist.toml` | Advisory today; should become blocking only for workflow/policy changes. |
+| Risk-pack vocabulary | ✅ already present | `policy/ci-risk-packs.toml` | Path/label vocabulary for expensive lanes. |
+| PR Plan | 🟨 needs hardening | `.github/workflows/pr-plan.yml` | Static estimates exist; hard ceiling enforcement must remain override-label based. |
+| PR Gate Success | 🟨 needs hardening | `.github/workflows/pr-gate.yml` | Aggregator exists; branch protection still requires legacy `CI / ci-supported`. |
+| ci-actuals receipt | 🟨 needs hardening | `scripts/ci/emit-ci-actuals.py` | Receipt exists; normalize per-lane schema before learned estimates. |
+| Coverage routing | ✅ already present | `.github/workflows/coverage.yml` | Non-default label/main/manual coverage lane. |
+| Routing label vocabulary | 🟨 needs hardening | `docs/ci/labels.md`, `.github/settings.yml` | Settings must contain all labels used by risk packs and workflows. |
 
-## What this rollout branch contains
+## Next implementation wave
 
-The rollout branch (`claude/adze-ci-economics-rollout-IxzNZ`) contains
-**PRs 01–16**, stacked. Branch-protection promotion (17) and learned
-estimates (18) are documented but intentionally deferred:
+The next wave replaces the older PR-numbered rollout stack with small,
+single-intention PRs. Do not combine branch protection changes with workflow
+pruning.
 
-- **17** changes branch protection. It needs ≥14 days of `PR Gate
-  Success` history and explicit operator coordination. See
-  `docs/ci/branch-protection.md` for the promotion criteria.
-- **18** needs ≥30 days of `ci-actuals.json` data to compute meaningful
-  percentiles. Until then, static estimates are correct. See
-  `docs/ci/learned-estimates.md` for the model and promotion criteria.
+| Wave PR | Title | Status | Scope | Acceptance |
+| ---: | --- | --- | --- | --- |
+| 1 | `docs(ci): reconcile CI economics rollout status` | 🟨 needs hardening | Normalize this doc set and the lane ledger narrative. | `cargo xtask check-ci-lane-whitelist --mode advisory || true`; `cargo xtask policy-report || true`; `git diff --check`. |
+| 2 | `ci(labels): add CI routing labels` | 🟨 needs hardening | Add all routing labels to `.github/settings.yml`. | `git diff --check`. |
+| 3 | `ci: require PR Gate Success as the stable merge gate` | 🟨 needs hardening | Switch branch protection to `PR Gate / PR Gate Success` only after stability criteria pass. | `git diff --check`. |
+| 4 | `ci: stop running legacy ci.yml on ordinary PRs` | 🧹 needs pruning | Remove ordinary `pull_request` execution from legacy `ci.yml`; keep push/schedule/manual. | `cargo xtask check-ci-lane-whitelist --mode advisory || true`; `git diff --check`. |
+| 5 | `ci(test-policy): split PR smoke from full inventory enforcement` | 🧹 needs pruning | Create `test-policy-smoke` for every PR; move full inventory to main/nightly/manual/`full-ci`. | `cargo xtask test-policy-smoke`; `cargo xtask test-policy-full || true`; whitelist advisory; diff check. |
+| 6 | `ci(pure-rust): make platform proof label and main only` | 🧹 needs pruning | PR execution only for `platform-matrix`, `pure-rust`, or `full-ci`; keep main/schedule/manual. | Whitelist advisory; diff check. |
+| 7 | `ci(microcrate): route docs wasm and strict features off ordinary PRs` | 🧹 needs pruning | Keep changed crate groups; move docs/WASM/strict features to labels/main/manual. | Whitelist advisory; diff check. |
+| 8 | `ci(perf): keep benchmark smoke default but label-gate comparisons` | 🧹 needs pruning | Keep compile smoke path-routed; move comparisons to `ci:perf`/`benchmarks`/`full-ci`/main/manual. | Whitelist advisory; diff check. |
+| 9 | `ci(ts-bridge): consolidate smoke and move parity off default PR` | 🧹 needs pruning | Keep one path-routed smoke; move parity to main/schedule/manual/`ts-bridge`/`full-ci`. | Whitelist advisory; diff check. |
+| 10 | `ci(api): route public API checks by API risk` | 🧹 needs pruning | Run SemVer/public API checks only on API-risk paths or labels. | `cargo semver-checks check-release -p adze || true`; `cargo public-api -p adze || true`; diff check. |
+| 11 | `ci(policy): block undeclared workflow lanes` | 🟨 needs hardening | Make whitelist blocking only when workflows/policy/docs/scripts/xtask CI files change. | `cargo xtask check-ci-lane-whitelist --mode blocking`; diff check. |
+| 12 | `ci(plan): enforce static LEM ceilings with override labels` | 🟨 needs hardening | Static budget warnings/failures; no learned estimates yet. | `cargo run -q -p xtask -- ci-plan --base origin/main --head HEAD --json-out target/ci/ci-plan.json`; fallback script; diff check. |
+| 13 | `ci: split main smoke from nightly deep verification` | 🧹 needs pruning | Prevent push-to-main from becoming the cost sink; no macOS/windows on every main push. | Whitelist advisory; diff check. |
+| 14 | `ci(actuals): normalize per-lane LEM receipts` | 🟨 needs hardening | Emit normalized per-lane actuals schema. | `python3 scripts/ci/emit-ci-actuals.py`; `python3 -m json.tool target/ci/ci-actuals.json`; diff check. |
+| 15 | `ci(metrics): compute learned lane estimates from actuals` | ⏸ deferred until actuals | Advisory learned estimates after sufficient samples. | Generated estimates are advisory only. |
+| 16 | `ci(metrics): update lane LEM baselines from measured actuals` | ⏸ deferred until actuals | Ratchet static `base_lem` from measured p90 with owner signoff. | Docs and ledger update together. |
 
-## Per-PR contract
+## Default PR pruning decisions
 
-Each PR body in this rollout must include:
+| Lane family | Current concern | Target behavior |
+| --- | --- | --- |
+| Legacy `ci.yml` | Duplicates supported proof on ordinary PRs. | Push/schedule/manual only after PR Gate is required. |
+| Test policy | Full inventory is useful but too expensive as an always-on PR lane. | Cheap PR smoke; full policy on main/nightly/manual/`full-ci`. |
+| Pure Rust / OS matrix | Ubuntu/stable still duplicates supported proof; macOS/windows are high-multiplier. | Label/main/manual/scheduled only; no macOS/windows ordinary PR defaults. |
+| Microcrate CI | Path routing exists but docs/WASM/strict feature work remains expensive. | Changed crate groups only by default; docs/WASM/strict features by label/main/manual. |
+| Performance | Comparisons are expensive and duplicate benchmark workflows. | Compile smoke only by default and only on benchmark paths; comparisons by label/main/manual. |
+| ts-bridge | Two smoke workflows and parity overlap. | One path-routed smoke; parity by label/main/schedule/manual. |
+| API/SemVer | Valuable release signal, not useful for docs/fixture-only PRs. | API-risk paths or API/release labels; advisory until release prep. |
 
-- estimated LEM impact
-- workflows touched
-- default PR effect
-- rollback path
-- proof obligation
-- cheaper signal considered
-- branch protection impact (almost always: none, until PR 17)
+## Branch-protection migration
+
+The required context is still `CI / ci-supported`. The target context is
+`PR Gate / PR Gate Success`, but the migration must be a dedicated PR after the
+criteria in `docs/ci/branch-protection.md` pass. Never require a raw matrix leaf
+as a branch-protection context.
+
+Rollback for the migration is to restore `CI / ci-supported` as the required
+context in `.github/settings.yml`.
+
+## Per-PR CI economics contract
+
+Every CI economics PR body must include:
+
+```markdown
+## CI economics
+
+- Estimated LEM impact:
+- Workflows touched:
+- Default PR effect:
+- Branch protection impact:
+- Rollback path:
+- Proof obligation:
+- Cheaper signal considered:
+- Expensive runners added? yes/no
+- macOS/windows default PR? must be no
+
+## Verification
+
+- [ ] `cargo xtask check-ci-lane-whitelist --mode advisory`
+- [ ] `cargo xtask policy-report || true`
+- [ ] `git diff --check`
+
+## Claim boundary
+
+This PR changes CI routing/cost only. It does not weaken `just ci-supported`,
+remove deep verification from main/nightly/release/manual paths, or make
+advisory lanes required.
+```
+
+## Agent rules
+
+1. One CI intention per PR.
+2. Never combine branch protection change with large workflow pruning.
+3. Never introduce macOS or Windows as default PR lanes.
+4. Never add a workflow job without a lane entry.
+5. Never make a raw matrix leaf a required branch-protection check.
+6. Keep PR Gate Success as the stable required summary.
+7. Keep deep verification available through main/nightly/manual/label/release.
+8. If a job is `duplicate_of` another lane, justify it or remove/reroute it.
+9. If a lane is expensive and `default_pr = true`, it needs an exception and expiry.
+10. After each merge, refresh `main` and rerun the lane whitelist check.
 
 ## Rollback paths
 
 | Layer | Rollback |
 | --- | --- |
-| docs | revert PR |
-| policy TOML | revert PR; advisory lints stop firing |
-| advisory workflow (PR Plan, ripr, whitelist lint) | delete the workflow file |
-| PR Gate Success | delete the workflow file; old required checks remain |
-| cache normalization | revert per-workflow `save-if` lines |
-| risk-pack routing | revert path filters; lanes go back to default-on |
-| branch protection promotion | switch the required check back |
+| Docs/specs | Revert the PR. |
+| Label registry | Revert `.github/settings.yml` label additions; workflows using absent labels remain safe but less discoverable. |
+| Policy TOML | Revert the lane entry or exception; advisory lints stop using it. |
+| PR Plan budget enforcement | Disable hard-ceiling mode or revert to warnings. |
+| PR Gate branch protection | Restore `CI / ci-supported`. |
+| Legacy `ci.yml` PR pruning | Restore the `pull_request` trigger. |
+| Expensive lane routing | Restore previous triggers; deep lanes remain available throughout. |
+| Learned estimates | Fall back to static `base_lem`. |

--- a/docs/ci/adze-rollout-status.md
+++ b/docs/ci/adze-rollout-status.md
@@ -1,102 +1,70 @@
 # CI Economics Rollout Status
 
-Last review: 2026-05-08.
+Last review: 2026-05-12.
 
-This file is a status snapshot, not a live source of truth. Before using it for
-execution, refresh with `gh pr list` and the current workflow state.
+This is the agent-readable status snapshot for the CI economics rollout. The
+implementation sequence and per-PR contract live in
+`docs/ci/adze-rollout-plan.md`.
 
 ## Status legend
 
-- ✅ landed — present on `main` and working
-- 🟡 in progress — open PR or active follow-up
-- ⏳ planned — not yet started
-- ⏸ deferred — waiting on actuals or coordination
+- ✅ already present — rail exists in this repository.
+- 🟨 needs hardening — rail exists but must be made authoritative or enforced.
+- 🧹 needs pruning — rail exists but is too broad or duplicative for ordinary PRs.
+- ⏸ deferred until actuals — wait for enough `ci-actuals.json` receipts.
 
-## Foundation layer
+## Already present
 
-| # | Item | Status | Notes |
-| --- | --- | --- | --- |
-| F01 | CI lane whitelist (`policy/ci-lane-whitelist.toml`) | ✅ | All workflows mapped with owner, LEM, triggers |
-| F02 | CI risk packs (`policy/ci-risk-packs.toml`) | ✅ | 10 risk packs: core_runtime, macro_tool, glr_core, tablegen, grammar_golden, microcrate_governance, concurrency, wasm, performance, manifest_release |
-| F03 | PR Plan workflow (`pr-plan.yml`) | ✅ | Calls `xtask ci-plan`, emits `ci-plan.json` with outputs `docs_only`, `estimated_lem`, `band` |
-| F04 | PR Gate Success workflow (`pr-gate.yml`) | ✅ | Supported Gate + Docs Gate + `PR Gate Success` aggregator |
-| F05 | ci-actuals telemetry scaffold | ✅ | `scripts/ci/emit-ci-actuals.py` emits plan vs actual; uploaded as artifact |
-| F06 | ripr advisory (`ripr.yml`) | ✅ | Advisory install attempts run on an isolated Rust 1.93 toolchain and fall back to a stub report on install failure |
+| Rail | Source | Notes |
+| --- | --- | --- |
+| CI cost doctrine | `docs/ci/cost-and-verification-policy.md` | LEM model, cost bands, verification ladder. |
+| Lane whitelist | `policy/ci-lane-whitelist.toml` | Owner/cost/evidence/duplicate metadata for workflow jobs. |
+| Risk packs | `policy/ci-risk-packs.toml` | Path and label vocabulary for routed lanes. |
+| PR Plan | `.github/workflows/pr-plan.yml` | Computes changed surfaces, selected lanes, estimated LEM, and budget band. |
+| PR Gate Success | `.github/workflows/pr-gate.yml` | Aggregates Supported Rust Gate or Docs Gate behind one stable check. |
+| CI policy workflow | `.github/workflows/ci-policy.yml` | Runs lane whitelist lint in advisory mode. |
+| ci-actuals scaffold | `scripts/ci/emit-ci-actuals.py` | Emits `ci-actuals.json`; schema still needs normalization. |
+| Non-default coverage | `.github/workflows/coverage.yml` | Coverage is label/main/manual, not an ordinary default. |
 
-## Control plane
+## Needs hardening
 
-| # | Item | Status | Notes |
-| --- | --- | --- | --- |
-| C01 | CI policy workflow (`ci-policy.yml`) | ✅ | Runs `check-ci-lane-whitelist --mode advisory` on every PR |
-| C02 | Synchronize-only cancellation | ✅ | PR #563 merged — prevents label events from killing running jobs |
-| C03 | Lane whitelist cost alignment | ✅ | PR #564 merged — corrects stale LEM for already-gated lanes |
-| C04 | Real ripr provisioning | ✅ | PR #565 merged — isolated Rust 1.93 install with graceful stub fallback |
-| C05 | Benchmark deduplication | ✅ | PR #566 merged — `performance-check` gated to `ci:perf` label |
+| Work | Why | Target PR |
+| --- | --- | --- |
+| Reconcile docs/control plane | Agents need one current truth table and stable sequence. | PR 1 |
+| Add routing labels to repo settings | Labels are the operator interface for expensive verification. | PR 2 |
+| Promote PR Gate Success | Branch protection should require the aggregate, not a raw legacy job. | PR 3 |
+| Make lane whitelist blocking for workflow changes | Prevent new undeclared lanes and expensive defaults from landing silently. | PR 11 |
+| Enforce static budget ceilings | Over-ceiling plans should fail unless override labels are present. | PR 12 |
+| Normalize ci-actuals receipts | Learned estimates need lane-level receipts. | PR 14 |
 
-## Routing
+## Needs pruning
 
-| # | Item | Status | Notes |
-| --- | --- | --- | --- |
-| R01 | Fuzz gating (label/push only) | ✅ | `fuzz.yml` — runtime fuzz requires `fuzz`/`full-ci` label or push/schedule |
-| R02 | Pure-Rust PR matrix reduction | ✅ | `pure-rust-ci.yml` — ubuntu/stable default; full matrix on `platform-matrix`/`full-ci`/main |
-| R03 | Golden tests grammar routing | ✅ | `golden-tests.yml` — paths + `ci:golden`/`full-ci` label gates |
-| R04 | Microcrate CI risk-pack routing | ✅ | `microcrate-ci.yml` — per-group path detection (concurrency/governance/bdd/parser/core/runtime) |
-| R05 | Benchmark PR ownership cleanup | ✅ | PR #566 merged — removes duplicate baseline+comparison from default PR path |
+| Lane family | Current issue | Target PR |
+| --- | --- | --- |
+| Legacy `ci.yml` | Still has ordinary PR trigger and duplicates supported proof. | PR 4 |
+| Test policy | Full inventory enforcement is too expensive for every PR. | PR 5 |
+| Pure Rust / OS matrix | Ubuntu/stable PR default duplicates supported proof; macOS/windows must be non-default. | PR 6 |
+| Microcrate CI | Path routing exists, but docs/WASM/strict feature checks need harder labels/main/manual routing. | PR 7 |
+| Performance comparison | Expensive comparison should not be a default PR lane. | PR 8 |
+| ts-bridge smoke/parity | Duplicate smokes and default parity should be consolidated/rerouted. | PR 9 |
+| API/SemVer | Should run on API-risk paths or API/release labels, not docs/fixture-only PRs. | PR 10 |
+| Main push deep verification | Moving everything to main would become the next cost sink. | PR 13 |
 
-## Policy ledgers
+## Deferred until actuals
 
-| # | Item | Status | Notes |
-| --- | --- | --- | --- |
-| P01 | Clippy lint policy (`policy/clippy-lints.toml`) | ✅ | Schema, active, staged, and planned lints documented |
-| P02 | No-panic allowlist (`policy/no-panic-allowlist.toml`) | ✅ | Schema in place; intentionally empty until `cargo xtask no-panic-propose --baseline` run |
-| P03 | Non-Rust file policy (`policy/non-rust-allowlist.toml`) | ✅ | All non-Rust surfaces registered |
-| P04 | ripr suppressions (`policy/ripr-suppressions.toml`) | ✅ | Schema in place; empty baseline |
-| P05 | Workspace rust lints (`[workspace.lints.rust]`) | ✅ | `unsafe_op_in_unsafe_fn`, `unused_must_use`, `missing_docs`, `unused_extern_crates` |
-| P06 | Strict Clippy Stage A (`[workspace.lints.clippy]`) | 🟡 | PR #567: `policy/clippy-stage-a` — `allow_attributes_without_reason` + stage-A rust lints |
-
-## MSRV and toolchain
-
-| # | Item | Status | Notes |
-| --- | --- | --- | --- |
-| T01 | MSRV 1.93 | ⏳ | PR: `policy/msrv-1-93` — dedicated policy PR, prerequisite for ripr simplification |
-
-## Branch protection
-
-| # | Item | Status | Notes |
-| --- | --- | --- | --- |
-| B01 | Branch protection migration docs | ✅ | `docs/ci/branch-protection.md` — criteria for promoting required check |
-| B02 | `PR Gate Success` stable run history | ⏸ | Needs ≥14 days and ≥5 distinct PRs per path before promotion |
-| B03 | Migrate required check to `PR Gate Success` | ⏸ | After B02 — see `docs/ci/branch-protection.md` |
-
-## Learned estimates
-
-| # | Item | Status | Notes |
-| --- | --- | --- | --- |
-| L01 | ci-actuals collection | ✅ | Artifact upload on every PR Gate run |
-| L02 | Learned LEM model | ⏸ | Needs ≥30 days of actuals; see `docs/ci/learned-estimates.md` |
-
-## Effective default PR lane cost (current)
-
-With all routing already in place, the effective default PR cost estimate:
-
-| Lane | Effective default PR cost |
+| Work | Criteria |
 | --- | --- |
-| PR Plan | ~1 LEM |
-| Supported Rust Gate | ~20 LEM |
-| PR Gate Success | ~1 LEM |
-| CI Lane Whitelist | ~2 LEM |
-| ripr advisory | ~4 LEM (isolated install attempted; stub report on toolchain/binary failure) |
-| Test Policy | ~12 LEM |
-| Pure Rust (ubuntu/stable only) | ~18 LEM |
-| Microcrate CI (routed by risk pack) | ~5–20 LEM depending on changed surface |
-| Fuzz build smoke (parser/glr paths only) | ~3 LEM |
-| Criterion smoke | ~6 LEM |
-| ts-bridge lanes | ~8 LEM |
-| Clippy quarantine report | ~4 LEM |
-| **Estimated total (typical runtime PR)** | **~65–80 LEM** |
+| Learned estimates | >=30 days or enough normalized per-lane receipts; advisory only. |
+| Ratchet static lane costs | Enough samples, p90-based updates, owner signoff for expensive lanes. |
 
-Target is ≤35 LEM for ordinary PRs. The gap comes from `pure-rust-ci` (18 LEM)
-and `microcrate-ci` (variable) running broadly on every PR. Active exceptions in
-`policy/ci-whitelist-exceptions.toml` track these while tightening continues.
+## Current default PR gap
 
-See `docs/ci/lem-budgeting.md` for budget bands and override labels.
+The target ordinary PR shape is <=25 LEM preferred and <=35 LEM ceiling. Current
+ordinary PR cost can still exceed that because several useful but duplicative
+lanes remain default or broad-path PR lanes: full test policy (~12 LEM),
+pure-rust ubuntu/stable (~18 LEM), microcrate CI (variable), ts-bridge lanes,
+and performance/API signals on some surfaces.
+
+The pruning PRs must preserve deep verification through routed, advisory,
+scheduled, `main`, release, and manual paths while removing those costs from the
+ordinary default.

--- a/docs/ci/branch-protection.md
+++ b/docs/ci/branch-protection.md
@@ -1,56 +1,90 @@
 # Branch protection
 
-## Today
+Branch protection is part of the CI economics control plane. It must expose one
+stable required context instead of requiring raw workflow leaves or matrix jobs.
 
-The required check today is the existing `ci-supported` job in `ci.yml`
-(see `docs/status/KNOWN_RED.md`). Branch protection has not been changed
-by the rollout.
+## Current required context
 
-## Future
+The required check today is:
 
-The rollout introduces a new aggregated check called **PR Gate Success**
-(see `.github/workflows/pr-gate.yml`). It depends on:
+```text
+CI / ci-supported
+```
 
-- `PR Plan` (advisory)
-- `Supported Rust Gate` (= `just ci-supported`)
-- `Docs Gate` (fmt only, runs only on docs-only PRs)
+That context comes from the legacy `ci.yml` supported lane. The CI economics
+rollout has not changed branch protection yet.
 
-`PR Gate Success` succeeds when exactly one of `Supported Rust Gate` /
-`Docs Gate` succeeded and the other was skipped. PR Plan must not fail.
+## Target required context
 
-This is **additive only** in the rollout's foundation phase. Branch
-protection is *not* updated yet. PR 17 in `docs/ci/adze-rollout-plan.md`
-is the dedicated change that flips the required check to
-`PR Gate Success` once the workflow has been stable for a sufficient
-window of PRs.
+The target required check is:
 
-## PR 17 — promotion criteria
+```text
+PR Gate / PR Gate Success
+```
+
+`PR Gate Success` is the stable aggregate in `.github/workflows/pr-gate.yml`.
+It depends on:
+
+- `PR Plan` (advisory control-plane planning),
+- `Supported Rust Gate` (`just ci-supported`) for ordinary Rust PRs, and
+- `Docs Gate` for docs-only PRs.
+
+`PR Gate Success` succeeds when PR Plan did not fail and exactly the expected
+cheap required proof passed: Supported Rust Gate for code PRs, or Docs Gate for
+docs-only PRs.
+
+## Migration rule
+
+Move branch protection in a dedicated PR only. Do not combine this change with
+workflow pruning, lane removal, or label-routing changes.
+
+The settings change is:
+
+```yaml
+required_status_checks:
+  strict: true
+  contexts:
+    - "PR Gate / PR Gate Success"
+```
+
+Never require raw matrix leaves (for example a single OS/toolchain matrix job),
+nightly lanes, macOS/windows jobs, benchmark jobs, or advisory jobs as branch
+protection contexts.
+
+## Promotion criteria
 
 Branch protection promotion to `PR Gate Success` is gated on:
 
 | Criterion | Target |
 | --- | --- |
-| `PR Gate Success` job has run on every PR for | ≥ 14 calendar days |
-| `PR Gate Success` flake rate | < 1% |
-| Number of distinct PRs that exercised both `Supported Rust Gate` and `Docs Gate` paths | ≥ 5 each |
-| `ci-actuals.json` artifacts uploaded | ≥ 30 PRs |
+| `PR Gate Success` job has run on every PR for | >=14 calendar days |
+| `PR Gate Success` flake rate | <1% |
+| Distinct PRs that exercised Supported Rust Gate | >=5 |
+| Distinct PRs that exercised Docs Gate | >=5 |
+| `ci-actuals.json` artifacts uploaded | >=30 PRs |
 | Manual review of band/LEM accuracy | passes |
 
-When all five gates clear, PR 17 is opened. PR 17 itself only:
+When all gates clear, open the dedicated branch-protection PR. That PR should
+only update `.github/settings.yml` and the docs/policy references to the
+required context.
 
-1. updates `.github/settings.yml` (and any equivalent platform config) to
-   require `PR Gate Success` and stop requiring the legacy `ci-supported`
-   job, **and**
-2. removes the redundant `ci-supported` job from `ci.yml` if it is no
-   longer used by anything else (it is also reachable via the new
-   `pr-gate.yml`).
+## Relationship to legacy `ci.yml`
+
+After branch protection requires `PR Gate / PR Gate Success`, a separate PR may
+remove ordinary `pull_request` execution from legacy `ci.yml`. That is a
+separate pruning step because it changes where duplicate PR cost is charged.
+
+`ci.yml` deep jobs should remain available through push to `main`, schedule, and
+manual dispatch unless a later dedicated PR reroutes them.
 
 ## Rollback
 
-Removing `pr-gate.yml` reverts to the existing required check. No state
-needs migrating because PR Gate Success is a new, separate workflow.
+If the new required check causes problems, restore the previous required context
+in `.github/settings.yml`:
 
-If PR 17 has landed and the new required check is causing problems, the
-rollback is to restore the previous required check name in
-`.github/settings.yml` and re-add the legacy `ci-supported` job
-configuration.
+```text
+CI / ci-supported
+```
+
+No data migration is required. `PR Gate Success` is additive until the migration
+PR lands, and the old supported proof remains `just ci-supported` either way.

--- a/docs/ci/cost-and-verification-policy.md
+++ b/docs/ci/cost-and-verification-policy.md
@@ -28,10 +28,10 @@ external services (Docker build farms, AI review) carry their own multipliers.
 
 | Band | LEM | Behavior |
 | --- | --- | --- |
-| ordinary | 0–35 | green; preferred default <25 |
-| elevated | 36–75 | warning; explicit risk surface |
-| high | 76–125 | high warning; explicit label/ack |
-| over ceiling | >125 | fails unless `full-ci` or `ci-budget-override` |
+| ordinary | 0-35 | green; preferred default <=25 |
+| elevated | 36-75 | warning summary; explicit risk surface |
+| high | 76-125 | high warning plus explicit label recommendation |
+| over ceiling | >125 | fail unless `full-ci` or `ci-budget-override` |
 
 The target is sub-`$0.50` ordinary PRs when possible. `$1` is a ceiling, not
 the design center.
@@ -40,31 +40,39 @@ the design center.
 
 | Tier | Trigger | Examples |
 | --- | --- | --- |
-| frontdoor | every PR, blocking | `just ci-supported`, test-policy |
-| advisory | every PR, non-blocking | PR Plan, ripr |
-| risk-routed | risk pack matches | parser fuzz build, golden, microcrate group |
-| deep | `main`, nightly, label | OS matrix, fuzz runtime, full benchmarks |
+| frontdoor | every PR, blocking | `PR Gate Success`, `just ci-supported` or Docs Gate |
+| advisory | every PR, non-blocking | PR Plan, ripr, lane whitelist |
+| risk-routed | risk pack matches | parser fuzz build, golden, matching microcrate group |
+| deep | `main`, nightly, label, manual | OS matrix, fuzz runtime, full benchmarks, full test-policy inventory |
 | release | tag, manual | semver, MSRV, security audit |
+
+The frontdoor target is deliberately narrow. Ordinary Rust PRs should normally
+pay for PR Plan (~1 LEM), Supported Rust Gate (~18-22 LEM), PR Gate Success
+(~1 LEM), cheap advisory policy signals, and at most a smoke-level test-policy
+lane. Docs-only PRs should pay for PR Plan, Docs Gate, PR Gate Success, and
+policy lint only. All other proof stays available, but it is selected by path,
+label, schedule, `main`, release, or manual dispatch.
 
 ## How we get there
 
-The rollout is not "delete CI". It is, in order:
+The rollout is not "delete CI". It proceeds as infrastructure product work:
 
-1. Document the policy (this doc).
-2. Inventory every existing CI lane in `policy/ci-lane-whitelist.toml`.
-3. Lint workflows against that whitelist (advisory).
-4. Forecast each PR's cost with PR Plan (advisory).
-5. Stand up `PR Gate Success` as the future required check.
-6. Normalize cache save semantics so PRs restore but only `main` saves.
-7. Add `ripr` as cheap oracle-gap detection.
-8. Encode risk packs so routing has a vocabulary.
-9. Make planning testable with `xtask ci plan`.
-10. Route the heavy lanes (fuzz, OS matrix, benchmarks, golden, microcrate) by
-    risk pack and label.
-11. Calibrate from actuals.
-12. Promote `PR Gate Success` to the required branch protection.
+```text
+stabilize docs/control plane
+-> make PR Gate authoritative
+-> remove duplicate PR execution
+-> route expensive lanes harder
+-> enforce lane metadata
+-> add labels / branch-protection rails
+-> collect actuals
+-> ratchet budgets from measured data
+```
 
-See `docs/ci/adze-rollout-plan.md` for the per-PR breakdown.
+The already-present rails are the policy docs, lane whitelist, risk packs,
+PR Plan, PR Gate Success, and ci-actuals scaffold. The next work is to harden
+those rails, prune duplicate ordinary-PR execution, and defer learned estimates
+until enough receipts exist. See `docs/ci/adze-rollout-plan.md` for the
+single-intention PR sequence.
 
 ## What we will not do
 
@@ -73,6 +81,8 @@ See `docs/ci/adze-rollout-plan.md` for the per-PR breakdown.
 - Enforce learned LEM budgets before actuals exist.
 - Combine docs, policy, and routing changes into a single PR.
 - Remove broad validation from `main`/nightly/label paths.
+- Introduce macOS or Windows as ordinary PR defaults.
+- Make a raw matrix leaf the required branch-protection context.
 
 ## Related
 

--- a/docs/ci/labels.md
+++ b/docs/ci/labels.md
@@ -1,47 +1,58 @@
 # CI labels
 
-The label vocabulary used by PR Plan to opt in to deeper verification.
+Labels are the operator interface for CI economics. They opt a PR into deeper
+verification, acknowledge budget bands, or route a specific risk pack. Labels do
+not weaken `just ci-supported`, and they must not make macOS/windows ordinary PR
+defaults.
 
-## Cost labels
+## Budget labels
 
 | Label | Meaning |
 | --- | --- |
-| `ci-budget-ack` | acknowledge elevated/high LEM (35–125) |
-| `ci-budget-override` | allow >125 LEM |
-| `full-ci` | run all heavy lanes; implies budget override |
+| `full-ci` | Opt into all heavy verification lanes that are safe for the event. Implies budget override intent. |
+| `ci-budget-override` | Allow a static PR Plan over the hard ceiling (>125 LEM). |
+| `ci-budget-ack` | Acknowledge elevated/high cost (35-125 LEM) without forcing all lanes. |
 
-## Risk-pack opt-in
-
-| Label | Adds |
-| --- | --- |
-| `ci:perf` | full benchmark comparison |
-| `ci:golden` | golden tests for grammars |
-| `ci:microcrate` | full microcrate CI matrix |
-| `ci:concurrency` | concurrency microcrate group |
-| `platform-matrix` | full OS/toolchain matrix |
-| `fuzz` | fuzz runtime |
-| `coverage` | coverage instrumentation |
-| `wasm` | wasm-check |
-
-## Release / API
+## Risk-pack opt-ins
 
 | Label | Adds |
 | --- | --- |
-| `release-check` | release-gate verification |
-| `security-audit` | dependency / RUSTSEC audit |
-| `mutation` | mutation testing on parser/glr core |
-| `property-tests` | property-test runs on parser |
+| `platform-matrix` | Full OS/toolchain platform proof. |
+| `pure-rust` | Pure-Rust implementation proof without implying unrelated heavy lanes. |
+| `coverage` | Coverage instrumentation/reporting. |
+| `ci:golden` | Grammar golden/parity lanes. |
+| `ci:perf` | Performance comparison lanes. |
+| `ci:microcrate` | Full microcrate CI matrix. |
+| `ci:concurrency` | Concurrency microcrate group. |
+| `wasm` | WASM checks. |
+| `fuzz` | Runtime fuzzing lanes. |
+| `benchmarks` | Full benchmark suite/reporting. |
+| `api` | Public API / SemVer checks. |
+| `release-check` | Release-prep verification. |
+| `security-audit` | Dependency and RUSTSEC audit lanes. |
+| `mutation` | Mutation testing on parser/GLR core. |
+| `property-tests` | Property-test runs on parser surfaces. |
+| `ts-bridge` | ts-bridge parity or non-smoke FFI validation. |
 
 ## Skip labels
 
 | Label | Effect |
 | --- | --- |
-| `skip-golden` | skip golden tests (only honored when no `ci:golden`) |
-| `skip-perf` | skip perf compare (only honored when no `ci:perf`) |
+| `skip-golden` | Skip golden tests where the workflow supports it and no explicit golden opt-in is present. |
+| `skip-perf` | Skip performance comparison where the workflow supports it and no explicit perf opt-in is present. |
+
+## Required settings labels
+
+`.github/settings.yml` should define every label that appears in this document,
+`policy/ci-risk-packs.toml`, `policy/ci-lane-whitelist.toml`, or workflow label
+conditions. Missing labels make expensive verification harder for operators and
+agents to request consistently.
 
 ## Notes
 
-- Labels are advisory until the routing PRs (10–14) land. Until then they
-  appear in the PR Plan summary but do not change which lanes run.
-- Labels never *raise* the hard ceiling. They explain a high LEM number; they
-  do not silence safety checks.
+- Labels select additional proof; they do not replace the cheap required gate.
+- Labels may explain or allow high LEM plans, but only `full-ci` and
+  `ci-budget-override` can allow over-ceiling static plans.
+- Expensive labels should be paired with a PR body explanation of LEM impact,
+  default PR effect, branch-protection impact, rollback path, and proof
+  obligation.

--- a/docs/ci/labels.md
+++ b/docs/ci/labels.md
@@ -41,6 +41,34 @@ defaults.
 | `skip-golden` | Skip golden tests where the workflow supports it and no explicit golden opt-in is present. |
 | `skip-perf` | Skip performance comparison where the workflow supports it and no explicit perf opt-in is present. |
 
+## Routing status
+
+Labels marked **(active)** are checked by at least one workflow condition today.
+Labels marked **(planned)** are defined for future routing; adding them to a PR
+has no CI effect until a workflow gates on them.
+
+| Label | Status |
+| --- | --- |
+| `full-ci` | active |
+| `ci-budget-override` | active |
+| `ci-budget-ack` | active |
+| `platform-matrix` | active |
+| `ci:golden` | active |
+| `ci:perf` | active |
+| `ci:microcrate` | active |
+| `ci:concurrency` | active |
+| `fuzz` | active |
+| `wasm` | planned |
+| `pure-rust` | planned |
+| `benchmarks` | planned |
+| `api` | planned |
+| `release-check` | planned |
+| `security-audit` | planned |
+| `mutation` | planned |
+| `property-tests` | planned |
+| `ts-bridge` | planned |
+| `coverage` | planned |
+
 ## Required settings labels
 
 `.github/settings.yml` should define every label that appears in this document,

--- a/docs/ci/learned-estimates.md
+++ b/docs/ci/learned-estimates.md
@@ -1,57 +1,92 @@
-# Learned LEM estimates (PR 18)
+# Learned LEM estimates
 
-Static `base_lem` values in `policy/ci-lane-whitelist.toml` are the
-starting estimate. Once `ci-actuals.json` artifacts have accumulated,
-the planner can use observed durations instead.
+Static `base_lem` values in `policy/ci-lane-whitelist.toml` are the source of
+truth until enough `ci-actuals.json` receipts exist. Learned estimates are a
+future advisory calibration layer; they must not become the first enforcement
+mechanism.
 
-## Promotion criteria
+## Deferral rule
 
-PR 18 is opened when:
+Do not use learned estimates for blocking decisions until both are true:
 
-- `target/ci/ci-actuals.json` artifacts have been uploaded by ≥ 30 PRs,
-- the runner-multiplier × wall-clock time for each lane has a stable
-  p50 and p90 within ±15% across two consecutive weeks,
-- the band thresholds (`35` / `75` / `125`) still match the operator's
-  cost target after observing actuals (see `docs/ci/lem-budgeting.md`).
+1. at least 30 days of receipts, or an equivalent sample size, exists for the
+   lanes being calibrated; and
+2. the per-lane p50/p90/p95 values are stable enough that updating static
+   estimates will not hide real cost.
 
-## Model
+Static estimates and override labels (`full-ci`, `ci-budget-override`) remain
+correct during the rollout.
 
+## Receipt schema target
+
+The actuals receipt should normalize each selected lane before learned estimates
+consume it:
+
+```json
+{
+  "schema_version": 1,
+  "pr": 123,
+  "head_sha": "...",
+  "lanes": [
+    {
+      "id": "ci-supported",
+      "workflow": "PR Gate",
+      "job": "Supported Rust Gate",
+      "runner": "ubuntu_latest",
+      "wall_minutes": 21.4,
+      "runner_multiplier": 1.0,
+      "lem": 21.4,
+      "selected_by": ["default_pr"],
+      "result": "success"
+    }
+  ],
+  "total_lem": 27.2,
+  "budget_band": "ordinary"
+}
 ```
-estimate(lane) = max(static_floor(lane), p50_recent_actual(lane) × 1.15)
+
+## Metrics to compute
+
+For each lane, learned estimates should report:
+
+| Metric | Use |
+| --- | --- |
+| p50 LEM | Typical observed cost. |
+| p90 LEM | Budget baseline candidate; do not lower static `base_lem` below this without a written reason. |
+| p95 LEM | Outlier / hard-warning signal. |
+| sample count | Determines whether the estimate is mature enough to use. |
+| last seen | Detects stale lanes. |
+| outliers | Explains exceptional receipts that should not silently ratchet budgets. |
+
+## Advisory model
+
+When enough samples exist:
+
+```text
+estimate(lane) = max(static_floor(lane), p50_recent_actual(lane) * 1.15)
 warning(lane)  = p90_recent_actual(lane)
 hard(lane)     = p95_recent_actual(lane)
 ```
 
-`static_floor` is the `base_lem` from the whitelist. The `× 1.15` factor
-keeps the estimate slightly pessimistic, so a normal PR's actuals stay
-under the estimate.
+`static_floor` is the lane's `base_lem`. The 15% buffer keeps planning slightly
+pessimistic so ordinary PR actuals usually land below the forecast.
 
-## Implementation outline
+## Ratchet rules
 
-PR 18 will:
+Static ledger updates are a separate PR after learned estimates have been
+computed:
 
-1. Add a `learned_estimates` section to the planner that loads the
-   most recent `ci-actuals.json` artifacts (from the previous N runs on
-   `main` or any matching workflow).
-2. Replace the static `base_lem` lookup in `xtask ci plan` with
-   `max(static_floor, p50_recent × 1.15)`.
-3. Continue to fall back to `base_lem` whenever fewer than 5 actuals
-   exist for a lane.
-4. Add `--enforce-hard-ceiling` to the workflow only if the band
-   thresholds have been validated against actuals.
+- require enough samples for the lane,
+- do not lower estimates below p90 without a written reason,
+- require owner signoff for expensive default lanes,
+- keep Linux/windows/macOS multipliers explicit,
+- update docs and `policy/ci-lane-whitelist.toml` together,
+- keep learned estimates advisory until the updated static ledger has reviewed
+  budgets.
 
 ## Why this is deferred
 
-Until enough actuals exist, learned estimates are noisier than static
-ones. Worse, they make PR planning depend on historical data that may
-not exist for new lanes (a new lane has zero actuals and would either
-fall back to `base_lem` or be silently underestimated). Static
-estimates are correct in the meantime.
-
-## Privacy and stability
-
-- The learned estimates only consume aggregated p50/p90/p95 numbers.
-- They are stored in the planner's working memory, not committed to
-  the repo.
-- Static `base_lem` remains the audit trail; learned estimates inform,
-  they do not replace.
+New or rarely selected lanes have sparse data. If learned estimates are enforced
+too early, they either underestimate new lanes or make PR planning depend on
+history that is not available. The current rollout therefore enforces static
+bands first and uses actuals only after receipts are normalized and sampled.

--- a/policy/ci-lane-whitelist.toml
+++ b/policy/ci-lane-whitelist.toml
@@ -12,14 +12,14 @@
 #            from `job` so we can rename workflow jobs without churn.
 #
 # This file is advisory until `cargo xtask check-ci-lane-whitelist` is run
-# in blocking mode in CI; until then the whitelist lint reports findings to
-# `target/policy/ci-lane-whitelist.json` without failing the build.
+# in blocking mode in CI. The rollout target is blocking enforcement only
+# for workflow/policy/control-plane changes, not every ordinary code PR.
 
 schema_version = "1.0"
 policy = "ci-lane-whitelist"
 owner = "release/ci"
 status = "advisory"
-updated = "2026-05-08"
+updated = "2026-05-12"
 
 [budget]
 # All values in LEM (Linux-equivalent minutes).
@@ -95,7 +95,7 @@ blocking = true
 runner = "ubuntu_latest"
 base_lem = 1
 owner = "release/ci"
-intent = "Single stable summary check intended to become the future required check."
+intent = "Single stable summary check that becomes the stable required check after branch-protection promotion."
 failure_mode = "Required check name churn would break branch protection during the rollout."
 proof_obligation = "Aggregate pr-plan + supported / docs gate results into a stable status."
 evidence = ["job summary"]
@@ -189,7 +189,7 @@ failure_mode = "Pure-Rust parser path passes Linux but fails on Windows, macOS, 
 proof_obligation = "Run clippy, build, tests, and bench compile checks across OS/toolchain matrix."
 evidence = ["job logs"]
 allowed_triggers = ["pull_request", "push"]
-routing_note = "matrix-setup job limits default PR to ubuntu/stable (~18 LEM). Full OS*toolchain matrix (was 180 LEM) gated to 'platform-matrix'/'full-ci' labels and main/push."
+routing_note = "Needs pruning: target behavior is no ordinary PR execution unless platform-matrix, pure-rust, or full-ci is present; main/scheduled/manual keep platform proof. Full OS*toolchain matrix remains label/main/manual only."
 expensive = true
 default_pr_exception = "ci-exception-pure-rust-os-matrix-default-pr"
 duplicate_of = ["ci-supported", "microcrate-ci"]
@@ -212,7 +212,7 @@ failure_mode = "Microcrate split surfaces drift independently from supported run
 proof_obligation = "Run crate-group tests, docs, WASM check, strict feature checks, and formatting."
 evidence = ["job logs"]
 allowed_triggers = ["pull_request", "push"]
-routing_note = "changes setup job routes each PR to the matching crate groups only (concurrency/governance/bdd/parser/core/runtime). Full run on 'ci:microcrate'/'full-ci' labels and main."
+routing_note = "Needs pruning: keep changed crate-group tests only for matching paths; move formatting, docs build, WASM, and strict features to main/manual/full-ci or specific labels."
 expensive = true
 default_pr_exception = "ci-exception-microcrate-ci-default-pr"
 duplicate_of = ["ci-supported", "core-tests"]
@@ -258,7 +258,7 @@ failure_mode = "Runtime/GLR/tablegen performance regresses silently."
 proof_obligation = "Run baseline and PR Criterion benchmarks and report >5% deltas."
 evidence = ["performance_report.txt", "PR comment"]
 allowed_triggers = ["pull_request"]
-routing_note = "performance-check job uses path filter on PR. ci/benchmark-dedup will gate baseline comparison to 'ci:perf'/'full-ci' labels; quick-smoke-test remains default."
+routing_note = "Needs pruning: keep criterion compile smoke path-routed; gate baseline/performance comparison to ci:perf, benchmarks, full-ci, main, or manual."
 expensive = true
 default_pr_exception = "ci-exception-performance-default-pr"
 duplicate_of = ["benchmarks-pr"]
@@ -412,7 +412,8 @@ failure_mode = "ABI parity drift goes unnoticed."
 proof_obligation = "Run ts-bridge parity harness on canonical grammars."
 evidence = ["job logs"]
 allowed_triggers = ["pull_request", "push"]
-duplicate_of = []
+duplicate_of = ["smoke-ts-bridge"]
+routing_note = "Needs pruning: move parity off ordinary PRs to main/scheduled/manual/ts-bridge/full-ci after smoke consolidation."
 review_after = "2026-06-07"
 expires = "2026-09-07"
 


### PR DESCRIPTION
### Motivation

- Establish a single agent-readable control plane for the CI-economics rollout so follow-up work can be implemented as small, single-intention PRs. 
- Make the future `PR Gate / PR Gate Success` promotion explicit with clear migration criteria and avoid requiring raw matrix leaves or expensive macOS/windows defaults. 
- Provide a stable label vocabulary and ledger metadata so expensive lanes are label-gated and reviewers/operators can opt into deep verification consistently. 
- Defer learned-estimates enforcement until normalized per-lane `ci-actuals.json` receipts exist so static `base_lem` remains the safety floor.

### Description

- Reconciled and expanded the rollout/control-plane documentation in `docs/ci/adze-rollout-plan.md`, `docs/ci/adze-rollout-status.md`, `docs/ci/branch-protection.md`, `docs/ci/learned-estimates.md`, and `docs/ci/cost-and-verification-policy.md` to describe the 16-step rollout, PR contract, agent rules, and migration criteria. 
- Added and clarified the CI label vocabulary in `docs/ci/labels.md` and created corresponding entries in `.github/settings.yml` for `full-ci`, `ci-budget-override`, `platform-matrix`, `ci:perf`, `ci:golden`, `ci:microcrate`, `fuzz`, `coverage`, `pure-rust`, `ts-bridge`, and others so opt-in gating is discoverable. 
- Updated contributor-facing lane guidance in `.github/CI_LANES.md` to record current required context (`CI / ci-supported`), the target aggregate (`PR Gate / PR Gate Success`), and maintenance rules for adding jobs. 
- Adjusted the lane ledger metadata in `policy/ci-lane-whitelist.toml` (timestamps, routing notes, `intent` text, and a few `duplicate_of`/`routing_note` entries) to reflect pruning targets (pure-rust, microcrate, performance, ts-bridge) and to document which lanes are candidates for non-default routing. 
- All changes are documentation and settings-only control-plane work and do not change workflow execution triggers or make any advisory lanes required.

### Testing

- Ran `cargo xtask check-ci-lane-whitelist --mode advisory` which completed and reported advisory findings (undeclared `droid-security-scan` and `golden-tests` `paths` job) and otherwise validated the whitelist TOML; the command finished successfully. 
- Ran `cargo xtask policy-report || true` which executed and produced the policy report without failing. 
- Verified repository diffs and formatting checks with `git diff --check` which returned clean. 
- Validated TOML and settings parsing with `python -c "import tomllib; tomllib.load(open('policy/ci-lane-whitelist.toml','rb'))"` and `ruby -e "require 'yaml'; YAML.load_file('.github/settings.yml')"`, both of which parsed successfully (note: optional Python `yaml` module was not present when attempted, so Ruby was used for YAML validation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03b0a48948833380af054fd33583ee)