### PR TITLE
docs: consolidate 0.9 economics contracts

### DIFF
--- a/.adze/goals/active.toml
+++ b/.adze/goals/active.toml
@@ -1,0 +1,183 @@
+id = "adze-0-9-contract-convergence"
+title = "Adze 0.9.0 contract convergence"
+status = "active"
+owner = "droid-factory"
+created = "2026-05-12"
+
+objective = """
+Collapse or classify the workspace surface, recalibrate CI economics, update
+Rust/MSRV and lint policy in the right order, and promote product claims only
+where support-tier proof exists.
+"""
+
+end_state = [
+  "Every workspace package is classified.",
+  "No durable unpublished production crate category exists.",
+  "Owner-module migration targets name an owner and exit condition.",
+  "CI lane whitelist reflects the post-collapse workspace.",
+  "Ordinary PRs expose LEM estimates and over-ceiling PRs require override.",
+  "Rust/MSRV declarations agree after the 1.95 bump.",
+  "Lint policy checks pass without hiding easy refactors behind expect attributes.",
+  "Support tiers map every stable README claim to proof.",
+]
+
+[[work_item]]
+id = "source-of-truth-scaffolding"
+status = "complete"
+proposal = ""
+spec = ""
+adr = ""
+plan = "plans/0.9.0/implementation-plan.md"
+prs = [681]
+commands = [
+  "git diff --check",
+]
+
+[[work_item]]
+id = "contract-convergence-proposal"
+status = "complete"
+proposal = "docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md"
+spec = ""
+adr = ""
+plan = "plans/0.9.0/implementation-plan.md"
+prs = [691]
+commands = [
+  "git diff --check",
+]
+
+[[work_item]]
+id = "package-boundary-spec"
+status = "active"
+proposal = "docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md"
+spec = "docs/specs/ADZE-SPEC-0001-package-surface-boundary.md"
+adr = "ADZE-ADR-0002-no-durable-unpublished-production-crates"
+plan = "plans/0.9.0/implementation-plan.md"
+prs = []
+commands = [
+  "git diff --check",
+]
+
+[[work_item]]
+id = "ci-economics-spec"
+status = "active"
+proposal = "docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md"
+spec = "docs/specs/ADZE-SPEC-0002-ci-economics.md"
+adr = ""
+plan = "plans/0.9.0/implementation-plan.md"
+prs = []
+commands = [
+  "git diff --check",
+]
+
+[[work_item]]
+id = "adze-document-adr"
+status = "active"
+proposal = "docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md"
+spec = "ADZE-SPEC-0003-canonical-parse-document"
+adr = "docs/adr/ADZE-ADR-0001-adze-document-one-parse-truth.md"
+plan = "plans/0.9.0/implementation-plan.md"
+prs = []
+commands = [
+  "git diff --check",
+]
+
+[[work_item]]
+id = "contract-convergence-plan"
+status = "active"
+proposal = "docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md"
+spec = ""
+adr = ""
+plan = "plans/0.9.0/implementation-plan.md"
+prs = []
+commands = [
+  "git diff --check",
+  "python -c \"import tomllib; tomllib.load(open('.adze/goals/active.toml', 'rb'))\"",
+]
+
+[[work_item]]
+id = "package-boundary-audit"
+status = "ready"
+proposal = "docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md"
+spec = "docs/specs/ADZE-SPEC-0001-package-surface-boundary.md"
+adr = "ADZE-ADR-0002-no-durable-unpublished-production-crates"
+plan = "plans/0.9.0/implementation-plan.md"
+prs = []
+commands = [
+  "cargo metadata --format-version 1 --no-deps",
+  "cargo run -q -p xtask -- check-package-boundary",
+  "just ci-supported",
+]
+
+[[work_item]]
+id = "ci-economics-verifier"
+status = "ready"
+proposal = "docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md"
+spec = "docs/specs/ADZE-SPEC-0002-ci-economics.md"
+adr = ""
+plan = "plans/0.9.0/implementation-plan.md"
+prs = []
+commands = [
+  "cargo run -q -p xtask -- check-ci-lane-whitelist",
+  "cargo run -q -p xtask -- ci plan",
+  "just ci-supported",
+]
+
+[[work_item]]
+id = "microcrate-collapse"
+status = "blocked"
+proposal = "docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md"
+spec = "docs/specs/ADZE-SPEC-0001-package-surface-boundary.md"
+adr = "ADZE-ADR-0002-no-durable-unpublished-production-crates"
+plan = "plans/0.9.0/implementation-plan.md"
+blocked_by = ["package-boundary-audit"]
+prs = []
+commands = [
+  "cargo metadata --format-version 1 --no-deps",
+  "cargo run -q -p xtask -- check-package-boundary",
+  "just check-msrv",
+  "just ci-supported",
+]
+
+[[work_item]]
+id = "rust-1.95-msrv-bump"
+status = "blocked"
+proposal = "docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md"
+spec = ""
+adr = ""
+plan = "plans/0.9.0/implementation-plan.md"
+blocked_by = ["microcrate-collapse"]
+prs = []
+commands = [
+  "just check-msrv",
+  "just ci-supported",
+]
+
+[[work_item]]
+id = "clippy-policy-refresh"
+status = "blocked"
+proposal = "docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md"
+spec = ""
+adr = ""
+plan = "plans/0.9.0/implementation-plan.md"
+blocked_by = ["rust-1.95-msrv-bump"]
+prs = []
+commands = [
+  "cargo run -q -p xtask -- check-lint-policy",
+  "just clippy",
+  "just ci-supported",
+]
+
+[[work_item]]
+id = "product-proof-refresh"
+status = "blocked"
+proposal = "docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md"
+spec = "ADZE-SPEC-0004-product-proof-and-support-tiers"
+adr = ""
+plan = "plans/0.9.0/implementation-plan.md"
+blocked_by = ["clippy-policy-refresh", "ci-economics-verifier"]
+prs = []
+commands = [
+  "just ci-supported",
+  "cargo test -p adze --features pure-rust --test typed_ast_contract -- --nocapture",
+  "cargo test -p adze-cli readme_arithmetic_quickstart_builds_and_runs -- --exact --nocapture",
+]

