### PR TITLE
plans(0.9): mark economics docs complete

### DIFF
--- a/.adze/goals/active.toml
+++ b/.adze/goals/active.toml
@@ -47,48 +47,48 @@ commands = [
 
 [[work_item]]
 id = "package-boundary-spec"
-status = "active"
+status = "complete"
 proposal = "docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md"
 spec = "docs/specs/ADZE-SPEC-0001-package-surface-boundary.md"
 adr = "ADZE-ADR-0002-no-durable-unpublished-production-crates"
 plan = "plans/0.9.0/implementation-plan.md"
-prs = []
+prs = [692]
 commands = [
   "git diff --check",
 ]
 
 [[work_item]]
 id = "ci-economics-spec"
-status = "active"
+status = "complete"
 proposal = "docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md"
 spec = "docs/specs/ADZE-SPEC-0002-ci-economics.md"
 adr = ""
 plan = "plans/0.9.0/implementation-plan.md"
-prs = []
+prs = [692]
 commands = [
   "git diff --check",
 ]
 
 [[work_item]]
 id = "adze-document-adr"
-status = "active"
+status = "complete"
 proposal = "docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md"
 spec = "ADZE-SPEC-0003-canonical-parse-document"
 adr = "docs/adr/ADZE-ADR-0001-adze-document-one-parse-truth.md"
 plan = "plans/0.9.0/implementation-plan.md"
-prs = []
+prs = [692]
 commands = [
   "git diff --check",
 ]
 
 [[work_item]]
 id = "contract-convergence-plan"
-status = "active"
+status = "complete"
 proposal = "docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md"
 spec = ""
 adr = ""
 plan = "plans/0.9.0/implementation-plan.md"
-prs = []
+prs = [692]
 commands = [
   "git diff --check",
   "python -c \"import tomllib; tomllib.load(open('.adze/goals/active.toml', 'rb'))\"",

--- a/plans/0.9.0/implementation-plan.md
+++ b/plans/0.9.0/implementation-plan.md
@@ -32,9 +32,9 @@ and review cycle for each single-document branch.
 | --- | --- | --- |
 | #681 | source-of-truth-scaffolding | README files for proposals, specs, ADRs, 0.9 plans, and active goals |
 | #691 | contract-convergence-proposal | `ADZE-PROP-0001` |
-| pending | economics-docs-consolidation | `ADZE-SPEC-0001`, `ADZE-SPEC-0002`, `ADZE-ADR-0001`, implementation plan, active goal manifest |
+| #692 | economics-docs-consolidation | `ADZE-SPEC-0001`, `ADZE-SPEC-0002`, `ADZE-ADR-0001`, implementation plan, active goal manifest |
 
-Superseded stacked PRs should be closed once the consolidated follow-up is open.
+Superseded stacked PRs #683 through #686 were closed after #692 landed.
 
 ## Work Item: source-of-truth-scaffolding
 
@@ -118,7 +118,7 @@ Revert the proposal PR.
 
 ## Work Item: package-boundary-spec
 
-Status: active
+Status: complete
 Linked proposal: ../../docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md
 Linked spec: ../../docs/specs/ADZE-SPEC-0001-package-surface-boundary.md
 Linked ADR: ADZE-ADR-0002 no durable unpublished production crates
@@ -156,7 +156,7 @@ Revert the spec PR.
 
 ## Work Item: ci-economics-spec
 
-Status: active
+Status: complete
 Linked proposal: ../../docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md
 Linked spec: ../../docs/specs/ADZE-SPEC-0002-ci-economics.md
 Linked ADR:
@@ -194,7 +194,7 @@ Revert the spec PR.
 
 ## Work Item: adze-document-adr
 
-Status: active
+Status: complete
 Linked proposal: ../../docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md
 Linked spec: ADZE-SPEC-0003 canonical parse document
 Linked ADR: ../../docs/adr/ADZE-ADR-0001-adze-document-one-parse-truth.md
@@ -231,7 +231,7 @@ Revert the ADR PR.
 
 ## Work Item: contract-convergence-plan
 
-Status: active
+Status: complete
 Linked proposal: ../../docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md
 Linked spec:
 Linked ADR:


### PR DESCRIPTION
## Summary
- marks the consolidated economics docs batch as landed in the 0.9 plan
- records #692 for the package-boundary spec, CI economics spec, AdzeDocument ADR, and active goal manifest work items
- leaves package-boundary audit as the next ready item

## Validation
- `git diff --check`
- `python -c "import tomllib; tomllib.load(open('.adze/goals/active.toml', 'rb'))"`