### PR TITLE
chore: bump workspace MSRV to Rust 1.95

### DIFF
--- a/.adze/goals/active.toml
+++ b/.adze/goals/active.toml
@@ -155,26 +155,40 @@ commands = [
 
 [[work_item]]
 id = "rust-1.95-msrv-bump"
+status = "complete"
+proposal = "docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md"
+spec = ""
+adr = ""
+plan = "plans/0.9.0/rust-1.95.md"
+blocked_by = []
+prs = [760]
+commands = [
+  "cargo metadata --format-version 1 --no-deps",
+  "cargo run -q -p xtask -- check-lint-policy",
+  "cargo test -p xtask doctor -j 1 -- --nocapture",
+  "cargo test -p xtask lint_policy -j 1 -- --nocapture",
+  "cargo test -p adze-parsetable-metadata -- --test-threads=2",
+  "cargo clippy -p adze -p adze-macro -p adze-tool -p adze-common -p adze-ir -p adze-glr-core -p adze-tablegen --all-targets -- -D warnings",
+  "cargo run -q -p xtask -- check-package-boundary --release-gate",
+  "cargo fmt -p adze -- --check",
+  "cargo fmt -p adze-tool -- --check",
+  "cargo fmt -p adze-ir -- --check",
+  "cargo fmt -p adze-glr-core -- --check",
+  "cargo fmt -p adze-macro -- --check",
+  "cargo fmt -p adze-tablegen -- --check",
+  "cargo fmt -p xtask -p adze-parsetable-metadata -- --check",
+  "git diff --check",
+  "just ci-supported",
+]
+
+[[work_item]]
+id = "clippy-policy-refresh"
 status = "ready"
 proposal = "docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md"
 spec = ""
 adr = ""
 plan = "plans/0.9.0/implementation-plan.md"
 blocked_by = []
-prs = []
-commands = [
-  "just check-msrv",
-  "just ci-supported",
-]
-
-[[work_item]]
-id = "clippy-policy-refresh"
-status = "blocked"
-proposal = "docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md"
-spec = ""
-adr = ""
-plan = "plans/0.9.0/implementation-plan.md"
-blocked_by = ["rust-1.95-msrv-bump"]
 prs = []
 commands = [
   "cargo run -q -p xtask -- check-lint-policy",

--- a/.github/CI_LANES.md
+++ b/.github/CI_LANES.md
@@ -58,7 +58,7 @@ These jobs run on push to `main`, on schedules, or via `workflow_dispatch` with 
 | `ci.yml` | `Deterministic Codegen` | Push only | Push | Verifies build determinism |
 | `ci.yml` | `Feature Matrix` | Push only | Push | Per-crate feature matrix checks |
 | `ci.yml` | `Feature Matrix Extras` | Push only | Push | Feature powerset via cargo-hack |
-| `ci.yml` | `MSRV (1.92.0)` | Push only | Push | Minimum Supported Rust Version check |
+| `ci.yml` | `MSRV (1.95.0)` | Push only | Push | Minimum Supported Rust Version check |
 | `ci.yml` | `Security & Supply Chain` | Push only | Push | `cargo deny check` |
 | `ci.yml` | `Documentation` | Push only | Push | `cargo doc --workspace` with `-D warnings` |
 | `ci.yml` | `adze-python (Optimized Build)` | Push only | Push | Python grammar build + test |

--- a/.github/CI_README.md
+++ b/.github/CI_README.md
@@ -18,7 +18,7 @@ The CI pipeline ensures code quality, API stability, and security through multip
 2. **Lint** - Enforces code formatting and clippy warnings
 3. **Test** - Runs all tests using cargo-nextest for speed
 4. **Feature Matrix** - Tests all feature combinations
-5. **MSRV** - Ensures compatibility with Rust 1.92.0
+5. **MSRV** - Ensures compatibility with Rust 1.95.0
 6. **API Stability** - Detects breaking changes in public APIs
 7. **Security** - Scans for vulnerabilities and license issues
 8. **Documentation** - Builds docs with warnings as errors

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,12 +1,12 @@
 # Copilot Instructions — Adze
 
-Adze is an AST-first grammar toolchain for Rust. Rust 2024 edition, MSRV 1.92.0, 75-crate workspace.
+Adze is an AST-first grammar toolchain for Rust. Rust 2024 edition, MSRV 1.95.0, 28-crate workspace.
 
 ## Code Conventions
 
 ### Edition and Language
 - Rust 2024 edition — use `gen` keyword awareness, `unsafe_op_in_unsafe_fn` is denied
-- All crates inherit `edition = "2024"` and `rust-version = "1.92.0"` from workspace
+- All crates inherit `edition = "2024"` and `rust-version = "1.95.0"` from workspace
 - Dependencies use `workspace = true` in per-crate Cargo.toml:
   ```toml
   [dependencies]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -623,11 +623,11 @@ jobs:
 
   msrv:
     if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.run_full_ci)
-    name: MSRV (1.92.0)
+    name: MSRV (1.95.0)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
-      - uses: dtolnay/rust-toolchain@1.92.0
+      - uses: dtolnay/rust-toolchain@1.95.0
       - uses: Swatinem/rust-cache@v2
         with:
           key: msrv

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.92.0"
+          toolchain: "1.95.0"
           components: llvm-tools-preview
 
       - name: Use larger target dir

--- a/.github/workflows/ripr.yml
+++ b/.github/workflows/ripr.yml
@@ -48,18 +48,19 @@ jobs:
           echo "head=$HEAD_SHA" >> "$GITHUB_OUTPUT"
       - name: Install ripr (advisory, graceful on failure)
         id: ripr-install
-        # ripr requires Rust 1.93+; adze MSRV stays at 1.92.0. Keep both the
-        # isolated toolchain install and ripr install on the graceful path.
+        # ripr requires Rust 1.93+. Install through the workspace MSRV toolchain
+        # and keep the advisory install on a graceful path.
         run: |
           set -euo pipefail
-          if rustup toolchain install 1.93 --no-self-update --profile minimal --quiet \
-            && cargo +1.93 install --locked ripr 2>/dev/null; then
+          TOOLCHAIN="$(sed -n 's/^channel = "\(.*\)"$/\1/p' rust-toolchain.toml)"
+          if rustup toolchain install "$TOOLCHAIN" --no-self-update --profile minimal --quiet \
+            && cargo +"$TOOLCHAIN" install --locked ripr 2>/dev/null; then
             echo "available=true" >> "$GITHUB_OUTPUT"
             ripr --version || true
           else
             # ripr may not yet be published to crates.io; keep graceful fallback.
             echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "ripr or Rust 1.93 install unavailable; using stub report."
+            echo "ripr or workspace toolchain install unavailable; using stub report."
           fi
       - name: Run ripr (advisory)
         if: steps.ripr-install.outputs.available == 'true'
@@ -102,8 +103,8 @@ jobs:
             echo "## ripr advisory";
             echo "";
             if [ "${{ steps.ripr-install.outputs.available }}" = "true" ]; then
-              echo "- ripr installed via Rust 1.93 toolchain; analysis ran on \`${{ steps.shas.outputs.base }}..${{ steps.shas.outputs.head }}\`."
+              echo "- ripr installed via the workspace MSRV toolchain; analysis ran on \`${{ steps.shas.outputs.base }}..${{ steps.shas.outputs.head }}\`."
             else
-              echo "- ripr install attempted (Rust 1.93, cargo install --locked ripr) but not available yet; stub report uploaded."
+              echo "- ripr install attempted with the workspace MSRV toolchain, but was not available yet; stub report uploaded."
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,8 @@ Instructions for autonomous AI agents (OpenAI Codex, etc.) working on this repos
 Adze is an AST-first grammar toolchain for Rust. It generates Tree-sitter parsers from Rust type annotations using a pure-Rust GLR implementation.
 
 - **Language**: Rust 2024 edition
-- **MSRV**: 1.92.0
-- **Workspace**: 75 crates
+- **MSRV**: 1.95.0
+- **Workspace**: 28 crates
 - **Command runner**: `just` (see `justfile`)
 
 ## Setup
@@ -17,7 +17,7 @@ The toolchain is auto-configured via `rust-toolchain.toml` — no manual Rust in
 
 ```bash
 # Verify toolchain
-rustc --version   # Should be >= 1.92.0
+rustc --version   # Should be >= 1.95.0
 just --version    # Command runner
 
 # System dependency (only needed for ts-bridge)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ just policy                # Run all policy-stack checks (advisory)
 ## Requirements
 
 ### Minimum Rust Version (MSRV)
-- **Rust 1.92.0** or later
+- **Rust 1.95.0** or later
 - **Rust 2024 Edition** - all workspace crates use the latest edition
 - Components: `rustfmt`, `clippy` (automatically configured via `rust-toolchain.toml`)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thank you for your interest in contributing! This guide covers everything you ne
 # 1. Fork and clone
 git clone https://github.com/<you>/adze.git && cd adze
 
-# 2. Toolchain installs automatically via rust-toolchain.toml (Rust 1.92+)
+# 2. Toolchain installs automatically via rust-toolchain.toml (Rust 1.95+)
 rustup show  # verify toolchain
 
 # 3. Build
@@ -25,7 +25,7 @@ cargo fmt --all --check && cargo clippy --all -- -D warnings
 
 ## Prerequisites
 
-- **Rust 1.92.0+** with `rustfmt` and `clippy` (configured via `rust-toolchain.toml`)
+- **Rust 1.95.0+** with `rustfmt` and `clippy` (configured via `rust-toolchain.toml`)
 - **jq** for crate-aware checks
 - **rg** (ripgrep) — optional but recommended
 - **libtree-sitter-dev** — only needed for the `ts-bridge` tool

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ homepage = "https://github.com/effortlessmetrics/adze"
 license = "Apache-2.0 OR MIT"
 publish = false
 repository = "https://github.com/effortlessmetrics/adze"
-rust-version = "1.92.0"
+rust-version = "1.95.0"
 
 
 [workspace.lints.rust]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Codecov](https://codecov.io/gh/EffortlessMetrics/adze/graph/badge.svg?branch=main)](https://codecov.io/gh/EffortlessMetrics/adze)
 [![Crates.io](https://img.shields.io/crates/v/adze)](https://crates.io/crates/adze)
 [![docs.rs](https://img.shields.io/docsrs/adze)](https://docs.rs/adze)
-[![MSRV](https://img.shields.io/badge/MSRV-1.92-blue)](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)
+[![MSRV](https://img.shields.io/badge/MSRV-1.95-blue)](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](LICENSE-MIT)
 
 **Your grammar is your AST.** Formerly `rust-sitter`.

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adze-common"
 version = "0.8.0-dev"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.95.0"
 authors = ["Steven Zimmerman, CPA"]
 description = "Shared grammar expansion logic for the Adze macro and tool crates"
 license = "Apache-2.0 OR MIT"

--- a/crates/parsetable-metadata/benches/metadata_bench.rs
+++ b/crates/parsetable-metadata/benches/metadata_bench.rs
@@ -16,7 +16,7 @@ fn sample_metadata() -> ParsetableMetadata {
         generation: GenerationInfo {
             timestamp: "2025-01-15T12:00:00Z".to_string(),
             tool_version: "0.1.0".to_string(),
-            rust_version: "1.92.0".to_string(),
+            rust_version: "1.95.0".to_string(),
             host_triple: "x86_64-unknown-linux-gnu".to_string(),
         },
         statistics: TableStatistics {

--- a/crates/parsetable-metadata/src/lib.rs
+++ b/crates/parsetable-metadata/src/lib.rs
@@ -61,7 +61,7 @@ pub enum ParsetableError {
 ///     generation: GenerationInfo {
 ///         timestamp: "2025-01-01T00:00:00Z".into(),
 ///         tool_version: "0.1.0".into(),
-///         rust_version: "1.92.0".into(),
+///         rust_version: "1.95.0".into(),
 ///         host_triple: "x86_64-unknown-linux-gnu".into(),
 ///     },
 ///     statistics: TableStatistics {
@@ -257,7 +257,7 @@ mod tests {
             generation: GenerationInfo {
                 timestamp: "2025-01-01T00:00:00Z".to_string(),
                 tool_version: "0.1.0".to_string(),
-                rust_version: "1.92.0".to_string(),
+                rust_version: "1.95.0".to_string(),
                 host_triple: "x86_64-unknown-linux-gnu".to_string(),
             },
             statistics: TableStatistics {
@@ -292,7 +292,7 @@ mod tests {
             generation: GenerationInfo {
                 timestamp: "2025-01-01T00:00:00Z".to_string(),
                 tool_version: "0.1.0".to_string(),
-                rust_version: "1.92.0".to_string(),
+                rust_version: "1.95.0".to_string(),
                 host_triple: "x86_64-unknown-linux-gnu".to_string(),
             },
             statistics: TableStatistics {

--- a/crates/parsetable-metadata/tests/bdd_parsetable_metadata.rs
+++ b/crates/parsetable-metadata/tests/bdd_parsetable_metadata.rs
@@ -192,14 +192,14 @@ fn given_generation_info_when_creating_then_holds_values() {
     let info = GenerationInfo {
         timestamp: "2025-01-01T00:00:00Z".to_string(),
         tool_version: "0.1.0".to_string(),
-        rust_version: "1.92.0".to_string(),
+        rust_version: "1.95.0".to_string(),
         host_triple: "x86_64-unknown-linux-gnu".to_string(),
     };
 
     // When / Then
     assert_eq!(info.timestamp, "2025-01-01T00:00:00Z");
     assert_eq!(info.tool_version, "0.1.0");
-    assert_eq!(info.rust_version, "1.92.0");
+    assert_eq!(info.rust_version, "1.95.0");
     assert_eq!(info.host_triple, "x86_64-unknown-linux-gnu");
 }
 
@@ -209,7 +209,7 @@ fn given_generation_info_when_serializing_then_roundtrips() {
     let info = GenerationInfo {
         timestamp: "2025-06-15T12:30:00Z".to_string(),
         tool_version: "0.2.0".to_string(),
-        rust_version: "1.93.0".to_string(),
+        rust_version: "1.96.0".to_string(),
         host_triple: "aarch64-apple-darwin".to_string(),
     };
 
@@ -238,7 +238,7 @@ fn given_full_metadata_when_serializing_then_roundtrips() {
         generation: GenerationInfo {
             timestamp: "2025-01-01T00:00:00Z".to_string(),
             tool_version: "0.1.0".to_string(),
-            rust_version: "1.92.0".to_string(),
+            rust_version: "1.95.0".to_string(),
             host_triple: "x86_64-unknown-linux-gnu".to_string(),
         },
         statistics: TableStatistics {
@@ -278,7 +278,7 @@ fn given_metadata_with_optional_fields_when_serializing_then_roundtrips() {
         generation: GenerationInfo {
             timestamp: "2025-01-01T00:00:00Z".to_string(),
             tool_version: "0.1.0".to_string(),
-            rust_version: "1.92.0".to_string(),
+            rust_version: "1.95.0".to_string(),
             host_triple: "x86_64-unknown-linux-gnu".to_string(),
         },
         statistics: TableStatistics {
@@ -318,7 +318,7 @@ fn given_metadata_when_using_from_bytes_then_parses_correctly() {
         generation: GenerationInfo {
             timestamp: "2025-01-01T00:00:00Z".to_string(),
             tool_version: "0.1.0".to_string(),
-            rust_version: "1.92.0".to_string(),
+            rust_version: "1.95.0".to_string(),
             host_triple: "x86_64-unknown-linux-gnu".to_string(),
         },
         statistics: TableStatistics {

--- a/crates/parsetable-metadata/tests/comprehensive.rs
+++ b/crates/parsetable-metadata/tests/comprehensive.rs
@@ -36,7 +36,7 @@ fn sample_metadata() -> ParsetableMetadata {
         generation: GenerationInfo {
             timestamp: "2025-01-01T00:00:00Z".into(),
             tool_version: "0.1.0".into(),
-            rust_version: "1.92.0".into(),
+            rust_version: "1.95.0".into(),
             host_triple: "x86_64-unknown-linux-gnu".into(),
         },
         statistics: TableStatistics {
@@ -120,7 +120,7 @@ fn generation_info_fields() {
     let g = GenerationInfo {
         timestamp: "now".into(),
         tool_version: "0.1".into(),
-        rust_version: "1.92".into(),
+        rust_version: "1.95.0".into(),
         host_triple: "x86_64".into(),
     };
     assert_eq!(g.timestamp, "now");

--- a/crates/parsetable-metadata/tests/contract_lock.rs
+++ b/crates/parsetable-metadata/tests/contract_lock.rs
@@ -46,7 +46,7 @@ fn test_contract_lock_types() {
     let _generation = GenerationInfo {
         timestamp: "2025-01-01T00:00:00Z".into(),
         tool_version: "0.1.0".into(),
-        rust_version: "1.92.0".into(),
+        rust_version: "1.95.0".into(),
         host_triple: "x86_64-unknown-linux-gnu".into(),
     };
 
@@ -77,7 +77,7 @@ fn test_contract_lock_types() {
         generation: GenerationInfo {
             timestamp: "2025-01-01T00:00:00Z".into(),
             tool_version: "0.1.0".into(),
-            rust_version: "1.92.0".into(),
+            rust_version: "1.95.0".into(),
             host_triple: "x86_64-unknown-linux-gnu".into(),
         },
         statistics: TableStatistics {
@@ -110,7 +110,7 @@ fn test_contract_lock_metadata_methods() {
         generation: GenerationInfo {
             timestamp: "2025-01-01T00:00:00Z".into(),
             tool_version: "0.1.0".into(),
-            rust_version: "1.92.0".into(),
+            rust_version: "1.95.0".into(),
             host_triple: "x86_64-unknown-linux-gnu".into(),
         },
         statistics: TableStatistics {
@@ -179,7 +179,7 @@ fn test_contract_lock_serde_roundtrip() {
     let generation = GenerationInfo {
         timestamp: "2025-06-15T12:00:00Z".into(),
         tool_version: "0.8.0".into(),
-        rust_version: "1.92.0".into(),
+        rust_version: "1.95.0".into(),
         host_triple: "aarch64-unknown-linux-gnu".into(),
     };
     let json = serde_json::to_string(&generation).unwrap();

--- a/crates/parsetable-metadata/tests/serde_roundtrip.rs
+++ b/crates/parsetable-metadata/tests/serde_roundtrip.rs
@@ -17,7 +17,7 @@ fn sample_generation_info() -> GenerationInfo {
     GenerationInfo {
         timestamp: "2025-01-15T12:00:00Z".to_string(),
         tool_version: "0.1.0".to_string(),
-        rust_version: "1.92.0".to_string(),
+        rust_version: "1.95.0".to_string(),
         host_triple: "x86_64-unknown-linux-gnu".to_string(),
     }
 }
@@ -243,7 +243,7 @@ fn deserialize_metadata_missing_optional_fields() {
         "generation": {
             "timestamp": "2025-01-01T00:00:00Z",
             "tool_version": "0.1.0",
-            "rust_version": "1.92.0",
+            "rust_version": "1.95.0",
             "host_triple": "x86_64-unknown-linux-gnu"
         },
         "statistics": {

--- a/crates/ts-c-harness/Cargo.toml
+++ b/crates/ts-c-harness/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adze-ts-c-harness"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.92.0"
+rust-version = "1.95.0"
 license = "Apache-2.0 OR MIT"
 description = "Internal Tree-sitter C FFI parity test harness."
 repository = "https://github.com/EffortlessMetrics/adze"

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -5,7 +5,7 @@
 ## Prerequisites
 
 ### System Requirements
-- **Rust 1.92.0+** (2024 edition support)
+- **Rust 1.95.0+** (2024 edition support)
 - **Node.js**: Required for `tree-sitter` CLI compatibility (legacy/C backend only)
 - **C Compiler**: Required for `tree-sitter` C integration
 - **just**: Command runner (optional but recommended)

--- a/docs/agent-context/review-invariants.md
+++ b/docs/agent-context/review-invariants.md
@@ -5,7 +5,7 @@ Invariants that must hold in all code submitted to this repository.
 ## Type System
 1. **Extract trait usage**: All grammar types implement `Extract` correctly
 2. **No orphaned derives**: Macro derives are paired with type definitions
-3. **MSRV compliance**: Code compiles with Rust 1.92.0 (check `rust-version` in Cargo.toml)
+3. **MSRV compliance**: Code compiles with Rust 1.95.0 (check `rust-version` in Cargo.toml)
 4. **Edition consistency**: All crates use Rust 2024 edition
 
 ## Parser Behavior

--- a/docs/ci/adze-rollout-status.md
+++ b/docs/ci/adze-rollout-status.md
@@ -21,7 +21,7 @@ execution, refresh with `gh pr list` and the current workflow state.
 | F03 | PR Plan workflow (`pr-plan.yml`) | ✅ | Calls `xtask ci-plan`, emits `ci-plan.json` with outputs `docs_only`, `estimated_lem`, `band` |
 | F04 | PR Gate Success workflow (`pr-gate.yml`) | ✅ | Supported Gate + Docs Gate + `PR Gate Success` aggregator |
 | F05 | ci-actuals telemetry scaffold | ✅ | `scripts/ci/emit-ci-actuals.py` emits plan vs actual; uploaded as artifact |
-| F06 | ripr advisory (`ripr.yml`) | ✅ | Advisory install attempts run on an isolated Rust 1.93 toolchain and fall back to a stub report on install failure |
+| F06 | ripr advisory (`ripr.yml`) | ✅ | Advisory install attempts run on the workspace MSRV toolchain and fall back to a stub report on install failure |
 
 ## Control plane
 
@@ -30,7 +30,7 @@ execution, refresh with `gh pr list` and the current workflow state.
 | C01 | CI policy workflow (`ci-policy.yml`) | ✅ | Runs `check-ci-lane-whitelist --mode advisory` on every PR |
 | C02 | Synchronize-only cancellation | ✅ | PR #563 merged — prevents label events from killing running jobs |
 | C03 | Lane whitelist cost alignment | ✅ | PR #564 merged — corrects stale LEM for already-gated lanes |
-| C04 | Real ripr provisioning | ✅ | PR #565 merged — isolated Rust 1.93 install with graceful stub fallback |
+| C04 | Real ripr provisioning | ✅ | PR #565 merged — graceful stub fallback remains; install now uses the workspace MSRV toolchain |
 | C05 | Benchmark deduplication | ✅ | PR #566 merged — `performance-check` gated to `ci:perf` label |
 
 ## Routing
@@ -58,7 +58,7 @@ execution, refresh with `gh pr list` and the current workflow state.
 
 | # | Item | Status | Notes |
 | --- | --- | --- | --- |
-| T01 | MSRV 1.93 | ⏳ | PR: `policy/msrv-1-93` — dedicated policy PR, prerequisite for ripr simplification |
+| T01 | MSRV 1.95 | 🟡 | Dedicated policy PR after microcrate collapse; unblocks Clippy policy refresh |
 
 ## Branch protection
 

--- a/docs/ci/inventory.md
+++ b/docs/ci/inventory.md
@@ -22,7 +22,7 @@ See `adze-rollout-status.md` for status of each item.
 | `pr-plan.yml` | Reusable; computes LEM/band/docs_only from `xtask ci-plan` | Active |
 | `pr-gate.yml` | Aggregates Supported + Docs Gate → `PR Gate Success` | Active |
 | `ci-policy.yml` | CI lane whitelist advisory lint | Active |
-| `ripr.yml` | ripr advisory with isolated Rust 1.93 install and stub fallback | Active advisory |
+| `ripr.yml` | ripr advisory with workspace MSRV install and stub fallback | Active advisory |
 | `fuzz.yml` | Label/push/schedule-gated runtime fuzz; build smoke on parser/glr PRs | Active |
 | `pure-rust-ci.yml` | Matrix-setup: ubuntu/stable on default PR; full matrix on labels/main | Active |
 | `golden-tests.yml` | Grammar-path and `ci:golden`/`full-ci` label gated | Active |

--- a/docs/ci/ripr.md
+++ b/docs/ci/ripr.md
@@ -18,17 +18,16 @@ PR, never on docs-only PRs, never on `merge_group`, and is configured with
 
 ## MSRV and provisioning
 
-Adze pins `rust-toolchain.toml` to `1.92.0`. `ripr` requires `1.93+`. We
-do not bump MSRV for this advisory check. Provisioning options, in order
-of preference:
+Adze pins `rust-toolchain.toml` to `1.95.0`. `ripr` requires `1.93+`, so the
+advisory workflow can use the workspace MSRV toolchain. Provisioning options,
+in order of preference:
 
 1. **Pinned prebuilt binary** — drop a `ripr` binary on the runner via a
    release asset URL or self-hosted artifact mirror.
-2. **Isolated toolchain** — install a `1.93` toolchain only for the ripr
-   step using `dtolnay/rust-toolchain@stable` with a different `with:
-   toolchain:` value, then `cargo install --locked --root /opt/ripr ripr`.
-3. **MSRV bump** — once the workspace MSRV moves past `1.93`, install
-   normally via `cargo install --locked ripr`.
+2. **Workspace toolchain** — install through the pinned MSRV toolchain with
+   `cargo install --locked ripr`.
+3. **Stub report** — if install fails, upload a skipped advisory report rather
+   than blocking the PR.
 
 Until one of those is wired in, the workflow detects the absence of `ripr`
 and emits a stub `ripr-report.json` with `"status": "skipped"`. The

--- a/docs/tutorials/glr-quickstart.md
+++ b/docs/tutorials/glr-quickstart.md
@@ -37,7 +37,7 @@ adze-tablegen = { version = "0.8.0-dev", features = ["serialization"] }
 
 ### System Requirements
 
-- **Rust**: 1.92.0 or later (Rust 2024 Edition)
+- **Rust**: 1.95.0 or later (Rust 2024 Edition)
 - **Disk Space**: ~100-500 KB per grammar (depends on grammar size)
 - **Memory**: Minimal overhead (~1-2 MB for typical grammars)
 
@@ -249,7 +249,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
   "generation": {
     "timestamp": "2025-11-20T15:30:00Z",
     "tool_version": "0.8.0-dev",
-    "rust_version": "1.92.0",
+    "rust_version": "1.95.0",
     "host_triple": "x86_64-unknown-linux-gnu"
   },
   "statistics": {

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -3,7 +3,7 @@ name = "adze-fuzz"
 version = "0.0.0"
 publish = false
 edition = "2024"
-rust-version = "1.92.0"
+rust-version = "1.95.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/glr-core/Cargo.toml
+++ b/glr-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adze-glr-core"
 version = "0.8.0-dev"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.95.0"
 description = "GLR parser generation algorithms for pure-Rust Tree-sitter"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/effortlessmetrics/adze"

--- a/glr-core/tests/proptest_first_follow_v5.rs
+++ b/glr-core/tests/proptest_first_follow_v5.rs
@@ -806,11 +806,10 @@ fn reachable_terminals(g: &Grammar, nt: SymbolId) -> Vec<u16> {
                         Symbol::Terminal(id) => {
                             terminals.push(id.0);
                         }
-                        Symbol::NonTerminal(id) => {
-                            if visited.insert(*id) {
-                                queue.push_back(*id);
-                            }
+                        Symbol::NonTerminal(id) if visited.insert(*id) => {
+                            queue.push_back(*id);
                         }
+                        Symbol::NonTerminal(_) => {}
                         _ => {}
                     }
                 }

--- a/ir/Cargo.toml
+++ b/ir/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adze-ir"
 version = "0.8.0-dev"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.95.0"
 description = "Grammar Intermediate Representation for pure-Rust Tree-sitter"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/effortlessmetrics/adze"

--- a/ir/tests/optimizer_proptest.rs
+++ b/ir/tests/optimizer_proptest.rs
@@ -81,9 +81,8 @@ fn build_left_recursive_grammar(grammar_name: &str, op_count: usize) -> Grammar 
         },
     );
 
-    let mut next_tok = 2u16;
     let mut op_ids = Vec::new();
-    for i in 0..op_count.max(1) {
+    for (next_tok, i) in (2u16..).zip(0..op_count.max(1)) {
         let id = SymbolId(next_tok);
         grammar.tokens.insert(
             id,
@@ -94,14 +93,12 @@ fn build_left_recursive_grammar(grammar_name: &str, op_count: usize) -> Grammar 
             },
         );
         op_ids.push(id);
-        next_tok += 1;
     }
 
     let expr_id = SymbolId(100);
     grammar.rule_names.insert(expr_id, "expr".to_string());
 
-    let mut prod_id = 0u16;
-    for op in &op_ids {
+    for (prod_id, op) in op_ids.iter().enumerate() {
         grammar.add_rule(Rule {
             lhs: expr_id,
             rhs: vec![
@@ -112,9 +109,8 @@ fn build_left_recursive_grammar(grammar_name: &str, op_count: usize) -> Grammar 
             precedence: None,
             associativity: None,
             fields: vec![],
-            production_id: ProductionId(prod_id),
+            production_id: ProductionId(prod_id as u16),
         });
-        prod_id += 1;
     }
 
     // Base case: expr -> number
@@ -124,7 +120,7 @@ fn build_left_recursive_grammar(grammar_name: &str, op_count: usize) -> Grammar 
         precedence: None,
         associativity: None,
         fields: vec![],
-        production_id: ProductionId(prod_id),
+        production_id: ProductionId(op_ids.len() as u16),
     });
 
     grammar

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adze-macro"
 version = "0.8.0-dev"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.95.0"
 authors = ["Steven Zimmerman, CPA"]
 description = "Procedural macros for defining tree-sitter grammars alongside Rust logic"
 license = "Apache-2.0 OR MIT"

--- a/macro/tests/extra_annotation_proptest.rs
+++ b/macro/tests/extra_annotation_proptest.rs
@@ -847,11 +847,10 @@ proptest! {
                         }
                     }
                 }
-                Item::Enum(e) => {
-                    if e.attrs.iter().any(|a| is_adze_attr(a, "language")) {
-                        *found.entry("language".to_string()).or_insert(0usize) += 1;
-                    }
+                Item::Enum(e) if e.attrs.iter().any(|a| is_adze_attr(a, "language")) => {
+                    *found.entry("language".to_string()).or_insert(0usize) += 1;
                 }
+                Item::Enum(_) => {}
                 _ => {}
             }
         }

--- a/macro/tests/extra_attribute_proptest.rs
+++ b/macro/tests/extra_attribute_proptest.rs
@@ -959,11 +959,10 @@ proptest! {
                         }
                     }
                 }
-                Item::Enum(e) => {
-                    if e.attrs.iter().any(|a| is_adze_attr(a, "language")) {
-                        *found.entry("language".to_string()).or_insert(0usize) += 1;
-                    }
+                Item::Enum(e) if e.attrs.iter().any(|a| is_adze_attr(a, "language")) => {
+                    *found.entry("language".to_string()).or_insert(0usize) += 1;
                 }
+                Item::Enum(_) => {}
                 _ => {}
             }
         }

--- a/plans/0.9.0/implementation-plan.md
+++ b/plans/0.9.0/implementation-plan.md
@@ -432,7 +432,7 @@ entry.
 
 ## Work Item: rust-1.95-msrv-bump
 
-Status: ready
+Status: complete
 Linked proposal: ../../docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md
 Linked spec:
 Linked ADR:
@@ -445,8 +445,8 @@ Bump workspace MSRV/toolchain policy after the package graph is smaller.
 
 ### Production Delta
 
-Expected later changes include toolchain files, manifest `rust-version` fields,
-CI setup, docs, and any xtask doctor or policy checks that enforce MSRV.
+Changed toolchain files, manifest `rust-version` fields, CI setup, docs, and
+xtask doctor/lint policy checks that enforce MSRV.
 
 ### Non-Goals
 
@@ -459,7 +459,21 @@ All MSRV declarations agree and the supported gate is green.
 ### Proof Commands
 
 ```bash
-just check-msrv
+cargo metadata --format-version 1 --no-deps
+cargo run -q -p xtask -- check-lint-policy
+cargo test -p xtask doctor -j 1 -- --nocapture
+cargo test -p xtask lint_policy -j 1 -- --nocapture
+cargo test -p adze-parsetable-metadata -- --test-threads=2
+cargo clippy -p adze -p adze-macro -p adze-tool -p adze-common -p adze-ir -p adze-glr-core -p adze-tablegen --all-targets -- -D warnings
+cargo run -q -p xtask -- check-package-boundary --release-gate
+cargo fmt -p adze -- --check
+cargo fmt -p adze-tool -- --check
+cargo fmt -p adze-ir -- --check
+cargo fmt -p adze-glr-core -- --check
+cargo fmt -p adze-macro -- --check
+cargo fmt -p adze-tablegen -- --check
+cargo fmt -p xtask -p adze-parsetable-metadata -- --check
+git diff --check
 just ci-supported
 ```
 
@@ -469,12 +483,12 @@ Revert the MSRV bump PR.
 
 ## Work Item: clippy-policy-refresh
 
-Status: blocked
+Status: ready
 Linked proposal: ../../docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md
 Linked spec:
 Linked ADR:
 Blocks: product-proof-refresh
-Blocked by: rust-1.95-msrv-bump
+Blocked by: none
 
 ### Goal
 

--- a/plans/0.9.0/rust-1.95.md
+++ b/plans/0.9.0/rust-1.95.md
@@ -1,0 +1,65 @@
+# 0.9 Rust 1.95 MSRV Bump
+
+Status: complete
+Owner: release/toolchain
+Created: 2026-05-14
+Linked proposal: ../../docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md
+Linked plan: ./implementation-plan.md
+Active goal: ../../.adze/goals/active.toml
+
+## Goal
+
+Bump the workspace MSRV and pinned toolchain from Rust 1.92.0 to Rust 1.95.0
+after the microcrate-to-SRP package collapse reduced the release surface.
+
+## Production Delta
+
+- `rust-toolchain.toml` pins `1.95.0`.
+- `[workspace.package].rust-version` is `1.95.0`.
+- `policy/clippy-lints.toml` records policy MSRV `1.95`.
+- `xtask doctor` checks Rust 1.95.0.
+- CI jobs with fixed MSRV toolchains use Rust 1.95.0.
+- User/operator docs advertise Rust 1.95.0.
+
+## Non-Goals
+
+- No Clippy lint promotion in this PR.
+- No parser/runtime behavior changes.
+- No support-tier product claim promotion.
+
+## Acceptance
+
+All workspace MSRV declarations agree. CI uses the new pinned MSRV where a
+fixed toolchain is required. The Clippy policy refresh becomes the next ready
+work item.
+
+## Proof Commands
+
+```bash
+cargo metadata --format-version 1 --no-deps
+cargo run -q -p xtask -- check-lint-policy
+cargo test -p xtask doctor -j 1 -- --nocapture
+cargo test -p xtask lint_policy -j 1 -- --nocapture
+cargo test -p adze-parsetable-metadata -- --test-threads=2
+cargo clippy -p adze -p adze-macro -p adze-tool -p adze-common -p adze-ir -p adze-glr-core -p adze-tablegen --all-targets -- -D warnings
+cargo run -q -p xtask -- check-package-boundary --release-gate
+cargo fmt -p adze -- --check
+cargo fmt -p adze-tool -- --check
+cargo fmt -p adze-ir -- --check
+cargo fmt -p adze-glr-core -- --check
+cargo fmt -p adze-macro -- --check
+cargo fmt -p adze-tablegen -- --check
+cargo fmt -p xtask -p adze-parsetable-metadata -- --check
+git diff --check
+```
+
+The hosted required gate remains:
+
+```bash
+just ci-supported
+```
+
+## Rollback
+
+Revert the MSRV/toolchain PR and restore all `1.92.0` / `1.92` policy
+references.

--- a/policy/ci-lane-whitelist.toml
+++ b/policy/ci-lane-whitelist.toml
@@ -143,7 +143,7 @@ proof_obligation = "Run ripr in diff mode and emit JSON/SARIF report."
 evidence = ["target/ripr/ripr-report.json"]
 allowed_triggers = ["pull_request", "workflow_dispatch"]
 duplicate_of = []
-provisioning_note = "Stub (no-op) until ripr binary provisioned via isolated Rust 1.93 toolchain. See PR ci/ripr-provision and docs/ci/ripr.md."
+provisioning_note = "Stub (no-op) until ripr binary provisioned via workspace MSRV toolchain. See docs/ci/ripr.md."
 review_after = "2026-06-07"
 expires = "2026-11-07"
 

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -1,5 +1,5 @@
 schema_version = "1.0"
-msrv = "1.92"
+msrv = "1.95"
 
 # This file is the source of truth for the workspace lint policy.
 # It is *documentation + manifest*. Actual enforcement happens through:

--- a/policy/doc-artifacts.toml
+++ b/policy/doc-artifacts.toml
@@ -202,6 +202,16 @@ source_of_truth_for = ["microcrate to SRP submodule transition sequence"]
 links_to = ["ADZE-PROP-0001", "ADZE-SPEC-0001", "ADZE-ADR-0002", ".adze/goals/active.toml", "policy/package-boundary.toml"]
 
 [[artifact]]
+id = "plans/0.9.0/rust-1.95.md"
+kind = "plan"
+path = "plans/0.9.0/rust-1.95.md"
+status = "complete"
+owner = "release/toolchain"
+milestone = "0.9.0"
+source_of_truth_for = ["Rust 1.95 MSRV bump"]
+links_to = ["ADZE-PROP-0001", ".adze/goals/active.toml", "plans/0.9.0/implementation-plan.md"]
+
+[[artifact]]
 id = "plans/0.9.0/api-foundation.md"
 kind = "plan"
 path = "plans/0.9.0/api-foundation.md"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adze"
 version = "0.8.0-dev"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.95.0"
 authors = ["Steven Zimmerman, CPA"]
 description = "Define tree-sitter grammars alongside Rust logic with AST-first parsing"
 license = "Apache-2.0 OR MIT"

--- a/runtime/src/document.rs
+++ b/runtime/src/document.rs
@@ -1515,7 +1515,7 @@ fn build_diagnostics(root: &ParseNode, error_count: usize, source: &str) -> Vec<
         return Vec::new();
     }
 
-    let span = first_error_span(root).unwrap_or_else(|| root.start_byte..root.end_byte);
+    let span = first_error_span(root).unwrap_or(root.start_byte..root.end_byte);
     let start_byte = span.start.min(source.len());
     let end_byte = span.end.min(source.len()).max(start_byte);
     let point_range = PointRange::from_byte_range(source, start_byte..end_byte);

--- a/runtime/src/optimizations.rs
+++ b/runtime/src/optimizations.rs
@@ -52,11 +52,7 @@ impl PerfStats {
         let hits = self.cache_hits.load(Ordering::Relaxed);
         let misses = self.cache_misses.load(Ordering::Relaxed);
 
-        let avg_time_us = if calls > 0 {
-            (time_ns / calls) / 1000
-        } else {
-            0
-        };
+        let avg_time_us = time_ns.checked_div(calls).unwrap_or(0) / 1000;
         let throughput_mb_s = if time_ns > 0 {
             (bytes as f64 / (1024.0 * 1024.0)) / (time_ns as f64 / 1_000_000_000.0)
         } else {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.92.0"
+channel = "1.95.0"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/samples/downstream-demo/Cargo.toml
+++ b/samples/downstream-demo/Cargo.toml
@@ -3,7 +3,7 @@ name = "downstream-demo"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.95.0"
 publish = false
 
 [dependencies]

--- a/tablegen/Cargo.toml
+++ b/tablegen/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adze-tablegen"
 version = "0.8.0-dev"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.95.0"
 description = "Table generation and compression for pure-Rust Tree-sitter"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/effortlessmetrics/adze"

--- a/tablegen/src/lexer_gen.rs
+++ b/tablegen/src/lexer_gen.rs
@@ -70,7 +70,7 @@ pub fn generate_lexer(
     }
 
     // Sort keywords by length (longest first)
-    keywords.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+    keywords.sort_by_key(|(_, keyword)| std::cmp::Reverse(keyword.len()));
 
     let mut token_matches = Vec::new();
 

--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adze-tool"
 version = "0.8.0-dev"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.95.0"
 authors = ["Steven Zimmerman, CPA"]
 description = "Build-time code generation tool for Adze grammar definitions"
 license = "Apache-2.0 OR MIT"

--- a/tool/src/grammar_js/mod.rs
+++ b/tool/src/grammar_js/mod.rs
@@ -187,11 +187,10 @@ impl GrammarJs {
 
     fn validate_rule(&self, rule: &Rule, context: &str) -> Result<()> {
         match rule {
-            Rule::Symbol { name } => {
-                if !self.rules.contains_key(name) && !self.is_external(name) {
-                    bail!("Symbol '{}' referenced in '{}' not found", name, context);
-                }
+            Rule::Symbol { name } if !self.rules.contains_key(name) && !self.is_external(name) => {
+                bail!("Symbol '{}' referenced in '{}' not found", name, context);
             }
+            Rule::Symbol { .. } => {}
             Rule::Seq { members } | Rule::Choice { members } => {
                 for member in members {
                     self.validate_rule(member, context)?;

--- a/tools/ts-bridge/Cargo.toml
+++ b/tools/ts-bridge/Cargo.toml
@@ -3,7 +3,7 @@ name = "ts-bridge"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
 edition = "2024"
-rust-version = "1.92.0"
+rust-version = "1.95.0"
 
 [lib]
 crate-type = ["rlib", "cdylib"]

--- a/xtask/src/doctor.rs
+++ b/xtask/src/doctor.rs
@@ -6,7 +6,7 @@
 use anyhow::Result;
 use std::process::Command;
 
-const MSRV: &str = "1.92.0";
+const MSRV: &str = "1.95.0";
 
 struct CheckResult {
     name: &'static str,
@@ -206,8 +206,8 @@ fn check_wasm32_target() -> CheckResult {
     }
 }
 
-/// Minimal semver parser: returns (major, minor, patch) from "1.92.0" style strings.
-/// Handles trailing metadata like "1.92.0 (hash date)" or "1.92.0-nightly".
+/// Minimal semver parser: returns (major, minor, patch) from "1.95.0" style strings.
+/// Handles trailing metadata like "1.95.0 (hash date)" or "1.95.0-nightly".
 fn parse_semver(s: &str) -> Option<(u32, u32, u32)> {
     let s = s.split(&[' ', '(', '-'][..]).next()?;
     let mut parts = s.split('.');
@@ -231,23 +231,23 @@ mod tests {
 
     #[test]
     fn parse_semver_accepts_stable_and_prerelease_rustc_versions() {
-        assert_eq!(parse_semver("1.92.0"), Some((1, 92, 0)));
-        assert_eq!(parse_semver("1.93.0-nightly"), Some((1, 93, 0)));
-        assert_eq!(parse_semver("1.92.0 (abcdef 2026-01-01)"), Some((1, 92, 0)));
-        assert_eq!(parse_semver("1.92"), Some((1, 92, 0)));
+        assert_eq!(parse_semver("1.95.0"), Some((1, 95, 0)));
+        assert_eq!(parse_semver("1.96.0-nightly"), Some((1, 96, 0)));
+        assert_eq!(parse_semver("1.95.0 (abcdef 2026-01-01)"), Some((1, 95, 0)));
+        assert_eq!(parse_semver("1.95"), Some((1, 95, 0)));
     }
 
     #[test]
     fn parse_semver_rejects_invalid_versions() {
-        assert_eq!(parse_semver("rustc 1.92.0"), None);
+        assert_eq!(parse_semver("rustc 1.95.0"), None);
         assert_eq!(parse_semver("not-a-version"), None);
         assert_eq!(parse_semver("1.x.0"), None);
     }
 
     #[test]
     fn meets_msrv_compares_against_workspace_msrv() {
-        assert!(!meets_msrv("1.91.9"));
-        assert!(meets_msrv("1.92.0"));
-        assert!(meets_msrv("1.93.0-nightly"));
+        assert!(!meets_msrv("1.94.9"));
+        assert!(meets_msrv("1.95.0"));
+        assert!(meets_msrv("1.96.0-nightly"));
     }
 }

--- a/xtask/src/policy/lint_policy.rs
+++ b/xtask/src/policy/lint_policy.rs
@@ -236,20 +236,20 @@ mod tests {
 
     #[test]
     fn version_compare_works() {
-        assert!(version_geq("1.93.0", "1.92"));
-        assert!(version_geq("1.93.0", "1.93"));
-        assert!(!version_geq("1.92.0", "1.93"));
+        assert!(version_geq("1.96.0", "1.95"));
+        assert!(version_geq("1.95.0", "1.95"));
+        assert!(!version_geq("1.94.0", "1.95"));
     }
 
     #[test]
     fn extract_kv_handles_spaced_assignment() {
-        let text = "rust-version = \"1.92.0\"\nother = 1\n";
-        assert_eq!(extract_kv(text, "rust-version").as_deref(), Some("1.92.0"));
+        let text = "rust-version = \"1.95.0\"\nother = 1\n";
+        assert_eq!(extract_kv(text, "rust-version").as_deref(), Some("1.95.0"));
     }
 
     #[test]
     fn extract_kv_handles_tight_assignment() {
-        let text = "channel=\"1.92.0\"\n";
-        assert_eq!(extract_kv(text, "channel").as_deref(), Some("1.92.0"));
+        let text = "channel=\"1.95.0\"\n";
+        assert_eq!(extract_kv(text, "channel").as_deref(), Some("1.95.0"));
     }
 }


### PR DESCRIPTION
## Summary

Bumps the Adze workspace MSRV and pinned toolchain to Rust 1.95.0 after the microcrate-to-SRP collapse reduced the release surface.

## Linked artifacts

- Proposal: `docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md`
- Spec: none
- ADR: none
- Plan: `plans/0.9.0/rust-1.95.md`, `plans/0.9.0/implementation-plan.md`
- Active goal item: `rust-1.95-msrv-bump`

## Production delta

- Pins `rust-toolchain.toml` and workspace `rust-version` declarations to `1.95.0`.
- Updates the lint policy MSRV and `xtask doctor`/lint policy tests.
- Updates fixed CI toolchain references, ripr advisory provisioning docs, and user/operator docs.
- Updates parsetable metadata sample fixtures to report the new compiler baseline.
- Applies Rust 1.95 Clippy fallout fixes across the supported gate crates and affected tests.
- Marks the MSRV work item complete and makes `clippy-policy-refresh` ready.

## Non-goals

- No parser/runtime behavior changes beyond mechanical Rust 1.95 lint compliance.
- No broad Clippy policy promotion in this PR.
- No support-tier product claim promotion.

## Source-of-truth impact

- Roadmap: unchanged.
- Proposal: linked to ADZE-PROP-0001.
- Spec: unchanged.
- ADR: unchanged.
- Plan: adds `plans/0.9.0/rust-1.95.md` and updates the 0.9 implementation plan.
- Active manifest: marks `rust-1.95-msrv-bump` complete and unblocks `clippy-policy-refresh`.
- Support tiers: unchanged.
- Policy ledger: updates `policy/clippy-lints.toml`, `policy/doc-artifacts.toml`, and CI lane provisioning notes.

## User impact

Users and downstream maintainers see one consistent Rust 1.95.0 baseline across manifests, docs, CI, and operator instructions.

## Agent impact

Agents can treat the Rust 1.95 bump as complete and move to the Clippy policy refresh work item without scraping chat history.

## Proof commands

```bash
python -c "import tomllib; [tomllib.load(open(p,'rb')) for p in ['Cargo.toml','policy/clippy-lints.toml','policy/doc-artifacts.toml','.adze/goals/active.toml','policy/ci-lane-whitelist.toml']]"
cargo metadata --format-version 1 --no-deps
cargo run -q -p xtask -- check-lint-policy
cargo run -q -p xtask -- check-ci-lane-whitelist
cargo run -q -p xtask -- ci-plan
cargo run -q -p xtask -- check-package-boundary
cargo run -q -p xtask -- check-package-boundary --release-gate
cargo test -p xtask doctor -j 1 -- --nocapture
cargo test -p xtask lint_policy -j 1 -- --nocapture
cargo test -p xtask ci_plan -j 1 -- --nocapture
cargo test -p adze-parsetable-metadata -- --test-threads=2
cargo clippy -p adze -p adze-macro -p adze-tool -p adze-common -p adze-ir -p adze-glr-core -p adze-tablegen --all-targets -- -D warnings
cargo fmt -p adze -- --check
cargo fmt -p adze-tool -- --check
cargo fmt -p adze-ir -- --check
cargo fmt -p adze-glr-core -- --check
cargo fmt -p adze-macro -- --check
cargo fmt -p adze-tablegen -- --check
cargo fmt -p xtask -p adze-parsetable-metadata -- --check
git diff --check
```

Local note: `cargo fmt --all --check` fails on this Windows host with `os error 206` before formatting due command-line/path length. The touched Rust packages pass targeted format checks. The hosted required gate remains `just ci-supported`.

## Rollback

Revert this PR to restore the Rust 1.92.0 toolchain/MSRV declarations, lint policy MSRV, CI provisioning text, Rust 1.95 Clippy cleanup, and parsetable metadata fixture baseline.