--- a/docs/adr/ADZE-ADR-0001-adze-document-one-parse-truth.md
+++ b/docs/adr/ADZE-ADR-0001-adze-document-one-parse-truth.md
@@ -1,0 +1,167 @@
+# ADZE-ADR-0001: AdzeDocument is one parse truth
+
+Status: proposed
+Date: 2026-05-12
+Owner: Adze maintainers
+Linked proposal: ../proposals/ADZE-PROP-0001-0.9-contract-convergence.md
+Linked specs: ../specs/ADZE-SPEC-0003-canonical-parse-document.md
+
+## Decision
+
+`AdzeDocument` is the canonical native parse product for Adze.
+
+Generic CST, typed CST, typed AST extraction, Tree-sitter-compatible projection,
+diagnostics, parse metadata, and GLR ambiguity summaries must project from the
+same document rather than from parallel parse products.
+
+The native document is monomorphic:
+
+```rust
+pub struct AdzeDocument {
+    source: SourceText,
+    tree: AdzeTree,
+    diagnostics: Vec<ParseDiagnostic>,
+    ambiguities: AmbiguitySet,
+    metadata: ParseMetadata,
+}
+```
+
+Typed ASTs and typed CSTs are views or extractions:
+
+```rust
+let doc = grammar::parse_document(source)?;
+
+let tree = doc.tree();
+let syntax: syntax::SourceFile = doc.syntax()?;
+let ast: ast::Module = doc.ast()?;
+let ts_tree = doc.as_tree_sitter();
+```
+
+They are not fields that make `AdzeDocument` generic over one AST type.
+
+## Context
+
+Adze needs two public stories to share one parse truth:
+
+- Tree-sitter-compatible output for adoption, editor tooling, S-expressions,
+  field lookup, node metadata, and familiar CST inspection.
+- Adze-native output for Rust typed ASTs, typed CST, structured diagnostics,
+  parse provenance, and GLR ambiguity insight.
+
+If each surface builds its own tree or error model, the repo will accumulate
+semantic drift. A field label could work in Tree-sitter compatibility but be
+missing from typed CST. A diagnostic could exist in parse errors but not in the
+native tree. A GLR ambiguity could be known by runtime internals but invisible
+to the document API.
+
+The current design documents already point to the desired shape:
+
+- `../design/adze-document.md` defines `AdzeDocument` as the planned native
+  parse-product boundary and source of truth for multiple views.
+- `../design/typed-cst.md` defines typed CST as a generated view over
+  `AdzeDocument`, not a separate tree.
+- `../status/SUPPORT_TIERS.md` keeps `AdzeDocument` and typed CST experimental
+  until proof commands and promotion criteria support stronger claims.
+
+This ADR records the durable architecture rule so future compatibility,
+serialization, WASM, CLI, and GLR work do not create independent parse truths.
+
+## Consequences
+
+### Enabled
+
+- Tree-sitter compatibility becomes a projection and regression harness over
+  native document facts.
+- Typed CST wrappers can resolve fields through native `AdzeEdge` metadata.
+- Typed AST extraction can record provenance against document node IDs, spans,
+  or synthetic recovery facts.
+- Structured diagnostics can attach to document nodes and ranges.
+- GLR ambiguity summaries can explain the selected tree without forcing forest
+  internals into the Tree-sitter-compatible API.
+- CLI and WASM outputs can serialize the same facts through different schemas.
+
+### Constrained
+
+- `ts_compat` must not be the only place where field IDs, node identity, error
+  state, or alias-visible behavior exists.
+- Typed CST must not own copied syntax data or a second tree.
+- Typed AST extraction must not silently discard provenance when the document has
+  enough information to describe it.
+- GLR forest internals should not be exposed through Tree-sitter compatibility;
+  compatibility sees the selected tree, while native APIs expose ambiguity
+  summaries and later forest data.
+- Serialized output schemas must identify which projection of `AdzeDocument`
+  they represent.
+
+### Costs
+
+- The native document model must carry enough metadata for all projections,
+  including fields on edges, node identity, ranges, flags, diagnostics, and
+  ambiguity summaries.
+- Some projections should be lazy so common parsing paths do not pay for typed
+  AST extraction, JSON serialization, or full forest export unless requested.
+- Compatibility adapter code may need refactoring when a feature currently lives
+  only in `ts_compat`.
+
+## Alternatives Considered
+
+### Tree-sitter-compatible tree as the core
+
+Adze could make the Tree-sitter-shaped `Tree` and `Node` API the central runtime
+model.
+
+Rejected because Tree-sitter compatibility is an upstream conformance target,
+not Adze's full native product. It should expose the selected compatible tree,
+but it should not own typed ASTs, diagnostics, GLR ambiguity, or provenance.
+
+### Generic `AdzeDocument<TAst>`
+
+Adze could store one typed AST inside the document:
+
+```rust
+pub struct AdzeDocument<TAst = ()> {
+    tree: AdzeTree,
+    typed_ast: Option<TAst>,
+    diagnostics: Vec<ParseDiagnostic>,
+    ambiguities: AmbiguitySet,
+    metadata: ParseMetadata,
+}
+```
+
+Rejected because it ties a canonical document to one AST projection, complicates
+serialization and WASM, and makes multiple semantic views over one CST harder.
+The document should be monomorphic; ASTs should be extracted from it.
+
+### Separate parse products per output
+
+Adze could generate separate structures for generic CST, typed CST, typed AST,
+Tree-sitter compatibility, diagnostics, and GLR output.
+
+Rejected because separate parse products invite drift and make tests less
+meaningful. A passing S-expression test would not prove the native document has
+the same field metadata unless both use the same source of truth.
+
+### Raw GLR forest as the first native API
+
+Adze could expose the full forest before defining document-level ambiguity
+summaries.
+
+Rejected for the first stable native shape. Raw forest internals are useful for
+advanced tooling, but the first product API should answer user-facing questions:
+where ambiguity occurred, which alternatives existed, which tree was selected,
+and why.
+
+## Follow-Up Specs / Plans
+
+This ADR requires follow-up behavior specs for:
+
+- `ADZE-SPEC-0003-canonical-parse-document.md`;
+- typed CST wrapper generation over document node IDs and field edges;
+- typed AST provenance;
+- structured diagnostics and node/range attachment;
+- GLR ambiguity summaries and selection reasons;
+- Tree-sitter compatibility projection over document facts;
+- JSON schema versioning for native and compatibility outputs.
+
+Implementation plans should sequence these as PR-sized changes and keep support
+tier promotion tied to `../status/SUPPORT_TIERS.md`.

