### PR TITLE
Refactor grammar.js parser helpers into focused SRP modules

### DIFF
--- a/tool/src/grammar_js/parser_v3.rs
+++ b/tool/src/grammar_js/parser_v3.rs
@@ -25,6 +25,9 @@ macro_rules! eprintln {
     };
 }
 
+mod function_block;
+mod lexing;
+
 /// Check if a string is a symbol reference like $.identifier
 fn is_symbol_ref(s: &str) -> bool {
     let trimmed = s.trim();
@@ -277,71 +280,14 @@ impl GrammarJsParserV3 {
     }
 
     fn extract_balanced_delim(&self, content: &str, open: char, close: char) -> Result<String> {
-        let mut depth = 1;
-        let mut pos = 0;
-        let chars: Vec<char> = content.chars().collect();
-
         eprintln!(
             "Debug: extract_balanced_delim called with open='{}' close='{}', content length={}",
             open,
             close,
-            chars.len()
+            content.chars().count()
         );
 
-        while depth > 0 && pos < chars.len() {
-            let ch = chars[pos];
-
-            // Simple string handling - just skip quoted content
-            if ch == '\'' || ch == '"' || ch == '`' {
-                let quote = ch;
-                pos += 1;
-                while pos < chars.len() {
-                    if chars[pos] == '\\' {
-                        pos += 2; // Skip escaped char
-                    } else if chars[pos] == quote {
-                        pos += 1;
-                        break;
-                    } else {
-                        pos += 1;
-                    }
-                }
-            } else if ch == '/' && pos + 1 < chars.len() {
-                // Handle regex patterns
-                if pos > 0
-                    && "[,({:;=\n ".contains(chars[pos - 1])
-                    && chars[pos + 1] != '/'
-                    && chars[pos + 1] != '*'
-                {
-                    // Likely a regex
-                    pos += 1;
-                    while pos < chars.len() {
-                        if chars[pos] == '\\' {
-                            pos += 2;
-                        } else if chars[pos] == '/' {
-                            pos += 1;
-                            break;
-                        } else {
-                            pos += 1;
-                        }
-                    }
-                } else {
-                    pos += 1;
-                }
-            } else {
-                if ch == open {
-                    depth += 1;
-                } else if ch == close {
-                    depth -= 1;
-                }
-                pos += 1;
-            }
-        }
-
-        if depth == 0 {
-            Ok(content[..pos - 1].to_string())
-        } else {
-            bail!("Unbalanced {} and {} in content", open, close)
-        }
+        lexing::extract_balanced_delim(content, open, close)
     }
 
     fn find_matching_paren(&self, content: &str) -> Result<usize> {
@@ -428,159 +374,13 @@ impl GrammarJsParserV3 {
     }
 
     fn parse_function_block(&self, block: &str) -> Result<Rule> {
-        // Function blocks have JavaScript code that ends with a return statement
-        // We need to extract the return value and handle inline const helper functions
-
-        eprintln!("Debug: parse_function_block called with block:\n{}", block);
-
-        // Special case: binary_operator-style table definitions
-        if block.contains("const table = [") {
-            // This is the pattern used in binary_operator: const table = [...] return choice(...table.map(...))
-            // For now, return a placeholder since we can't execute JavaScript
-            eprintln!("Warning: Complex JavaScript table definition found, returning placeholder");
-            return Ok(Rule::Choice { members: vec![] });
-        }
-
-        // Extract const helper function declarations
-        let mut helpers: IndexMap<String, (String, String)> = IndexMap::new();
-        let lines: Vec<&str> = block.lines().collect();
-
-        for line in &lines {
-            let trimmed = line.trim();
-            if trimmed.starts_with("const ") {
-                // Parse: const helperName = (param) => body
-                if let Some(eq_pos) = trimmed.find('=') {
-                    let helper_name = trimmed[6..eq_pos].trim();
-                    let rhs = trimmed[eq_pos + 1..].trim();
-
-                    // Check for arrow function: (param) => body
-                    if let Some(arrow_pos) = rhs.find("=>") {
-                        let params = rhs[..arrow_pos].trim();
-                        let body = rhs[arrow_pos + 2..].trim();
-
-                        // Extract parameter name from (param) or param
-                        let param_name = params
-                            .trim_matches(|c: char| c == '(' || c == ')' || c.is_whitespace());
-
-                        // Remove trailing semicolon from body if present
-                        let body = body.trim_end_matches(';').trim();
-
-                        helpers.insert(
-                            helper_name.to_string(),
-                            (param_name.to_string(), body.to_string()),
-                        );
-                        eprintln!(
-                            "Debug: Registered helper '{}' with param '{}' and body '{}'",
-                            helper_name, param_name, body
-                        );
-                    }
-                }
+        match function_block::parse(block)? {
+            function_block::ParsedFunctionBlock::PlaceholderChoice => {
+                Ok(Rule::Choice { members: vec![] })
             }
-        }
-
-        // Find the last 'return' statement
-        if let Some(return_pos) = block.rfind("return ") {
-            let return_content = &block[return_pos + 7..]; // Skip "return "
-
-            // Find the end of the return statement (either ';' or '}')
-            let mut end_pos = return_content.len();
-            let mut depth = 0;
-            let mut in_string = false;
-            let mut in_regex = false;
-            let mut escape_next = false;
-
-            for (i, ch) in return_content.chars().enumerate() {
-                if escape_next {
-                    escape_next = false;
-                    continue;
-                }
-
-                if ch == '\\' {
-                    escape_next = true;
-                    continue;
-                }
-
-                if !in_regex && (ch == '"' || ch == '\'') {
-                    in_string = !in_string;
-                }
-
-                if !in_string && ch == '/' {
-                    in_regex = !in_regex;
-                }
-
-                if !in_string && !in_regex {
-                    match ch {
-                        '(' | '{' | '[' => depth += 1,
-                        ')' | '}' | ']' => depth -= 1,
-                        ';' if depth == 0 => {
-                            end_pos = i;
-                            break;
-                        }
-                        _ => {}
-                    }
-                }
-
-                // If we hit the closing brace at depth -1, that's the end of the block
-                if depth < 0 {
-                    end_pos = i;
-                    break;
-                }
+            function_block::ParsedFunctionBlock::ReturnExpression(return_expr) => {
+                self.parse_rule(&return_expr)
             }
-
-            let mut return_expr = return_content[..end_pos].trim().to_string();
-
-            // Expand inline helper function calls
-            for (helper_name, (param_name, body)) in &helpers {
-                // Look for helperName(arg) pattern
-                let call_pattern = format!("{}(", helper_name);
-                if return_expr.contains(&call_pattern) {
-                    eprintln!(
-                        "Debug: Expanding helper '{}' in return expression",
-                        helper_name
-                    );
-
-                    // Find the argument to the helper function call
-                    if let Some(call_start) = return_expr.find(&call_pattern) {
-                        let args_start = call_start + call_pattern.len();
-
-                        // Extract the argument (handle nested parens)
-                        let mut depth = 1;
-                        let mut arg_end = args_start;
-                        let chars: Vec<char> = return_expr.chars().collect();
-
-                        for (i, ch) in chars.iter().enumerate().skip(args_start) {
-                            match ch {
-                                '(' => depth += 1,
-                                ')' => {
-                                    depth -= 1;
-                                    if depth == 0 {
-                                        arg_end = i;
-                                        break;
-                                    }
-                                }
-                                _ => {}
-                            }
-                        }
-
-                        let arg = &return_expr[args_start..arg_end];
-                        eprintln!("Debug: Helper argument: '{}'", arg);
-
-                        // Substitute parameter with argument in the body
-                        let expanded = body.replace(param_name, arg);
-                        eprintln!("Debug: Expanded body: '{}'", expanded);
-
-                        // Replace the helper call with the expanded body
-                        let replacement = expanded.clone();
-                        let call_expr = &return_expr[call_start..=arg_end];
-                        return_expr = return_expr.replace(call_expr, &replacement);
-                        eprintln!("Debug: New return expression: '{}'", return_expr);
-                    }
-                }
-            }
-
-            self.parse_rule(&return_expr)
-        } else {
-            bail!("Function block must contain a return statement")
         }
     }
 
@@ -872,57 +672,7 @@ impl GrammarJsParserV3 {
     }
 
     fn split_args(&self, content: &str, expected: i32) -> Result<Vec<String>> {
-        let mut args = Vec::new();
-        let mut current = String::new();
-        let mut depth = 0;
-        let mut in_string = false;
-        let mut string_char = ' ';
-        let mut escape_next = false;
-
-        for ch in content.chars() {
-            if escape_next {
-                escape_next = false;
-                current.push(ch);
-            } else if ch == '\\' {
-                escape_next = true;
-                current.push(ch);
-            } else if !in_string && (ch == '\'' || ch == '"' || ch == '`') {
-                in_string = true;
-                string_char = ch;
-                current.push(ch);
-            } else if in_string && ch == string_char {
-                in_string = false;
-                current.push(ch);
-            } else if !in_string {
-                match ch {
-                    '(' | '[' | '{' => {
-                        depth += 1;
-                        current.push(ch);
-                    }
-                    ')' | ']' | '}' => {
-                        depth -= 1;
-                        current.push(ch);
-                    }
-                    ',' if depth == 0 => {
-                        args.push(current.trim().to_string());
-                        current.clear();
-                    }
-                    _ => current.push(ch),
-                }
-            } else {
-                current.push(ch);
-            }
-        }
-
-        if !current.trim().is_empty() {
-            args.push(current.trim().to_string());
-        }
-
-        if expected > 0 && args.len() != expected as usize {
-            bail!("Expected {} arguments, got {}", expected, args.len());
-        }
-
-        Ok(args)
+        lexing::split_args(content, expected)
     }
 
     fn parse_rule_list(&self, content: &str) -> Result<Vec<Rule>> {

--- a/tool/src/grammar_js/parser_v3/function_block.rs
+++ b/tool/src/grammar_js/parser_v3/function_block.rs
@@ -1,0 +1,240 @@
+use anyhow::{Result, bail};
+use indexmap::IndexMap;
+
+/// Parsed result for JavaScript block-bodied grammar rules.
+pub(super) enum ParsedFunctionBlock {
+    /// Complex executable JavaScript that cannot be represented statically yet.
+    PlaceholderChoice,
+    /// A statically extracted return expression ready for rule parsing.
+    ReturnExpression(String),
+}
+
+#[derive(Debug)]
+struct InlineHelper {
+    param_name: String,
+    body: String,
+}
+
+/// Extracts the static rule expression from a JavaScript function block.
+pub(super) fn parse(block: &str) -> Result<ParsedFunctionBlock> {
+    eprintln!("Debug: parse_function_block called with block:\n{}", block);
+
+    if has_table_driven_definition(block) {
+        eprintln!("Warning: Complex JavaScript table definition found, returning placeholder");
+        return Ok(ParsedFunctionBlock::PlaceholderChoice);
+    }
+
+    let helpers = extract_inline_helpers(block);
+    let return_expr = extract_return_expression(block)?;
+    Ok(ParsedFunctionBlock::ReturnExpression(
+        expand_inline_helpers(return_expr, &helpers),
+    ))
+}
+
+fn has_table_driven_definition(block: &str) -> bool {
+    block.contains("const table = [")
+}
+
+fn extract_inline_helpers(block: &str) -> IndexMap<String, InlineHelper> {
+    let mut helpers = IndexMap::new();
+
+    for line in block.lines() {
+        let trimmed = line.trim();
+        if !trimmed.starts_with("const ") {
+            continue;
+        }
+
+        let Some(eq_pos) = trimmed.find('=') else {
+            continue;
+        };
+
+        let helper_name = trimmed[6..eq_pos].trim();
+        let rhs = trimmed[eq_pos + 1..].trim();
+        let Some(arrow_pos) = rhs.find("=>") else {
+            continue;
+        };
+
+        let params = rhs[..arrow_pos].trim();
+        let body = rhs[arrow_pos + 2..].trim().trim_end_matches(';').trim();
+        let param_name = params.trim_matches(|c: char| c == '(' || c == ')' || c.is_whitespace());
+
+        helpers.insert(
+            helper_name.to_string(),
+            InlineHelper {
+                param_name: param_name.to_string(),
+                body: body.to_string(),
+            },
+        );
+        eprintln!(
+            "Debug: Registered helper '{}' with param '{}' and body '{}'",
+            helper_name, param_name, body
+        );
+    }
+
+    helpers
+}
+
+fn extract_return_expression(block: &str) -> Result<&str> {
+    let Some(return_pos) = block.rfind("return ") else {
+        bail!("Function block must contain a return statement")
+    };
+
+    let return_content = &block[return_pos + 7..];
+    let end_pos = find_return_expression_end(return_content);
+    Ok(return_content[..end_pos].trim())
+}
+
+fn find_return_expression_end(return_content: &str) -> usize {
+    let mut depth = 0;
+    let mut in_string = false;
+    let mut in_regex = false;
+    let mut escape_next = false;
+
+    for (i, ch) in return_content.char_indices() {
+        if escape_next {
+            escape_next = false;
+            continue;
+        }
+
+        if ch == '\\' {
+            escape_next = true;
+            continue;
+        }
+
+        if !in_regex && (ch == '"' || ch == '\'') {
+            in_string = !in_string;
+        }
+
+        if !in_string && ch == '/' {
+            in_regex = !in_regex;
+        }
+
+        if !in_string && !in_regex {
+            match ch {
+                '(' | '{' | '[' => depth += 1,
+                ')' | '}' | ']' => depth -= 1,
+                ';' if depth == 0 => return i,
+                _ => {}
+            }
+        }
+
+        if depth < 0 {
+            return i;
+        }
+    }
+
+    return_content.len()
+}
+
+fn expand_inline_helpers(return_expr: &str, helpers: &IndexMap<String, InlineHelper>) -> String {
+    let mut expanded = return_expr.to_string();
+
+    for (helper_name, helper) in helpers {
+        let call_pattern = format!("{}(", helper_name);
+        if !expanded.contains(&call_pattern) {
+            continue;
+        }
+
+        eprintln!(
+            "Debug: Expanding helper '{}' in return expression",
+            helper_name
+        );
+
+        if let Some(next_expr) = expand_first_helper_call(&expanded, &call_pattern, helper) {
+            expanded = next_expr;
+            eprintln!("Debug: New return expression: '{}'", expanded);
+        }
+    }
+
+    expanded
+}
+
+fn expand_first_helper_call(
+    return_expr: &str,
+    call_pattern: &str,
+    helper: &InlineHelper,
+) -> Option<String> {
+    let call_start = return_expr.find(call_pattern)?;
+    let args_start = call_start + call_pattern.len();
+    let arg_end = find_helper_argument_end(return_expr, args_start)?;
+    let arg = &return_expr[args_start..arg_end];
+    eprintln!("Debug: Helper argument: '{}'", arg);
+
+    let expanded_body = helper.body.replace(&helper.param_name, arg);
+    eprintln!("Debug: Expanded body: '{}'", expanded_body);
+
+    let mut result = String::new();
+    result.push_str(&return_expr[..call_start]);
+    result.push_str(&expanded_body);
+    result.push_str(&return_expr[arg_end + 1..]);
+    Some(result)
+}
+
+fn find_helper_argument_end(expr: &str, args_start: usize) -> Option<usize> {
+    let mut depth = 1;
+
+    for (i, ch) in expr.char_indices().skip_while(|(i, _)| *i < args_start) {
+        match ch {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(i);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ParsedFunctionBlock, parse};
+
+    #[test]
+    fn extracts_return_expression_until_top_level_semicolon() {
+        let block = r#"{
+            return seq($.left, choice(';', /a;b/), $.right);
+        }"#;
+
+        let parsed = parse(block).unwrap();
+
+        match parsed {
+            ParsedFunctionBlock::ReturnExpression(expr) => {
+                assert_eq!(expr, "seq($.left, choice(';', /a;b/), $.right)");
+            }
+            ParsedFunctionBlock::PlaceholderChoice => panic!("expected return expression"),
+        }
+    }
+
+    #[test]
+    fn expands_simple_inline_helper_call() {
+        let block = r#"{
+            const commaSep = (rule) => seq(rule, repeat(seq(',', rule)));
+            return commaSep($.item);
+        }"#;
+
+        let parsed = parse(block).unwrap();
+
+        match parsed {
+            ParsedFunctionBlock::ReturnExpression(expr) => {
+                assert_eq!(expr, "seq($.item, repeat(seq(',', $.item)))");
+            }
+            ParsedFunctionBlock::PlaceholderChoice => panic!("expected return expression"),
+        }
+    }
+
+    #[test]
+    fn reports_table_definitions_as_placeholder_choices() {
+        let block = r#"{
+            const table = [[$.a, $.b]];
+            return choice(...table.map(([left, right]) => seq(left, right)));
+        }"#;
+
+        let parsed = parse(block).unwrap();
+
+        assert!(matches!(parsed, ParsedFunctionBlock::PlaceholderChoice));
+    }
+}

--- a/tool/src/grammar_js/parser_v3/lexing.rs
+++ b/tool/src/grammar_js/parser_v3/lexing.rs
@@ -1,0 +1,170 @@
+use anyhow::{Result, bail};
+
+/// Extracts content until the matching delimiter while respecting strings and regex literals.
+pub(super) fn extract_balanced_delim(content: &str, open: char, close: char) -> Result<String> {
+    let chars: Vec<char> = content.chars().collect();
+    let mut depth = 1;
+    let mut pos = 0;
+
+    while pos < chars.len() && depth > 0 {
+        let ch = chars[pos];
+
+        if ch == '\'' || ch == '"' || ch == '`' {
+            pos = skip_quoted_literal(&chars, pos, ch);
+        } else if ch == '/' && pos + 1 < chars.len() && is_regex_literal_start(&chars, pos) {
+            pos = skip_regex_literal(&chars, pos);
+        } else {
+            if ch == open {
+                depth += 1;
+            } else if ch == close {
+                depth -= 1;
+            }
+            pos += 1;
+        }
+    }
+
+    if depth == 0 {
+        Ok(content[..pos - 1].to_string())
+    } else {
+        bail!("Unbalanced {} and {} in content", open, close)
+    }
+}
+
+/// Splits top-level comma-separated arguments while preserving nested expressions.
+pub(super) fn split_args(content: &str, expected: i32) -> Result<Vec<String>> {
+    let mut splitter = ArgSplitter::default();
+
+    for ch in content.chars() {
+        splitter.accept(ch);
+    }
+
+    let args = splitter.finish();
+    if expected > 0 && args.len() != expected as usize {
+        bail!("Expected {} arguments, got {}", expected, args.len());
+    }
+
+    Ok(args)
+}
+
+fn skip_quoted_literal(chars: &[char], start: usize, quote: char) -> usize {
+    let mut pos = start + 1;
+
+    while pos < chars.len() {
+        if chars[pos] == '\\' {
+            pos += 2;
+        } else if chars[pos] == quote {
+            return pos + 1;
+        } else {
+            pos += 1;
+        }
+    }
+
+    pos
+}
+
+fn is_regex_literal_start(chars: &[char], pos: usize) -> bool {
+    pos > 0
+        && "[,({:;=\n ".contains(chars[pos - 1])
+        && chars[pos + 1] != '/'
+        && chars[pos + 1] != '*'
+}
+
+fn skip_regex_literal(chars: &[char], start: usize) -> usize {
+    let mut pos = start + 1;
+
+    while pos < chars.len() {
+        if chars[pos] == '\\' {
+            pos += 2;
+        } else if chars[pos] == '/' {
+            return pos + 1;
+        } else {
+            pos += 1;
+        }
+    }
+
+    pos
+}
+
+#[derive(Default)]
+struct ArgSplitter {
+    args: Vec<String>,
+    current: String,
+    depth: i32,
+    in_string: bool,
+    string_char: char,
+    escape_next: bool,
+}
+
+impl ArgSplitter {
+    fn accept(&mut self, ch: char) {
+        if self.escape_next {
+            self.escape_next = false;
+            self.current.push(ch);
+        } else if ch == '\\' {
+            self.escape_next = true;
+            self.current.push(ch);
+        } else if !self.in_string && (ch == '\'' || ch == '"' || ch == '`') {
+            self.in_string = true;
+            self.string_char = ch;
+            self.current.push(ch);
+        } else if self.in_string && ch == self.string_char {
+            self.in_string = false;
+            self.current.push(ch);
+        } else if !self.in_string {
+            self.accept_unquoted(ch);
+        } else {
+            self.current.push(ch);
+        }
+    }
+
+    fn accept_unquoted(&mut self, ch: char) {
+        match ch {
+            '(' | '[' | '{' => {
+                self.depth += 1;
+                self.current.push(ch);
+            }
+            ')' | ']' | '}' => {
+                self.depth -= 1;
+                self.current.push(ch);
+            }
+            ',' if self.depth == 0 => self.flush_current(),
+            _ => self.current.push(ch),
+        }
+    }
+
+    fn flush_current(&mut self) {
+        self.args.push(self.current.trim().to_string());
+        self.current.clear();
+    }
+
+    fn finish(mut self) -> Vec<String> {
+        if !self.current.trim().is_empty() {
+            self.flush_current();
+        }
+        self.args
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{extract_balanced_delim, split_args};
+
+    #[test]
+    fn splits_only_top_level_arguments() {
+        let args = split_args("$.left, choice(',', seq($.middle, $.right)), $.tail", 3).unwrap();
+
+        assert_eq!(
+            args,
+            vec!["$.left", "choice(',', seq($.middle, $.right))", "$.tail"]
+        );
+    }
+
+    #[test]
+    fn extracts_balanced_delimiter_content_around_nested_syntax() {
+        let content = "seq($.left, choice(')', /a\\)/), $.right))";
+
+        let extracted = extract_balanced_delim(content, '(', ')').unwrap();
+
+        assert_eq!(extracted, "seq($.left, choice(')', /a\\)/), $.right)");
+    }
+}


### PR DESCRIPTION
## Summary

Refactors `GrammarJsParserV3` by moving JavaScript function-block parsing and reusable lexing helpers into focused `parser_v3` submodules.

## Linked context

- Release lane: 0.9 contract convergence / SRP surface cleanup
- Related batch PRs: #720 covered only function-block extraction; this PR carries that useful test coverage while also extracting shared lexing helpers.

## Production delta

- Adds `tool/src/grammar_js/parser_v3/function_block.rs` for table-definition detection, return-expression extraction, inline helper collection, and helper expansion.
- Adds `tool/src/grammar_js/parser_v3/lexing.rs` for balanced-delimiter extraction and top-level argument splitting.
- Leaves `GrammarJsParserV3` as the orchestration facade and preserves existing parse behavior.
- Adds module-level tests for function-block extraction, placeholder table handling, inline helper expansion, balanced delimiter extraction, and argument splitting.

## Non-goals

- No Grammar.js semantic expansion beyond existing behavior.
- No converter refactor from the sibling batch.
- No runtime decoder refactor from the sibling batch.
- No release/support-tier claim promotion.

## Source-of-truth impact

- Roadmap: unchanged.
- Proposal/spec/ADR: unchanged.
- Plan: supports the 0.9 SRP cleanup direction but does not change plan state.
- Active manifest: unchanged.
- Support tiers: unchanged.
- Policy ledger: unchanged.

## Proof commands

```bash
cargo test -p adze-tool grammar_js::parser_v3 --lib -- --nocapture
cargo test -p adze-tool --lib -- --nocapture
cargo fmt -p adze-tool -- --check
cargo clippy -p adze-tool --all-targets -- -D warnings
git diff --check
```

## Rollback

Revert this PR to restore the parser_v3 helper logic inline in `tool/src/grammar_js/parser_v3.rs`.