### PR TITLE
policy: add package boundary audit

### DIFF
--- a/.adze/goals/active.toml
+++ b/.adze/goals/active.toml
@@ -96,12 +96,12 @@ commands = [
 
 [[work_item]]
 id = "package-boundary-audit"
-status = "ready"
+status = "complete"
 proposal = "docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md"
 spec = "docs/specs/ADZE-SPEC-0001-package-surface-boundary.md"
 adr = "ADZE-ADR-0002-no-durable-unpublished-production-crates"
 plan = "plans/0.9.0/implementation-plan.md"
-prs = []
+prs = [694]
 commands = [
   "cargo metadata --format-version 1 --no-deps",
   "cargo run -q -p xtask -- check-package-boundary",
@@ -124,12 +124,12 @@ commands = [
 
 [[work_item]]
 id = "microcrate-collapse"
-status = "blocked"
+status = "ready"
 proposal = "docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md"
 spec = "docs/specs/ADZE-SPEC-0001-package-surface-boundary.md"
 adr = "ADZE-ADR-0002-no-durable-unpublished-production-crates"
 plan = "plans/0.9.0/implementation-plan.md"
-blocked_by = ["package-boundary-audit"]
+blocked_by = []
 prs = []
 commands = [
   "cargo metadata --format-version 1 --no-deps",

--- a/plans/0.9.0/implementation-plan.md
+++ b/plans/0.9.0/implementation-plan.md
@@ -273,7 +273,7 @@ Revert the plan/manifest PR.
 
 ## Work Item: package-boundary-audit
 
-Status: ready
+Status: complete
 Linked proposal: ../../docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md
 Linked spec: ../../docs/specs/ADZE-SPEC-0001-package-surface-boundary.md
 Linked ADR: ADZE-ADR-0002 no durable unpublished production crates
@@ -287,13 +287,15 @@ surface boundary.
 
 ### Production Delta
 
-Expected later changes:
+Added:
 
 - `../../policy/package-boundary.toml`
 - package-boundary verifier command
 - verifier tests
-- support-tier or CI policy updates if the classification affects claims or
-  routing
+
+No support-tier or CI routing claim changed in this audit. Later package
+classification changes must update the relevant ledgers when they affect claims
+or routing.
 
 ### Non-Goals
 
@@ -366,12 +368,12 @@ until a replacement policy lands.
 
 ## Work Item: microcrate-collapse
 
-Status: blocked
+Status: ready
 Linked proposal: ../../docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md
 Linked spec: ../../docs/specs/ADZE-SPEC-0001-package-surface-boundary.md
 Linked ADR: ADZE-ADR-0002 no durable unpublished production crates
 Blocks: rust-1.95-msrv-bump; clippy-policy-refresh; ci-lem-refresh
-Blocked by: package-boundary-audit
+Blocked by: none
 
 ### Goal
 

--- a/policy/package-boundary.toml
+++ b/policy/package-boundary.toml
@@ -1,0 +1,1091 @@
+# Package boundary ledger for the Adze workspace.
+#
+# Source of truth for ADZE-SPEC-0001. Every workspace package must be
+# classified exactly once as published, dev-only, or owner-module-migration-target.
+
+schema_version = "1.0"
+policy = "package-boundary"
+owner = "release/package-surface"
+status = "advisory"
+updated = "2026-05-12"
+
+[[package]]
+name = "adze"
+path = "runtime"
+category = "published"
+owner = "core-pipeline/runtime"
+production_use = true
+publish_intent = "public"
+support_tier_impact = "links to docs/status/SUPPORT_TIERS.md before stable release claims"
+ci_impact = "ci-supported or explicitly routed product proof"
+removal_or_promotion_condition = "Maintain release metadata and support-tier proof before stable claims."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-bdd-contract"
+path = "crates/bdd-contract"
+category = "owner-module-migration-target"
+owner = "governance/bdd"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/bdd"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-bdd-governance-contract"
+path = "crates/bdd-governance-contract"
+category = "owner-module-migration-target"
+owner = "governance/bdd"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/bdd"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-bdd-governance-core"
+path = "crates/bdd-governance-core"
+category = "owner-module-migration-target"
+owner = "governance/bdd"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/bdd"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-bdd-governance-fixtures"
+path = "crates/bdd-governance-fixtures"
+category = "owner-module-migration-target"
+owner = "governance/bdd"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/bdd"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-bdd-governance-reporting-core"
+path = "crates/bdd-governance-reporting-core"
+category = "owner-module-migration-target"
+owner = "governance/bdd"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/bdd"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-bdd-grammar-analysis-core"
+path = "crates/bdd-grammar-analysis-core"
+category = "owner-module-migration-target"
+owner = "governance/bdd"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/bdd"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-bdd-grammar-fixtures"
+path = "crates/bdd-grammar-fixtures"
+category = "owner-module-migration-target"
+owner = "governance/bdd"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/bdd"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-bdd-grid-contract"
+path = "crates/bdd-grid-contract"
+category = "owner-module-migration-target"
+owner = "governance/bdd"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/bdd"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-bdd-grid-core"
+path = "crates/bdd-grid-core"
+category = "owner-module-migration-target"
+owner = "governance/bdd"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/bdd"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-bdd-scenario-core"
+path = "crates/bdd-scenario-core"
+category = "owner-module-migration-target"
+owner = "governance/bdd"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/bdd"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-bdd-scenario-fixtures"
+path = "crates/bdd-scenario-fixtures"
+category = "owner-module-migration-target"
+owner = "governance/bdd"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/bdd"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-benchmarks"
+path = "benchmarks"
+category = "dev-only"
+owner = "benchmarks"
+production_use = false
+publish_intent = "none"
+support_tier_impact = "dev/test/tooling only; excluded from product claims"
+ci_impact = "dev/test/tooling lane only"
+removal_or_promotion_condition = "Keep as dev-only while it has active test/tooling ownership; reclassify before any product claim."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-cli"
+path = "cli"
+category = "published"
+owner = "cli/user-tooling"
+production_use = true
+publish_intent = "public"
+support_tier_impact = "links to docs/status/SUPPORT_TIERS.md before stable release claims"
+ci_impact = "ci-supported or explicitly routed product proof"
+removal_or_promotion_condition = "Maintain release metadata and support-tier proof before stable claims."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-common"
+path = "common"
+category = "published"
+owner = "core-pipeline/common"
+production_use = true
+publish_intent = "public"
+support_tier_impact = "links to docs/status/SUPPORT_TIERS.md before stable release claims"
+ci_impact = "ci-supported or explicitly routed product proof"
+removal_or_promotion_condition = "Maintain release metadata and support-tier proof before stable claims."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-common-syntax-core"
+path = "crates/common-syntax-core"
+category = "owner-module-migration-target"
+owner = "syntax-formatting"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "syntax-formatting"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-concurrency-bounded-map-core"
+path = "crates/concurrency-bounded-map-core"
+category = "owner-module-migration-target"
+owner = "governance/concurrency"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/concurrency"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-concurrency-caps-contract-core"
+path = "crates/concurrency-caps-contract-core"
+category = "owner-module-migration-target"
+owner = "governance/concurrency"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/concurrency"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-concurrency-caps-core"
+path = "crates/concurrency-caps-core"
+category = "owner-module-migration-target"
+owner = "governance/concurrency"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/concurrency"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-concurrency-env-contract-core"
+path = "crates/concurrency-env-contract-core"
+category = "owner-module-migration-target"
+owner = "governance/concurrency"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/concurrency"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-concurrency-env-core"
+path = "crates/concurrency-env-core"
+category = "owner-module-migration-target"
+owner = "governance/concurrency"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/concurrency"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-concurrency-env-vars-core"
+path = "crates/concurrency-env-vars-core"
+category = "owner-module-migration-target"
+owner = "governance/concurrency"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/concurrency"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-concurrency-init-bootstrap-core"
+path = "crates/concurrency-init-bootstrap-core"
+category = "owner-module-migration-target"
+owner = "governance/concurrency"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/concurrency"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-concurrency-init-bootstrap-policy-core"
+path = "crates/concurrency-init-bootstrap-policy-core"
+category = "owner-module-migration-target"
+owner = "governance/concurrency"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/concurrency"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-concurrency-init-classifier-core"
+path = "crates/concurrency-init-classifier-core"
+category = "owner-module-migration-target"
+owner = "governance/concurrency"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/concurrency"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-concurrency-init-core"
+path = "crates/concurrency-init-core"
+category = "owner-module-migration-target"
+owner = "governance/concurrency"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/concurrency"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-concurrency-init-rayon-core"
+path = "crates/concurrency-init-rayon-core"
+category = "owner-module-migration-target"
+owner = "governance/concurrency"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/concurrency"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-concurrency-map-core"
+path = "crates/concurrency-map-core"
+category = "owner-module-migration-target"
+owner = "governance/concurrency"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/concurrency"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-concurrency-normalize-core"
+path = "crates/concurrency-normalize-core"
+category = "owner-module-migration-target"
+owner = "governance/concurrency"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/concurrency"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-concurrency-parse-core"
+path = "crates/concurrency-parse-core"
+category = "owner-module-migration-target"
+owner = "governance/concurrency"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/concurrency"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-concurrency-plan-core"
+path = "crates/concurrency-plan-core"
+category = "owner-module-migration-target"
+owner = "governance/concurrency"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/concurrency"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-error-location-core"
+path = "crates/error-location-core"
+category = "owner-module-migration-target"
+owner = "diagnostics/source-location"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "diagnostics/source-location"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-feature-policy-contract"
+path = "crates/feature-policy-contract"
+category = "owner-module-migration-target"
+owner = "governance/feature-policy"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/feature-policy"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-feature-policy-core"
+path = "crates/feature-policy-core"
+category = "owner-module-migration-target"
+owner = "governance/feature-policy"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/feature-policy"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-glr-core"
+path = "glr-core"
+category = "published"
+owner = "glr-core/parser-generation"
+production_use = true
+publish_intent = "public"
+support_tier_impact = "links to docs/status/SUPPORT_TIERS.md before stable release claims"
+ci_impact = "ci-supported or explicitly routed product proof"
+removal_or_promotion_condition = "Maintain release metadata and support-tier proof before stable claims."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-glr-versioning"
+path = "crates/glr-versioning"
+category = "owner-module-migration-target"
+owner = "0.9/microcrate-collapse"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "0.9/microcrate-collapse"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-go"
+path = "grammars/go"
+category = "dev-only"
+owner = "grammar-fixtures/go"
+production_use = false
+publish_intent = "none"
+support_tier_impact = "dev/test/tooling only; excluded from product claims"
+ci_impact = "dev/test/tooling lane only"
+removal_or_promotion_condition = "Keep as dev-only while it has active test/tooling ownership; reclassify before any product claim."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-golden-tests"
+path = "golden-tests"
+category = "dev-only"
+owner = "golden-tests"
+production_use = false
+publish_intent = "none"
+support_tier_impact = "dev/test/tooling only; excluded from product claims"
+ci_impact = "dev/test/tooling lane only"
+removal_or_promotion_condition = "Keep as dev-only while it has active test/tooling ownership; reclassify before any product claim."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-governance-contract"
+path = "crates/governance-contract"
+category = "owner-module-migration-target"
+owner = "governance/policy"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/policy"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-governance-matrix-contract"
+path = "crates/governance-matrix-contract"
+category = "owner-module-migration-target"
+owner = "governance/policy"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/policy"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-governance-matrix-core"
+path = "crates/governance-matrix-core"
+category = "owner-module-migration-target"
+owner = "governance/policy"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/policy"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-governance-matrix-core-impl"
+path = "crates/governance-matrix-core-impl"
+category = "owner-module-migration-target"
+owner = "governance/policy"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/policy"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-governance-metadata"
+path = "crates/governance-metadata"
+category = "owner-module-migration-target"
+owner = "governance/policy"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/policy"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-governance-runtime-core"
+path = "crates/governance-runtime-core"
+category = "owner-module-migration-target"
+owner = "governance/policy"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/policy"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-governance-runtime-profile-core"
+path = "crates/governance-runtime-profile-core"
+category = "owner-module-migration-target"
+owner = "governance/policy"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/policy"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-governance-runtime-reporting"
+path = "crates/governance-runtime-reporting"
+category = "owner-module-migration-target"
+owner = "governance/policy"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/policy"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-governance-status-core"
+path = "crates/governance-status-core"
+category = "owner-module-migration-target"
+owner = "governance/policy"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "governance/policy"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-grammar-analysis-core"
+path = "crates/grammar-analysis-core"
+category = "owner-module-migration-target"
+owner = "parser-contracts"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "parser-contracts"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-ir"
+path = "ir"
+category = "published"
+owner = "core-pipeline/ir"
+production_use = true
+publish_intent = "public"
+support_tier_impact = "links to docs/status/SUPPORT_TIERS.md before stable release claims"
+ci_impact = "ci-supported or explicitly routed product proof"
+removal_or_promotion_condition = "Maintain release metadata and support-tier proof before stable claims."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-javascript"
+path = "grammars/javascript"
+category = "dev-only"
+owner = "grammar-fixtures/javascript"
+production_use = false
+publish_intent = "none"
+support_tier_impact = "dev/test/tooling only; excluded from product claims"
+ci_impact = "dev/test/tooling lane only"
+removal_or_promotion_condition = "Keep as dev-only while it has active test/tooling ownership; reclassify before any product claim."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-linecol-core"
+path = "crates/linecol-core"
+category = "owner-module-migration-target"
+owner = "diagnostics/source-location"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "diagnostics/source-location"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-lsp-generator"
+path = "lsp-generator"
+category = "published"
+owner = "lsp-generator/user-tooling"
+production_use = true
+publish_intent = "public"
+support_tier_impact = "links to docs/status/SUPPORT_TIERS.md before stable release claims"
+ci_impact = "ci-supported or explicitly routed product proof"
+removal_or_promotion_condition = "Maintain release metadata and support-tier proof before stable claims."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-macro"
+path = "macro"
+category = "published"
+owner = "core-pipeline/macro"
+production_use = true
+publish_intent = "public"
+support_tier_impact = "links to docs/status/SUPPORT_TIERS.md before stable release claims"
+ci_impact = "ci-supported or explicitly routed product proof"
+removal_or_promotion_condition = "Maintain release metadata and support-tier proof before stable claims."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-parser-backend-core"
+path = "crates/parser-backend-core"
+category = "owner-module-migration-target"
+owner = "parser-contracts"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "parser-contracts"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-parser-contract"
+path = "crates/parser-contract"
+category = "owner-module-migration-target"
+owner = "parser-contracts"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "parser-contracts"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-parser-feature-contract"
+path = "crates/parser-feature-contract"
+category = "owner-module-migration-target"
+owner = "parser-contracts"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "parser-contracts"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-parser-feature-profile-core"
+path = "crates/parser-feature-profile-core"
+category = "owner-module-migration-target"
+owner = "parser-contracts"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "parser-contracts"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-parser-governance-contract"
+path = "crates/parser-governance-contract"
+category = "owner-module-migration-target"
+owner = "parser-contracts"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "parser-contracts"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-parsetable-metadata"
+path = "crates/parsetable-metadata"
+category = "owner-module-migration-target"
+owner = "parser-contracts"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "parser-contracts"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-playground"
+path = "playground"
+category = "dev-only"
+owner = "playground"
+production_use = false
+publish_intent = "none"
+support_tier_impact = "dev/test/tooling only; excluded from product claims"
+ci_impact = "dev/test/tooling lane only"
+removal_or_promotion_condition = "Keep as dev-only while it has active test/tooling ownership; reclassify before any product claim."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-python"
+path = "grammars/python"
+category = "dev-only"
+owner = "grammar-fixtures/python"
+production_use = false
+publish_intent = "none"
+support_tier_impact = "dev/test/tooling only; excluded from product claims"
+ci_impact = "dev/test/tooling lane only"
+removal_or_promotion_condition = "Keep as dev-only while it has active test/tooling ownership; reclassify before any product claim."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-python-simple"
+path = "grammars/python-simple"
+category = "dev-only"
+owner = "grammar-fixtures/python-simple"
+production_use = false
+publish_intent = "none"
+support_tier_impact = "dev/test/tooling only; excluded from product claims"
+ci_impact = "dev/test/tooling lane only"
+removal_or_promotion_condition = "Keep as dev-only while it has active test/tooling ownership; reclassify before any product claim."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-runtime"
+path = "runtime2"
+category = "published"
+owner = "runtime2/tree-sitter-compat"
+production_use = true
+publish_intent = "public"
+support_tier_impact = "links to docs/status/SUPPORT_TIERS.md before stable release claims"
+ci_impact = "ci-supported or explicitly routed product proof"
+removal_or_promotion_condition = "Maintain release metadata and support-tier proof before stable claims."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-runtime-governance"
+path = "crates/runtime-governance"
+category = "owner-module-migration-target"
+owner = "runtime-governance"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "runtime-governance"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-runtime-governance-api"
+path = "crates/runtime-governance-api"
+category = "owner-module-migration-target"
+owner = "runtime-governance"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "runtime-governance"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-runtime-governance-matrix"
+path = "crates/runtime-governance-matrix"
+category = "owner-module-migration-target"
+owner = "runtime-governance"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "runtime-governance"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-runtime2-governance"
+path = "crates/runtime2-governance"
+category = "owner-module-migration-target"
+owner = "runtime-governance"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "runtime-governance"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-stack-pool-core"
+path = "crates/stack-pool-core"
+category = "owner-module-migration-target"
+owner = "glr-core/runtime-memory"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "glr-core/runtime-memory"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-tablegen"
+path = "tablegen"
+category = "published"
+owner = "tablegen/ffi-and-table-output"
+production_use = true
+publish_intent = "public"
+support_tier_impact = "links to docs/status/SUPPORT_TIERS.md before stable release claims"
+ci_impact = "ci-supported or explicitly routed product proof"
+removal_or_promotion_condition = "Maintain release metadata and support-tier proof before stable claims."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-testing"
+path = "testing"
+category = "dev-only"
+owner = "test-infrastructure"
+production_use = false
+publish_intent = "none"
+support_tier_impact = "dev/test/tooling only; excluded from product claims"
+ci_impact = "dev/test/tooling lane only"
+removal_or_promotion_condition = "Keep as dev-only while it has active test/tooling ownership; reclassify before any product claim."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-tool"
+path = "tool"
+category = "published"
+owner = "core-pipeline/tool"
+production_use = true
+publish_intent = "public"
+support_tier_impact = "links to docs/status/SUPPORT_TIERS.md before stable release claims"
+ci_impact = "ci-supported or explicitly routed product proof"
+removal_or_promotion_condition = "Maintain release metadata and support-tier proof before stable claims."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-ts-format-core"
+path = "crates/ts-format-core"
+category = "owner-module-migration-target"
+owner = "syntax-formatting"
+production_use = true
+publish_intent = "retire-or-inline"
+support_tier_impact = "temporary internal surface; no stable product claim until migrated or promoted"
+ci_impact = "collapse target; keep out of default CI expansion unless routed by owner"
+migration_target = "syntax-formatting"
+removal_or_promotion_condition = "Move into the owner module or reclassify with an accepted spec/ADR before 0.9 release."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "adze-wasm-demo"
+path = "wasm-demo"
+category = "dev-only"
+owner = "wasm-demo"
+production_use = false
+publish_intent = "none"
+support_tier_impact = "dev/test/tooling only; excluded from product claims"
+ci_impact = "dev/test/tooling lane only"
+removal_or_promotion_condition = "Keep as dev-only while it has active test/tooling ownership; reclassify before any product claim."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "downstream-demo"
+path = "samples/downstream-demo"
+category = "dev-only"
+owner = "samples"
+production_use = false
+publish_intent = "none"
+support_tier_impact = "dev/test/tooling only; excluded from product claims"
+ci_impact = "dev/test/tooling lane only"
+removal_or_promotion_condition = "Keep as dev-only while it has active test/tooling ownership; reclassify before any product claim."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "glr-test-support"
+path = "glr-test-support"
+category = "dev-only"
+owner = "glr-test-support"
+production_use = false
+publish_intent = "none"
+support_tier_impact = "dev/test/tooling only; excluded from product claims"
+ci_impact = "dev/test/tooling lane only"
+removal_or_promotion_condition = "Keep as dev-only while it has active test/tooling ownership; reclassify before any product claim."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "governance-integration-tests"
+path = "tests/governance"
+category = "dev-only"
+owner = "integration-tests"
+production_use = false
+publish_intent = "none"
+support_tier_impact = "dev/test/tooling only; excluded from product claims"
+ci_impact = "dev/test/tooling lane only"
+removal_or_promotion_condition = "Keep as dev-only while it has active test/tooling ownership; reclassify before any product claim."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "test-mini"
+path = "test-mini"
+category = "dev-only"
+owner = "test-mini"
+production_use = false
+publish_intent = "none"
+support_tier_impact = "dev/test/tooling only; excluded from product claims"
+ci_impact = "dev/test/tooling lane only"
+removal_or_promotion_condition = "Keep as dev-only while it has active test/tooling ownership; reclassify before any product claim."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "test-vec-wrapper"
+path = "grammars/test-vec-wrapper"
+category = "dev-only"
+owner = "grammar-fixtures/test-vec-wrapper"
+production_use = false
+publish_intent = "none"
+support_tier_impact = "dev/test/tooling only; excluded from product claims"
+ci_impact = "dev/test/tooling lane only"
+removal_or_promotion_condition = "Keep as dev-only while it has active test/tooling ownership; reclassify before any product claim."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"
+
+[[package]]
+name = "xtask"
+path = "xtask"
+category = "dev-only"
+owner = "xtask/policy-automation"
+production_use = false
+publish_intent = "none"
+support_tier_impact = "dev/test/tooling only; excluded from product claims"
+ci_impact = "dev/test/tooling lane only"
+removal_or_promotion_condition = "Keep as dev-only while it has active test/tooling ownership; reclassify before any product claim."
+last_changed = "2026-05-12"
+last_changed_pr = "#694"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -238,6 +238,12 @@ enum Commands {
     },
     /// Run every policy check and emit a combined Markdown report.
     PolicyReport,
+    /// Verify workspace packages against policy/package-boundary.toml.
+    CheckPackageBoundary {
+        /// Operating mode: advisory | blocking-allowlist | blocking-strict
+        #[arg(long, default_value = "blocking-allowlist")]
+        mode: String,
+    },
     /// Lint workflows against policy/ci-lane-whitelist.toml.
     ///
     /// Reports undeclared workflow jobs, missing exceptions for expensive
@@ -493,6 +499,10 @@ fn main() -> Result<()> {
         }
         Commands::PolicyReport => {
             policy::report::run()?;
+        }
+        Commands::CheckPackageBoundary { mode } => {
+            let mode = policy::Mode::parse(&mode)?;
+            policy::package_boundary::run_check(mode)?;
         }
         Commands::CheckCiLaneWhitelist { mode } => {
             let mode = policy::Mode::parse(&mode)?;

--- a/xtask/src/policy.rs
+++ b/xtask/src/policy.rs
@@ -9,6 +9,7 @@ pub mod ci_lane_whitelist;
 pub mod file_policy;
 pub mod lint_policy;
 pub mod no_panic;
+pub mod package_boundary;
 pub mod report;
 
 /// Where the checks write their JSON/Markdown artefacts.

--- a/xtask/src/policy/package_boundary.rs
+++ b/xtask/src/policy/package_boundary.rs
@@ -1,0 +1,593 @@
+//! Workspace package-boundary policy checker.
+//!
+//! Verifies that every Cargo workspace package is classified in
+//! `policy/package-boundary.toml` as a published crate, dev-only crate, or
+//! owner-module migration target.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+use super::{Mode, ensure_report_dir, workspace_root};
+
+const POLICY_PATH: &str = "policy/package-boundary.toml";
+
+#[derive(Debug, Default, Deserialize)]
+struct PackageBoundaryFile {
+    #[serde(default)]
+    schema_version: String,
+    #[serde(default)]
+    policy: String,
+    #[serde(default)]
+    owner: String,
+    #[serde(default)]
+    status: String,
+    #[serde(default)]
+    updated: String,
+    #[serde(default, rename = "package")]
+    packages: Vec<PackageEntry>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct PackageEntry {
+    name: String,
+    path: String,
+    category: String,
+    owner: String,
+    production_use: Option<bool>,
+    publish_intent: String,
+    support_tier_impact: String,
+    ci_impact: String,
+    #[serde(default)]
+    migration_target: Option<String>,
+    removal_or_promotion_condition: String,
+    last_changed: String,
+    last_changed_pr: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct CargoMetadata {
+    packages: Vec<CargoPackage>,
+    workspace_members: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct CargoPackage {
+    id: String,
+    name: String,
+    manifest_path: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct WorkspacePackage {
+    path: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum Category {
+    Published,
+    DevOnly,
+    OwnerModuleMigrationTarget,
+}
+
+impl Category {
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "published" => Some(Self::Published),
+            "dev-only" => Some(Self::DevOnly),
+            "owner-module-migration-target" => Some(Self::OwnerModuleMigrationTarget),
+            _ => None,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Published => "published",
+            Self::DevOnly => "dev-only",
+            Self::OwnerModuleMigrationTarget => "owner-module-migration-target",
+        }
+    }
+}
+
+#[derive(Debug, Default, Serialize)]
+struct PackageBoundaryReport {
+    mode: String,
+    workspace_packages: usize,
+    ledger_packages: usize,
+    by_category: BTreeMap<String, usize>,
+    findings: Vec<Finding>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct Finding {
+    severity: &'static str,
+    code: &'static str,
+    package: Option<String>,
+    field: Option<String>,
+    message: String,
+}
+
+pub fn run_check(mode: Mode) -> Result<()> {
+    let root = workspace_root()?;
+    let report_dir = ensure_report_dir(&root)?;
+    let ledger = load_ledger(&root)?;
+    let workspace_packages = load_workspace_packages(&root)?;
+
+    let report = validate(&ledger, &workspace_packages, mode);
+    write_reports(&report_dir, &report)?;
+    print_summary(&report);
+
+    if matches!(mode, Mode::BlockingAllowlist | Mode::BlockingStrict) {
+        let errors = report
+            .findings
+            .iter()
+            .filter(|f| f.severity == "error")
+            .count();
+        if errors > 0 {
+            anyhow::bail!("package-boundary: {errors} error finding(s) in blocking mode");
+        }
+    }
+
+    Ok(())
+}
+
+fn load_ledger(root: &Path) -> Result<PackageBoundaryFile> {
+    let path = root.join(POLICY_PATH);
+    let text =
+        std::fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+    toml::from_str(&text).with_context(|| format!("parsing {}", path.display()))
+}
+
+fn load_workspace_packages(root: &Path) -> Result<BTreeMap<String, WorkspacePackage>> {
+    let output = std::process::Command::new("cargo")
+        .args(["metadata", "--format-version", "1", "--no-deps"])
+        .current_dir(root)
+        .output()
+        .context("running cargo metadata --format-version 1 --no-deps")?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "cargo metadata failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let metadata: CargoMetadata =
+        serde_json::from_slice(&output.stdout).context("parsing cargo metadata output")?;
+    let members: BTreeSet<&str> = metadata
+        .workspace_members
+        .iter()
+        .map(String::as_str)
+        .collect();
+    let mut packages = BTreeMap::new();
+    for package in metadata
+        .packages
+        .into_iter()
+        .filter(|package| members.contains(package.id.as_str()))
+    {
+        let manifest_dir = package
+            .manifest_path
+            .parent()
+            .with_context(|| format!("manifest has no parent for {}", package.name))?;
+        let path = relative_path(root, manifest_dir)?;
+        packages.insert(package.name.clone(), WorkspacePackage { path });
+    }
+    Ok(packages)
+}
+
+fn relative_path(root: &Path, path: &Path) -> Result<String> {
+    let rel = path
+        .strip_prefix(root)
+        .with_context(|| format!("{} is not under {}", path.display(), root.display()))?;
+    let rel = rel.to_string_lossy().replace('\\', "/");
+    if rel.is_empty() {
+        Ok(".".to_string())
+    } else {
+        Ok(rel)
+    }
+}
+
+fn validate(
+    ledger: &PackageBoundaryFile,
+    workspace_packages: &BTreeMap<String, WorkspacePackage>,
+    mode: Mode,
+) -> PackageBoundaryReport {
+    let mut report = PackageBoundaryReport {
+        mode: format!("{mode:?}"),
+        workspace_packages: workspace_packages.len(),
+        ledger_packages: ledger.packages.len(),
+        ..Default::default()
+    };
+
+    validate_header(ledger, &mut report);
+
+    let mut seen = BTreeSet::new();
+    let mut ledger_names = BTreeSet::new();
+    for entry in &ledger.packages {
+        if !seen.insert(entry.name.clone()) {
+            report.findings.push(finding(
+                "error",
+                "duplicate-package",
+                Some(&entry.name),
+                Some("name"),
+                "package appears more than once in policy/package-boundary.toml",
+            ));
+        }
+        ledger_names.insert(entry.name.clone());
+
+        validate_required_fields(entry, &mut report);
+        let Some(category) = Category::parse(&entry.category) else {
+            report.findings.push(finding(
+                "error",
+                "invalid-category",
+                Some(&entry.name),
+                Some("category"),
+                "category must be published, dev-only, or owner-module-migration-target",
+            ));
+            continue;
+        };
+        *report
+            .by_category
+            .entry(category.as_str().to_string())
+            .or_default() += 1;
+
+        match workspace_packages.get(&entry.name) {
+            Some(package) => {
+                if entry.path != package.path {
+                    report.findings.push(finding(
+                        "error",
+                        "path-mismatch",
+                        Some(&entry.name),
+                        Some("path"),
+                        &format!(
+                            "ledger path `{}` does not match workspace path `{}`",
+                            entry.path, package.path
+                        ),
+                    ));
+                }
+            }
+            None => report.findings.push(finding(
+                "error",
+                "unknown-package",
+                Some(&entry.name),
+                Some("name"),
+                "package is not a current workspace member",
+            )),
+        }
+
+        validate_category_contract(entry, category, &mut report);
+    }
+
+    for package in workspace_packages.keys() {
+        if !ledger_names.contains(package) {
+            report.findings.push(finding(
+                "error",
+                "missing-package",
+                Some(package),
+                Some("name"),
+                "workspace package is missing from policy/package-boundary.toml",
+            ));
+        }
+    }
+
+    report
+}
+
+fn validate_header(ledger: &PackageBoundaryFile, report: &mut PackageBoundaryReport) {
+    required_header("schema_version", &ledger.schema_version, report);
+    required_header("policy", &ledger.policy, report);
+    required_header("owner", &ledger.owner, report);
+    required_header("status", &ledger.status, report);
+    required_header("updated", &ledger.updated, report);
+
+    if !ledger.policy.is_empty() && ledger.policy != "package-boundary" {
+        report.findings.push(finding(
+            "error",
+            "wrong-policy",
+            None,
+            Some("policy"),
+            "policy must be package-boundary",
+        ));
+    }
+}
+
+fn required_header(field: &'static str, value: &str, report: &mut PackageBoundaryReport) {
+    if value.trim().is_empty() {
+        report.findings.push(finding(
+            "error",
+            "missing-header-field",
+            None,
+            Some(field),
+            "policy header field is required",
+        ));
+    }
+}
+
+fn validate_required_fields(entry: &PackageEntry, report: &mut PackageBoundaryReport) {
+    required_entry_field(&entry.name, "name", &entry.name, report);
+    required_entry_field(&entry.name, "path", &entry.path, report);
+    required_entry_field(&entry.name, "category", &entry.category, report);
+    required_entry_field(&entry.name, "owner", &entry.owner, report);
+    required_entry_field(&entry.name, "publish_intent", &entry.publish_intent, report);
+    required_entry_field(
+        &entry.name,
+        "support_tier_impact",
+        &entry.support_tier_impact,
+        report,
+    );
+    required_entry_field(&entry.name, "ci_impact", &entry.ci_impact, report);
+    required_entry_field(
+        &entry.name,
+        "removal_or_promotion_condition",
+        &entry.removal_or_promotion_condition,
+        report,
+    );
+    required_entry_field(&entry.name, "last_changed", &entry.last_changed, report);
+    required_entry_field(
+        &entry.name,
+        "last_changed_pr",
+        &entry.last_changed_pr,
+        report,
+    );
+    if entry.production_use.is_none() {
+        report.findings.push(finding(
+            "error",
+            "missing-production-use",
+            Some(&entry.name),
+            Some("production_use"),
+            "production_use must be true or false",
+        ));
+    }
+}
+
+fn required_entry_field(
+    package: &str,
+    field_name: &'static str,
+    value: &str,
+    report: &mut PackageBoundaryReport,
+) {
+    if value.trim().is_empty() {
+        report.findings.push(finding(
+            "error",
+            "missing-package-field",
+            Some(package),
+            Some(field_name),
+            "package ledger field is required",
+        ));
+    }
+}
+
+fn validate_category_contract(
+    entry: &PackageEntry,
+    category: Category,
+    report: &mut PackageBoundaryReport,
+) {
+    let production_use = entry.production_use.unwrap_or(false);
+
+    if production_use && category == Category::DevOnly {
+        report.findings.push(finding(
+            "error",
+            "production-dev-only",
+            Some(&entry.name),
+            Some("category"),
+            "production-used packages must be published crates or owner-module migration targets",
+        ));
+    }
+
+    match category {
+        Category::Published => {
+            if entry.publish_intent.trim().eq_ignore_ascii_case("none") {
+                report.findings.push(finding(
+                    "error",
+                    "published-without-publish-intent",
+                    Some(&entry.name),
+                    Some("publish_intent"),
+                    "published packages must declare a non-none publish intent",
+                ));
+            }
+        }
+        Category::DevOnly => {
+            if entry
+                .support_tier_impact
+                .to_ascii_lowercase()
+                .contains("stable")
+            {
+                report.findings.push(finding(
+                    "error",
+                    "dev-only-stable-claim",
+                    Some(&entry.name),
+                    Some("support_tier_impact"),
+                    "dev-only packages cannot be stable product proof surfaces",
+                ));
+            }
+        }
+        Category::OwnerModuleMigrationTarget => {
+            let target = entry.migration_target.as_deref().unwrap_or_default().trim();
+            if target.is_empty() {
+                report.findings.push(finding(
+                    "error",
+                    "missing-migration-target",
+                    Some(&entry.name),
+                    Some("migration_target"),
+                    "owner-module migration targets must name the target owner/module",
+                ));
+            }
+            if !production_use {
+                report.findings.push(finding(
+                    "warning",
+                    "migration-target-not-production-used",
+                    Some(&entry.name),
+                    Some("production_use"),
+                    "migration targets usually represent production surface debt; confirm false is intentional",
+                ));
+            }
+        }
+    }
+}
+
+fn write_reports(dir: &Path, report: &PackageBoundaryReport) -> Result<()> {
+    let json_path = dir.join("package-boundary.json");
+    std::fs::write(&json_path, serde_json::to_string_pretty(report)?)
+        .with_context(|| format!("writing {}", json_path.display()))?;
+
+    let mut md = String::new();
+    md.push_str("# Package boundary report\n\n");
+    md.push_str(&format!("- mode: `{}`\n", report.mode));
+    md.push_str(&format!(
+        "- workspace packages: {}\n",
+        report.workspace_packages
+    ));
+    md.push_str(&format!("- ledger packages: {}\n", report.ledger_packages));
+    md.push_str(&format!(
+        "- findings: {} error(s), {} warning(s)\n",
+        count_severity(report, "error"),
+        count_severity(report, "warning")
+    ));
+    md.push_str("\n## Categories\n\n");
+    md.push_str("| category | packages |\n|---|---:|\n");
+    for (category, count) in &report.by_category {
+        md.push_str(&format!("| `{category}` | {count} |\n"));
+    }
+    if !report.findings.is_empty() {
+        md.push_str("\n## Findings\n\n");
+        md.push_str("| severity | code | package | field | message |\n|---|---|---|---|---|\n");
+        for finding in &report.findings {
+            md.push_str(&format!(
+                "| {} | `{}` | `{}` | `{}` | {} |\n",
+                finding.severity,
+                finding.code,
+                finding.package.as_deref().unwrap_or("-"),
+                finding.field.as_deref().unwrap_or("-"),
+                finding.message.replace('|', "\\|")
+            ));
+        }
+    }
+    let md_path = dir.join("package-boundary.md");
+    std::fs::write(&md_path, md).with_context(|| format!("writing {}", md_path.display()))?;
+    Ok(())
+}
+
+fn print_summary(report: &PackageBoundaryReport) {
+    println!("package-boundary check ({})", report.mode);
+    println!("  workspace packages: {}", report.workspace_packages);
+    println!("  ledger packages:    {}", report.ledger_packages);
+    println!("  errors:             {}", count_severity(report, "error"));
+    println!(
+        "  warnings:           {}",
+        count_severity(report, "warning")
+    );
+    for finding in &report.findings {
+        let package = finding.package.as_deref().unwrap_or("-");
+        let field = finding.field.as_deref().unwrap_or("-");
+        println!(
+            "  [{}] {} ({}, {}): {}",
+            finding.severity, finding.code, package, field, finding.message
+        );
+    }
+}
+
+fn count_severity(report: &PackageBoundaryReport, severity: &str) -> usize {
+    report
+        .findings
+        .iter()
+        .filter(|finding| finding.severity == severity)
+        .count()
+}
+
+fn finding(
+    severity: &'static str,
+    code: &'static str,
+    package: Option<&str>,
+    field: Option<&'static str>,
+    message: &str,
+) -> Finding {
+    Finding {
+        severity,
+        code,
+        package: package.map(str::to_string),
+        field: field.map(str::to_string),
+        message: message.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(name: &str, category: &str) -> PackageEntry {
+        PackageEntry {
+            name: name.to_string(),
+            path: name.to_string(),
+            category: category.to_string(),
+            owner: "test/owner".to_string(),
+            production_use: Some(category != "dev-only"),
+            publish_intent: "public".to_string(),
+            support_tier_impact: "test impact".to_string(),
+            ci_impact: "test ci".to_string(),
+            migration_target: (category == "owner-module-migration-target")
+                .then(|| "test/owner-module".to_string()),
+            removal_or_promotion_condition: "test condition".to_string(),
+            last_changed: "2026-05-12".to_string(),
+            last_changed_pr: "test".to_string(),
+        }
+    }
+
+    #[test]
+    fn category_parse_accepts_contract_terms() {
+        assert_eq!(Category::parse("published"), Some(Category::Published));
+        assert_eq!(Category::parse("dev-only"), Some(Category::DevOnly));
+        assert_eq!(
+            Category::parse("owner-module-migration-target"),
+            Some(Category::OwnerModuleMigrationTarget)
+        );
+        assert_eq!(Category::parse("unpublished-production"), None);
+    }
+
+    #[test]
+    fn validation_reports_missing_unknown_duplicate_and_migration_fields() {
+        let ledger = PackageBoundaryFile {
+            schema_version: "1.0".to_string(),
+            policy: "package-boundary".to_string(),
+            owner: "test".to_string(),
+            status: "advisory".to_string(),
+            updated: "2026-05-12".to_string(),
+            packages: vec![
+                entry("known", "published"),
+                entry("known", "published"),
+                entry("unknown", "dev-only"),
+                PackageEntry {
+                    migration_target: None,
+                    ..entry("migration", "owner-module-migration-target")
+                },
+            ],
+        };
+        let workspace = BTreeMap::from([
+            (
+                "known".to_string(),
+                WorkspacePackage {
+                    path: "known".to_string(),
+                },
+            ),
+            (
+                "missing".to_string(),
+                WorkspacePackage {
+                    path: "missing".to_string(),
+                },
+            ),
+            (
+                "migration".to_string(),
+                WorkspacePackage {
+                    path: "migration".to_string(),
+                },
+            ),
+        ]);
+
+        let report = validate(&ledger, &workspace, Mode::BlockingAllowlist);
+        let codes: BTreeSet<_> = report.findings.iter().map(|f| f.code).collect();
+
+        assert!(codes.contains("duplicate-package"));
+        assert!(codes.contains("unknown-package"));
+        assert!(codes.contains("missing-package"));
+        assert!(codes.contains("missing-migration-target"));
+    }
+}


### PR DESCRIPTION
## Summary

- add `policy/package-boundary.toml` as the ADZE-SPEC-0001 package classification ledger
- add `cargo run -q -p xtask -- check-package-boundary` with blocking default mode
- mark package-boundary audit complete and unblock the next microcrate-collapse work item

## Classification Snapshot

- 79 workspace packages classified
- 10 published
- 15 dev-only
- 54 owner-module migration targets

## Proof

- `cargo metadata --format-version 1 --no-deps`
- `cargo run -q -p xtask -- check-package-boundary`
- `cargo test -p xtask --bin xtask package_boundary -j 1 -- --nocapture`
- `cargo check -p xtask`
- `cargo clippy -p xtask --bin xtask -- -D warnings`
- `cargo fmt -p xtask -- --check`
- `python -c "import tomllib; tomllib.load(open('.adze/goals/active.toml', 'rb')); tomllib.load(open('policy/package-boundary.toml', 'rb'))"`
- `git diff --check`

Local `just ci-supported` is blocked on this Windows host because `just` cannot find `cygpath` to translate the recipe shebang path. Hosted PR Gate should run the exact lane on Ubuntu.