--- a/docs/specs/ADZE-SPEC-0001-package-surface-boundary.md
+++ b/docs/specs/ADZE-SPEC-0001-package-surface-boundary.md
@@ -1,0 +1,185 @@
+# ADZE-SPEC-0001: Package surface boundary
+
+Status: proposed
+Owner: Adze maintainers
+Created: 2026-05-12
+Linked proposal: ../proposals/ADZE-PROP-0001-0.9-contract-convergence.md
+Linked ADRs: ADZE-ADR-0002 no durable unpublished production crates
+Linked plan: ../../plans/0.9.0/microcrate-collapse.md
+Linked issues:
+Linked PRs:
+
+## Problem
+
+The Adze workspace has grown beyond the stable product surface. Some packages
+are published user-facing crates, some are test or governance support, and some
+are temporary seams created while parser, policy, CI, and product-proof work was
+being split into small changes.
+
+That distinction is useful only if it is explicit. A workspace package that is
+neither publishable nor clearly dev-only becomes a hidden production surface:
+it affects CI cost, MSRV and lint migration effort, release confidence, and
+maintainer reasoning, but it has no stable user contract.
+
+Adze needs a package-boundary contract before 0.9 work changes MSRV, lint
+policy, CI routing, or public support claims.
+
+## Behavior
+
+Every workspace package must be classified as exactly one of these categories:
+
+| Category | Meaning | Allowed durability |
+| --- | --- | --- |
+| Published crate | A public package intended for crates.io or an equivalent stable user surface. | Durable when support-tier and release metadata agree. |
+| Dev-only crate | A package used only for tests, examples, benchmarks, fixtures, xtask support, or internal repo automation. | Durable only while it has a current dev/test/tooling owner and is excluded from production claims. |
+| Owner-module migration target | A temporary package scheduled to move into the public crate, dev-only crate, or xtask module that owns it. | Temporary; must name its target owner and removal condition. |
+
+There is no durable unpublished production crate category.
+
+If a package is used by production code but is not intended to be published as a
+public surface, it must either become an owner-module migration target or be
+reclassified with an explicit ADR and support-tier impact.
+
+## Required Package Metadata
+
+The package-boundary ledger must record enough data for automation and review:
+
+- package name;
+- package path;
+- category;
+- owner surface or owning module;
+- publish intent;
+- support-tier impact;
+- CI lane or risk-pack impact;
+- migration target when category is owner-module migration target;
+- removal or promotion condition;
+- date and PR that last changed the classification.
+
+The future ledger location is expected to be `../../policy/package-boundary.toml`.
+Until that file exists, this spec is the behavior contract and implementation
+plans must not invent conflicting category names.
+
+## Non-Goals
+
+This spec does not:
+
+- move, merge, publish, or delete any package;
+- decide which current packages belong in each category;
+- change Cargo metadata by itself;
+- change branch protection or CI routing by itself;
+- define support-tier promotion rules beyond requiring links to
+  `../status/SUPPORT_TIERS.md`;
+- require every dev-only crate to be collapsed immediately.
+
+## Required Evidence
+
+A package-boundary implementation must provide:
+
+- a machine-readable package-boundary ledger;
+- a verifier that checks every workspace package has exactly one category;
+- a verifier failure when a package is production-used, unpublished, and not a
+  migration target;
+- a verifier failure when an owner-module migration target has no owner or no
+  exit condition;
+- a docs update for any change that alters stable product claims;
+- a CI or local proof command that can be run before package-collapse PRs land.
+
+## Acceptance Examples
+
+### Published crate
+
+`adze` is a published crate because it is a user-facing runtime package and has
+stable product claims in `../status/SUPPORT_TIERS.md`.
+
+A published crate must have release metadata, support-tier mapping for stable
+claims, and a supported proof path.
+
+### Dev-only crate
+
+A benchmark, fixture, or repo-policy helper package can be dev-only when it is
+not part of the advertised runtime or generated-parser API and exists to support
+tests, measurement, examples, or automation.
+
+A dev-only crate must not be cited as a stable production surface unless it is
+reclassified.
+
+### Owner-module migration target
+
+A single-use helper crate consumed by one public crate can be a migration target
+when its desired end state is an internal module under that owner.
+
+The classification must name the target owner and the condition that closes the
+migration.
+
+### Invalid durable category
+
+A package cannot remain indefinitely classified as:
+
+```text
+unpublished production crate
+```
+
+That state hides a production dependency from release, support-tier, and CI
+economics decisions. It must be converted to a published crate, dev-only crate,
+or owner-module migration target.
+
+## Test Mapping
+
+The package-boundary verifier should include tests for:
+
+- every workspace member appears in the ledger;
+- unknown package names fail validation;
+- duplicate package entries fail validation;
+- each package has exactly one category;
+- published packages have publish intent and release metadata checks;
+- dev-only packages cannot be marked as stable product proof surfaces;
+- migration targets have owner and exit-condition fields;
+- production-used unpublished packages fail unless they are migration targets;
+- policy changes produce stable diagnostics that identify the package and field.
+
+These tests may live in xtask or a dedicated policy-check crate, but the command
+must be documented in the implementation plan.
+
+## Implementation Mapping
+
+Expected implementation surfaces:
+
+- `policy/package-boundary.toml` for package classification;
+- an xtask verifier such as `cargo run -q -p xtask -- check-package-boundary`;
+- `Cargo.toml` workspace metadata only when a later implementation PR changes
+  package membership or release metadata;
+- `docs/status/SUPPORT_TIERS.md` when stable product claims change;
+- `policy/ci-lane-whitelist.toml` and `policy/ci-risk-packs.toml` when package
+  classification changes CI routing.
+
+Specs and proposals must link to those ledgers instead of duplicating their
+contents.
+
+## CI Proof
+
+The intended proof sequence for package-boundary changes is:
+
+```bash
+cargo metadata --format-version 1 --no-deps
+cargo run -q -p xtask -- check-package-boundary
+just ci-supported
+```
+
+Implementation PRs may add narrower tests for the verifier. Package-collapse PRs
+must run the verifier and the supported gate after any workspace membership or
+Cargo metadata change.
+
+## Metrics / Promotion Rule
+
+This spec is satisfied for 0.9 when:
+
+- every workspace member is classified in the package-boundary ledger;
+- the verifier is part of the documented 0.9 proof sequence;
+- no package is classified as a durable unpublished production crate;
+- every migration target has an owner and exit condition;
+- support-tier and CI policy docs are updated when package classification
+  changes stable claims or CI routing.
+
+The package-boundary policy can be promoted from proposal-level guidance to an
+accepted repo contract after the ledger and verifier have both landed and
+`just ci-supported` is green with the verifier in the 0.9 proof sequence.

--- a/docs/specs/ADZE-SPEC-0002-ci-economics.md
+++ b/docs/specs/ADZE-SPEC-0002-ci-economics.md
@@ -1,0 +1,192 @@
+# ADZE-SPEC-0002: CI economics
+
+Status: proposed
+Owner: Adze maintainers
+Created: 2026-05-12
+Linked proposal: ../proposals/ADZE-PROP-0001-0.9-contract-convergence.md
+Linked ADRs:
+Linked plan: ../../plans/0.9.0/ci-economics-v2.md
+Linked issues:
+Linked PRs:
+
+## Problem
+
+Adze needs more verification than a broad default PR matrix can economically
+provide. Parser correctness, GLR routing, tablegen ABI, typed extraction,
+diagnostics, Tree-sitter compatibility, WASM, golden parity, benchmarks, and
+release policy all matter, but not every PR should pay for every lane.
+
+The current CI policy already defines LEM, risk routing, advisory lanes, and
+branch-protection promotion criteria. This spec turns that policy into a
+behavior contract for 0.9 work: every CI lane must have an owner, cost model,
+trigger rule, support-tier purpose, and rollback path.
+
+## Behavior
+
+CI economics must preserve product proof while routing expensive checks by risk.
+
+Adze CI lanes must be classified into these verification tiers:
+
+| Tier | Purpose | Default behavior |
+| --- | --- | --- |
+| Frontdoor | Required proof for supported product claims and policy consistency. | Runs on every PR and blocks merge. |
+| Advisory | Cheap or useful signal that should inform review but not block ordinary PRs. | Runs when economical; non-blocking. |
+| Risk-routed | Deep checks selected by path, label, or declared risk pack. | Runs only when the change touches the matching surface or is explicitly requested. |
+| Deep | Expensive validation for broad confidence. | Runs on `main`, scheduled workflows, release prep, or explicit labels. |
+| Release | Publication and release-readiness proof. | Runs for tags, release branches, or manual release operations. |
+
+The CI lane whitelist and risk-pack ledger own the concrete lane inventory:
+
+- `../../policy/ci-lane-whitelist.toml`
+- `../../policy/ci-risk-packs.toml`
+
+This spec owns the behavior rules. It must not duplicate the full whitelist.
+
+## LEM Bands
+
+CI cost should be expressed in LEM as defined by
+`../ci/cost-and-verification-policy.md`.
+
+The current behavioral bands are:
+
+| Band | LEM | Required behavior |
+| --- | ---: | --- |
+| Ordinary | 0-35 | Preferred default for normal PRs. |
+| Elevated | 36-75 | Warning with explicit risk surface. |
+| High | 76-125 | High warning with explicit label or acknowledgement. |
+| Over ceiling | >125 | Fails unless `full-ci` or `ci-budget-override` is present. |
+
+Learned estimates belong in `../ci/learned-estimates.md` and policy ledgers,
+not in this spec. This spec requires the estimates to be traceable and
+reviewable.
+
+## Required Lane Metadata
+
+Every CI lane in the whitelist must record:
+
+- workflow and job name;
+- tier;
+- owner surface;
+- trigger rule;
+- blocking status;
+- estimated LEM or cost band;
+- support-tier purpose;
+- risk packs or labels that activate the lane;
+- rollback path;
+- policy exception, if any.
+
+Any workflow job that is not in the whitelist must either be added to the
+ledger, explicitly exempted, or removed.
+
+## Non-Goals
+
+This spec does not:
+
+- weaken `just ci-supported` or the hosted `CI / ci-supported` gate;
+- make `ripr` or broad advisory lanes blocking;
+- promote learned LEM budgets before enough actuals exist;
+- change branch protection by itself;
+- remove broad validation from `main`, nightly, label-triggered, or release
+  paths;
+- duplicate the CI lane whitelist, risk-pack ledger, or learned estimates.
+
+## Required Evidence
+
+A CI-economics implementation must provide:
+
+- a machine-readable lane whitelist;
+- a verifier that detects unregistered workflow jobs;
+- explicit routing for risk-routed lanes;
+- LEM estimates or learned actuals for ordinary PR planning;
+- a branch-protection plan before required checks change;
+- PR evidence that names workflows touched, default PR effect, rollback path,
+  proof obligation, and branch-protection impact.
+
+## Acceptance Examples
+
+### Frontdoor lane
+
+`CI / ci-supported` is frontdoor proof because it represents the supported core
+pipeline. A PR that changes supported runtime, tablegen, macro, tool, common,
+IR, or GLR core behavior must keep this gate green.
+
+### Advisory lane
+
+An advisory static-analysis or review lane may run on every PR when cheap, but
+its result is not a substitute for supported product proof and should not block
+ordinary docs or low-risk changes unless explicitly promoted.
+
+### Risk-routed lane
+
+Golden Tree-sitter parity, fuzz build, benchmark compile, and broad grammar
+matrix jobs should run when a matching path, risk pack, or label requests them.
+They should not be the default cost paid by unrelated docs or policy PRs.
+
+### Over-ceiling PR
+
+A PR plan that estimates more than 125 LEM must fail or require an explicit
+override label. The override is a review signal, not a silent escape hatch.
+
+## Test Mapping
+
+The CI-economics verifier should include tests for:
+
+- every workflow job is present in the lane whitelist or an explicit exception;
+- each lane has exactly one tier;
+- blocking lanes are a subset of frontdoor or explicitly promoted release gates;
+- risk-routed lanes name a risk pack, path trigger, label trigger, or manual
+  trigger;
+- LEM bands are parsed and compared consistently;
+- over-ceiling PR plans fail without override;
+- docs-only PRs do not route parser-heavy risk packs by default;
+- branch-protection promotion requires a documented stability window.
+
+These tests may live in xtask, policy-check crates, or workflow-specific test
+fixtures, but the implementation plan must name the command that runs them.
+
+## Implementation Mapping
+
+Expected implementation surfaces:
+
+- `../../policy/ci-lane-whitelist.toml` for lane inventory;
+- `../../policy/ci-risk-packs.toml` for risk routing;
+- `../ci/cost-and-verification-policy.md` for CI doctrine;
+- `../ci/adze-rollout-plan.md` for per-PR rollout history;
+- `../ci/branch-protection.md` for required-check promotion;
+- `../ci/learned-estimates.md` for actuals-based estimate updates;
+- an xtask verifier such as `cargo run -q -p xtask -- check-ci-lane-whitelist`;
+- PR Plan or equivalent output for LEM estimates and risk routing.
+
+Specs should link to these files instead of copying their tables.
+
+## CI Proof
+
+The intended proof sequence for CI-economics changes is:
+
+```bash
+cargo run -q -p xtask -- check-ci-lane-whitelist
+cargo run -q -p xtask -- ci plan
+just ci-supported
+```
+
+If a PR changes branch protection, it must also include the branch-protection
+promotion evidence required by `../ci/branch-protection.md`.
+
+If a PR changes package boundaries, it must also run the package-boundary proof
+from `ADZE-SPEC-0001-package-surface-boundary.md`.
+
+## Metrics / Promotion Rule
+
+The CI-economics contract is satisfied for 0.9 when:
+
+- every workflow job is whitelisted or explicitly exempted;
+- ordinary PRs have a visible LEM estimate;
+- elevated and high-cost PRs produce explicit warnings;
+- over-ceiling PRs require an override;
+- risk-routed lanes have path, label, or manual triggers;
+- frontdoor product proof remains green and required;
+- branch-protection changes happen only after documented stability windows.
+
+This spec can move from proposed to accepted after the whitelist verifier,
+risk-pack routing, PR-cost signal, and branch-protection policy all have
+passing proof commands and current documentation.

--- a/plans/0.9.0/implementation-plan.md
+++ b/plans/0.9.0/implementation-plan.md
@@ -1,0 +1,530 @@
+# Adze 0.9.0 Contract Convergence Implementation Plan
+
+Status: proposed
+Owner: Adze maintainers
+Created: 2026-05-12
+Linked proposal: ../../docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md
+Linked specs:
+- ../../docs/specs/ADZE-SPEC-0001-package-surface-boundary.md
+- ../../docs/specs/ADZE-SPEC-0002-ci-economics.md
+Linked ADRs:
+- ../../docs/adr/ADZE-ADR-0001-adze-document-one-parse-truth.md
+Active goal: ../../.adze/goals/active.toml
+Support-tier map: ../../docs/status/SUPPORT_TIERS.md
+
+## Campaign Goal
+
+Make 0.9.0 a contract-convergence release: reduce hidden workspace surface,
+keep the supported core proof green, recalibrate CI economics, and promote only
+the product claims that have support-tier evidence.
+
+This plan sequences the work. It does not own the behavior contracts or policy
+ledgers; those live in linked specs and `../../policy/*.toml`.
+
+## Current Batch
+
+The first docs batch establishes the source-of-truth model before product or
+policy changes. The scaffold and proposal landed first; the remaining contract
+docs are intentionally consolidated into one follow-up to avoid paying a full CI
+and review cycle for each single-document branch.
+
+| PR | Work item | Artifact |
+| --- | --- | --- |
+| #681 | source-of-truth-scaffolding | README files for proposals, specs, ADRs, 0.9 plans, and active goals |
+| #691 | contract-convergence-proposal | `ADZE-PROP-0001` |
+| pending | economics-docs-consolidation | `ADZE-SPEC-0001`, `ADZE-SPEC-0002`, `ADZE-ADR-0001`, implementation plan, active goal manifest |
+
+Superseded stacked PRs should be closed once the consolidated follow-up is open.
+
+## Work Item: source-of-truth-scaffolding
+
+Status: complete
+Linked proposal:
+Linked spec:
+Linked ADR:
+Blocks: contract-convergence-proposal; package-boundary-spec; ci-economics-spec; adze-document-adr; contract-convergence-plan
+Blocked by: none
+
+### Goal
+
+Define where proposals, specs, ADRs, implementation plans, and active goal
+manifests live.
+
+### Production Delta
+
+Add README scaffolding under:
+
+- `../../docs/proposals/`
+- `../../docs/specs/`
+- `../../docs/adr/`
+- `../../plans/0.9.0/`
+- `../../.adze/goals/`
+
+### Non-Goals
+
+No behavior specs, policy ledgers, parser/runtime changes, or package moves.
+
+### Acceptance
+
+Each documentation layer states what it owns and what it must not duplicate.
+
+### Proof Commands
+
+```bash
+git diff --check
+```
+
+### Rollback
+
+Revert the scaffold PR.
+
+## Work Item: contract-convergence-proposal
+
+Status: complete
+Linked proposal: ../../docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md
+Linked spec:
+Linked ADR:
+Blocks: package-boundary-spec; ci-economics-spec; contract-convergence-plan
+Blocked by: none
+
+### Goal
+
+Record why 0.9.0 is a contract-convergence milestone rather than a broad
+feature-expansion milestone.
+
+### Production Delta
+
+Add `ADZE-PROP-0001`.
+
+### Non-Goals
+
+No package policy, CI implementation, parser/runtime changes, or support-tier
+promotion.
+
+### Acceptance
+
+The proposal names the problem, users, success criteria, alternatives, evidence
+plan, risks, non-goals, and exit criteria.
+
+### Proof Commands
+
+```bash
+git diff --check
+```
+
+### Rollback
+
+Revert the proposal PR.
+
+## Work Item: package-boundary-spec
+
+Status: active
+Linked proposal: ../../docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md
+Linked spec: ../../docs/specs/ADZE-SPEC-0001-package-surface-boundary.md
+Linked ADR: ADZE-ADR-0002 no durable unpublished production crates
+Blocks: package-boundary-audit; microcrate-collapse
+Blocked by: none
+
+### Goal
+
+Define the package categories and evidence required before collapsing or
+reclassifying workspace packages.
+
+### Production Delta
+
+Add `ADZE-SPEC-0001`.
+
+### Non-Goals
+
+No package moves, verifier implementation, or policy TOML changes.
+
+### Acceptance
+
+The spec states that every workspace package must be a published crate,
+dev-only crate, or owner-module migration target, and that there is no durable
+unpublished production crate category.
+
+### Proof Commands
+
+```bash
+git diff --check
+```
+
+### Rollback
+
+Revert the spec PR.
+
+## Work Item: ci-economics-spec
+
+Status: active
+Linked proposal: ../../docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md
+Linked spec: ../../docs/specs/ADZE-SPEC-0002-ci-economics.md
+Linked ADR:
+Blocks: ci-economics-verifier; ci-lem-refresh
+Blocked by: none
+
+### Goal
+
+Define CI lane tiers, LEM bands, required lane metadata, evidence, and promotion
+rules without copying the whitelist or risk-pack ledgers.
+
+### Production Delta
+
+Add `ADZE-SPEC-0002`.
+
+### Non-Goals
+
+No workflow, branch-protection, or policy TOML changes.
+
+### Acceptance
+
+The spec links to `../../policy/ci-lane-whitelist.toml`,
+`../../policy/ci-risk-packs.toml`, and the existing CI policy docs as sources of
+truth for concrete lane data.
+
+### Proof Commands
+
+```bash
+git diff --check
+```
+
+### Rollback
+
+Revert the spec PR.
+
+## Work Item: adze-document-adr
+
+Status: active
+Linked proposal: ../../docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md
+Linked spec: ADZE-SPEC-0003 canonical parse document
+Linked ADR: ../../docs/adr/ADZE-ADR-0001-adze-document-one-parse-truth.md
+Blocks: canonical-parse-document-spec; typed-cst-plan; ts-compat-over-document-plan
+Blocked by: none
+
+### Goal
+
+Record the durable architecture decision that `AdzeDocument` is one parse truth
+with multiple projections.
+
+### Production Delta
+
+Add `ADZE-ADR-0001`.
+
+### Non-Goals
+
+No API stabilization, parser/runtime changes, or support-tier promotion.
+
+### Acceptance
+
+The ADR rejects Tree-sitter-as-core, generic `AdzeDocument<TAst>`, independent
+parse products per output, and raw-forest-first native API design.
+
+### Proof Commands
+
+```bash
+git diff --check
+```
+
+### Rollback
+
+Revert the ADR PR.
+
+## Work Item: contract-convergence-plan
+
+Status: active
+Linked proposal: ../../docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md
+Linked spec:
+Linked ADR:
+Blocks: package-boundary-audit; ci-economics-verifier; microcrate-collapse
+Blocked by: none
+
+### Goal
+
+Add this implementation plan and the active goal manifest so agents can follow
+the campaign without scraping long prose.
+
+### Production Delta
+
+Add:
+
+- `implementation-plan.md`
+- `../../.adze/goals/active.toml`
+
+### Non-Goals
+
+No policy verifier, package move, runtime change, or support-tier promotion.
+
+### Acceptance
+
+The plan lists PR-sized work items with linked artifacts, non-goals, acceptance
+criteria, proof commands, and rollback notes. The active goal manifest exposes
+the same campaign state in machine-readable form.
+
+### Proof Commands
+
+```bash
+git diff --check
+python -c "import tomllib; tomllib.load(open('.adze/goals/active.toml', 'rb'))"
+```
+
+### Rollback
+
+Revert the plan/manifest PR.
+
+## Work Item: package-boundary-audit
+
+Status: ready
+Linked proposal: ../../docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md
+Linked spec: ../../docs/specs/ADZE-SPEC-0001-package-surface-boundary.md
+Linked ADR: ADZE-ADR-0002 no durable unpublished production crates
+Blocks: microcrate-collapse; rust-1.95-msrv-bump; clippy-policy-refresh
+Blocked by: package-boundary-spec; contract-convergence-plan
+
+### Goal
+
+Classify every workspace package and add verifier coverage for the package
+surface boundary.
+
+### Production Delta
+
+Expected later changes:
+
+- `../../policy/package-boundary.toml`
+- package-boundary verifier command
+- verifier tests
+- support-tier or CI policy updates if the classification affects claims or
+  routing
+
+### Non-Goals
+
+No package moves in the audit PR. Classification comes before collapse.
+
+### Acceptance
+
+Every workspace package is classified as a published crate, dev-only crate, or
+owner-module migration target. No package is classified as durable unpublished
+production code.
+
+### Proof Commands
+
+```bash
+cargo metadata --format-version 1 --no-deps
+cargo run -q -p xtask -- check-package-boundary
+just ci-supported
+```
+
+### Rollback
+
+Revert the verifier and ledger PR. Later package-collapse PRs must not proceed
+without a replacement classification source of truth.
+
+## Work Item: ci-economics-verifier
+
+Status: ready
+Linked proposal: ../../docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md
+Linked spec: ../../docs/specs/ADZE-SPEC-0002-ci-economics.md
+Linked ADR:
+Blocks: ci-lem-refresh; microcrate-collapse-ci-routing
+Blocked by: ci-economics-spec; contract-convergence-plan
+
+### Goal
+
+Ensure workflow jobs, lane tiers, risk packs, and LEM behavior are represented
+in policy ledgers and checked by automation.
+
+### Production Delta
+
+Expected later changes:
+
+- `../../policy/ci-lane-whitelist.toml`
+- `../../policy/ci-risk-packs.toml`
+- CI whitelist verifier updates
+- PR Plan or equivalent LEM output updates
+
+### Non-Goals
+
+No branch-protection promotion and no learned-estimate enforcement before the
+required actuals window exists.
+
+### Acceptance
+
+Every workflow job is whitelisted or exempted, ordinary PRs show visible LEM
+estimates, and over-ceiling PRs require an explicit override.
+
+### Proof Commands
+
+```bash
+cargo run -q -p xtask -- check-ci-lane-whitelist
+cargo run -q -p xtask -- ci plan
+just ci-supported
+```
+
+### Rollback
+
+Revert verifier or policy changes; broad lanes return to their previous routing
+until a replacement policy lands.
+
+## Work Item: microcrate-collapse
+
+Status: blocked
+Linked proposal: ../../docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md
+Linked spec: ../../docs/specs/ADZE-SPEC-0001-package-surface-boundary.md
+Linked ADR: ADZE-ADR-0002 no durable unpublished production crates
+Blocks: rust-1.95-msrv-bump; clippy-policy-refresh; ci-lem-refresh
+Blocked by: package-boundary-audit
+
+### Goal
+
+Move or remove temporary owner-module migration targets in owner-sized batches.
+
+### Production Delta
+
+Later PRs may change workspace membership, module ownership, crate imports,
+policy ledgers, CI routing, and docs that name package boundaries.
+
+### Non-Goals
+
+No opportunistic parser behavior changes or support-tier promotion.
+
+### Acceptance
+
+Each package-collapse PR removes a documented migration target or reclassifies
+it with a new accepted contract. The supported gate remains green.
+
+### Proof Commands
+
+```bash
+cargo metadata --format-version 1 --no-deps
+cargo run -q -p xtask -- check-package-boundary
+just check-msrv
+just ci-supported
+```
+
+### Rollback
+
+Revert the owner-sized package-collapse PR and restore the prior policy ledger
+entry.
+
+## Work Item: rust-1.95-msrv-bump
+
+Status: blocked
+Linked proposal: ../../docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md
+Linked spec:
+Linked ADR:
+Blocks: clippy-policy-refresh
+Blocked by: microcrate-collapse
+
+### Goal
+
+Bump workspace MSRV/toolchain policy after the package graph is smaller.
+
+### Production Delta
+
+Expected later changes include toolchain files, manifest `rust-version` fields,
+CI setup, docs, and any xtask doctor or policy checks that enforce MSRV.
+
+### Non-Goals
+
+No lint promotion or package collapse in the same PR.
+
+### Acceptance
+
+All MSRV declarations agree and the supported gate is green.
+
+### Proof Commands
+
+```bash
+just check-msrv
+just ci-supported
+```
+
+### Rollback
+
+Revert the MSRV bump PR.
+
+## Work Item: clippy-policy-refresh
+
+Status: blocked
+Linked proposal: ../../docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md
+Linked spec:
+Linked ADR:
+Blocks: product-proof-refresh
+Blocked by: rust-1.95-msrv-bump
+
+### Goal
+
+Promote planned lint policy only after package collapse and MSRV bump reduce
+workspace churn.
+
+### Production Delta
+
+Expected later changes:
+
+- `../../policy/clippy-lints.toml`
+- lint verifier updates
+- targeted code fixes where required
+
+### Non-Goals
+
+No broad refactors hidden behind lint updates.
+
+### Acceptance
+
+Lint policy checks pass and any new `#[expect]` usage is justified by policy
+rather than used to avoid straightforward cleanup.
+
+### Proof Commands
+
+```bash
+cargo run -q -p xtask -- check-lint-policy
+just clippy
+just ci-supported
+```
+
+### Rollback
+
+Revert the lint policy PR and any mechanical fixes tied only to that promotion.
+
+## Work Item: product-proof-refresh
+
+Status: blocked
+Linked proposal: ../../docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md
+Linked spec: ADZE-SPEC-0004 product proof and support tiers
+Linked ADR:
+Blocks: 0.9-closeout
+Blocked by: clippy-policy-refresh; ci-economics-verifier
+
+### Goal
+
+Refresh stable README claims, support-tier mapping, and product-proof canaries
+after package and CI policy changes land.
+
+### Production Delta
+
+Expected later changes:
+
+- `../../docs/status/SUPPORT_TIERS.md`
+- README or tutorial claim wording if needed
+- exact product-proof canaries for promoted surfaces
+
+### Non-Goals
+
+No promotion of runtime2, WASM, Tree-sitter compatibility, CLI output, or broad
+grammar support without receipts.
+
+### Acceptance
+
+Every stable README claim maps to a support-tier row and repeatable proof
+command.
+
+### Proof Commands
+
+```bash
+just ci-supported
+cargo test -p adze --features pure-rust --test typed_ast_contract -- --nocapture
+cargo test -p adze-cli readme_arithmetic_quickstart_builds_and_runs -- --exact --nocapture
+```
+
+### Rollback
+
+Revert claim wording or support-tier promotion until the missing proof lands.


### PR DESCRIPTION
## Summary
- consolidates the remaining 0.9 economics/spec docs into one follow-up after #681 and #691 landed
- adds package-boundary and CI-economics specs, the AdzeDocument parse-truth ADR, the 0.9 implementation plan, and the active goal manifest
- updates the plan/manifest to mark #681 and #691 complete and avoid keeping the superseded stacked PRs alive

## Replaces
- supersedes #683, #684, #685, and #686

## Validation
- `git diff --check`
- `git diff --cached --check`
- `python -c "import tomllib; tomllib.load(open('.adze/goals/active.toml', 'rb'))"`