### PR TITLE
docs: encode SRP release gate state

### DIFF
--- a/.adze/goals/active.toml
+++ b/.adze/goals/active.toml
@@ -131,7 +131,7 @@ spec = "docs/specs/ADZE-SPEC-0001-package-surface-boundary.md"
 adr = "docs/adr/ADZE-ADR-0002-no-durable-unpublished-production-crates.md"
 plan = "plans/0.9.0/microcrate-collapse.md"
 blocked_by = []
-prs = [696, 697, 729, 730, 731, 732, 733, 734, 735, 736, 737, 738, 740, 741, 742, 743, 744, 745, 746, 747, 748, 749, 750, 751, 752, 753, 754, 755, 756, 757, 758]
+prs = [696, 697, 729, 730, 731, 732, 733, 734, 735, 736, 737, 738, 740, 741, 742, 743, 744, 745, 746, 747, 748, 749, 750, 751, 752, 753, 754, 755, 756, 757, 758, 759]
 commands = [
   "cargo metadata --format-version 1 --no-deps",
   "cargo run -q -p xtask -- check-package-boundary",
@@ -147,7 +147,7 @@ spec = "docs/specs/ADZE-SPEC-0001-package-surface-boundary.md"
 adr = "docs/adr/ADZE-ADR-0002-no-durable-unpublished-production-crates.md"
 plan = "plans/0.9.0/microcrate-collapse.md"
 blocked_by = []
-prs = [738, 758]
+prs = [738, 758, 759]
 commands = [
   "cargo run -q -p xtask -- check-package-boundary --release-gate",
   "PACKAGE_BOUNDARY_RELEASE_GATE=1 ./scripts/validate-release-surface.sh",

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # Adze Roadmap
 
 **Current Version:** 0.8.0
-**MSRV:** 1.92 (Rust 2024 edition)
+**MSRV:** 1.95 (Rust 2024 edition)
 
 Adze (formerly `rust-sitter`) is a Rust-native grammar toolchain that turns Rust type definitions into high-performance GLR parse machinery.
 
@@ -42,26 +42,25 @@ Adze (formerly `rust-sitter`) is a Rust-native grammar toolchain that turns Rust
 
 ## 🚀 Milestone 0.9.0: Ecosystem & Tooling (Current)
 
-### Prerequisite: microcrate-to-SRP collapse
+### Completed prerequisite: microcrate-to-SRP collapse
 
-The `crates/` directory currently holds 56 governance/BDD/concurrency/tooling
-support crate directories. Before 0.9.0 ships, these should be audited and
-collapsed where a separate crate no longer has a current, proven boundary.
-The eventual release surface should stay tight, with implementation-only
-support code absorbed into SRP submodules under the crates or xtask tooling that
-actually use it.
+The release-blocking microcrate-to-SRP transition is complete. The post-collapse
+workspace has 28 packages and zero `owner-module-migration-target` entries in
+`policy/package-boundary.toml`.
 
-**Why before 0.9.0:** a workspace graph this wide is a maintenance and CI
-economics commitment that is very hard to walk back. Collapsing before the MSRV
-bump and clippy lint promotions also avoids touching twice as many Cargo.toml
-files.
+This remains a release gate, not just a historical cleanup. Before 0.9.0 ships,
+the release candidate must keep both package-boundary commands green:
 
-**Target shape — two categories only:**
+```bash
+cargo run -q -p xtask -- check-package-boundary
+cargo run -q -p xtask -- check-package-boundary --release-gate
+```
 
-1. **Public surfaces** — crates that ship on crates.io and have a stable API.
-2. **Internal seams** — crates kept separate only where the isolation genuinely
-   improves compile times, test isolation, or ownership boundaries between
-   existing public surfaces. Not "might be useful someday" — real, current benefit.
+The release surface should stay tight: implementation-only support code belongs
+in SRP submodules under the crate or xtask tooling that actually owns it. A
+standalone crate remains acceptable only when it is a published public surface,
+a durable published support surface recorded by ADR, or genuine dev-only
+tooling.
 
 Current supported/publishable core remains seven crates until a follow-up
 implementation PR changes Cargo metadata, release scripts, support docs, and CI
@@ -77,28 +76,19 @@ routing together.
 | `adze-glr-core` | GLR parser generation | publishable supported core | evaluate internal seam after public API/release impact review |
 | `adze-tablegen` | table compression, FFI generation | publishable supported core | evaluate internal seam after codegen/release impact review |
 
-Everything else — governance, BDD, concurrency, policy, grammar-analysis,
-linecol, stack-pool, etc. — should either be inlined into the crate that
-actually uses it as an SRP submodule or move into xtask as dev-only tooling. If
-it doesn't have a current consumer outside its own directory, it doesn't get its
-own crate.
-
-**Steps:**
-
-1. Audit which support crates have external dependents outside xtask.
-2. Inline single-use microcrates into their single consumer.
-3. Merge microcrate groups (governance-*, bdd-*, concurrency-*, parser-*, feature-policy-*) into one module per group under xtask or the consuming crate.
-4. Remove the now-empty microcrate directories.
-5. Update workspace members, CI routing, and `justfile`.
-6. Run `just check-msrv` and `just ci-supported`.
+The collapse record lives in `plans/0.9.0/microcrate-collapse.md`. The durable
+architecture rule lives in
+`docs/adr/ADZE-ADR-0002-no-durable-unpublished-production-crates.md`: there is
+no release-state category for unpublished production microcrates.
 
 ### Release blockers
 
-- [ ] Microcrate collapse/audit complete with Cargo metadata, CI routing, and support docs updated
-- [ ] MSRV bump to 1.95 (toolchain, Cargo.toml, CI, docs, xtask doctor)
+- [x] Microcrate collapse/audit complete with Cargo metadata, CI routing, and support docs updated
+- [x] MSRV bump to 1.95 (toolchain, Cargo.toml, CI, docs, xtask doctor)
 - [ ] Clippy planned-lint activation (6 lints gated on 1.94/1.95)
-- [ ] Non-Rust file allowlist reconciled against new structure
-- [ ] CI economics update (LEM estimates reflect new workspace shape)
+- [x] Non-Rust file allowlist reconciled against new structure
+- [x] CI economics update (LEM estimates reflect new workspace shape)
+- [ ] Product-proof refresh maps stable README claims to current proof commands
 
 ### Other 0.9.0 work
 - **Post-release hardening**: Finish narrowing workflow-only red and restore any proof surfaces trimmed only for publication.

--- a/docs/ci/adze-rollout-status.md
+++ b/docs/ci/adze-rollout-status.md
@@ -1,6 +1,6 @@
 # CI Economics Rollout Status
 
-Last review: 2026-05-08.
+Last review: 2026-05-14.
 
 This file is a status snapshot, not a live source of truth. Before using it for
 execution, refresh with `gh pr list` and the current workflow state.
@@ -58,7 +58,7 @@ execution, refresh with `gh pr list` and the current workflow state.
 
 | # | Item | Status | Notes |
 | --- | --- | --- | --- |
-| T01 | MSRV 1.95 | 🟡 | Dedicated policy PR after microcrate collapse; unblocks Clippy policy refresh |
+| T01 | MSRV 1.95 | ✅ | PR #760 landed after the microcrate collapse; Clippy policy refresh is the next lint ratchet |
 
 ## Branch protection
 

--- a/glr-test-support/Cargo.toml
+++ b/glr-test-support/Cargo.toml
@@ -14,6 +14,7 @@ adze-ir = { path = "../ir" }
 proptest = { workspace = true }
 
 [features]
+strict_docs = []
 perf-counters = ["adze-glr-core/perf-counters"]
 
 [lib]

--- a/plans/0.9.0/implementation-plan.md
+++ b/plans/0.9.0/implementation-plan.md
@@ -39,12 +39,12 @@ and review cycle for each single-document branch.
 Superseded stacked PRs #683 through #686 were closed after #692 landed.
 
 The microcrate-to-SRP submodule transition is tracked in
-`microcrate-collapse.md`. That release blocker is complete as of PR #758: no
-`owner-module-migration-target` entries remain and the package-boundary release
-gate is expected to stay green. The API foundation spec stack is tracked
-separately in `api-foundation.md`. It encodes the runtime/API build sequence so
-follow-up implementation PRs can be executed from source-of-truth artifacts
-rather than chat history.
+`microcrate-collapse.md`. That release blocker was completed by PR #758 and
+closed out by PR #759: no `owner-module-migration-target` entries remain and
+the package-boundary release gate is expected to stay green. The API foundation
+spec stack is tracked separately in `api-foundation.md`. It encodes the
+runtime/API build sequence so follow-up implementation PRs can be executed from
+source-of-truth artifacts rather than chat history.
 
 ## Work Item: source-of-truth-scaffolding
 

--- a/plans/0.9.0/microcrate-collapse.md
+++ b/plans/0.9.0/microcrate-collapse.md
@@ -19,13 +19,13 @@ This is a release prerequisite, not a documentation preference. A package can
 remain a standalone crate at release only when it is a published surface or a
 durable dev-only/tooling surface with a current owner and proof rationale.
 
-The release-blocking transition is complete as of PR #758. This plan remains as
-the closeout record and as the release-gate contract for keeping migration
-targets out of the release surface.
+The release-blocking transition was completed by PR #758 and closed out by PR
+#759. This plan remains as the closeout record and as the release-gate contract
+for keeping migration targets out of the release surface.
 
 ## Current State
 
-As of the post-collapse workspace after PR #758:
+As of the post-collapse workspace after PR #759:
 
 ```text
 workspace packages: 28


### PR DESCRIPTION
## Summary

Aligns the 0.9 source-of-truth docs with the completed microcrate-to-SRP transition and fixes a docs-lane feature declaration exposed by the PR.

## Linked artifacts

- Proposal: `docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md`
- Spec: `docs/specs/ADZE-SPEC-0001-package-surface-boundary.md`
- ADR: `docs/adr/ADZE-ADR-0002-no-durable-unpublished-production-crates.md`
- Plan: `plans/0.9.0/microcrate-collapse.md`
- Active goal item: `microcrate-collapse`, `package-boundary-release-gate`

## Production delta

- Updates `ROADMAP.md` so the microcrate-to-SRP collapse is recorded as complete but still release-gated.
- Records PR #759 as the closeout PR in the active manifest and 0.9 plans.
- Refreshes the CI rollout status for the Rust 1.95 bump now that #760 landed.
- Declares the existing `glr-test-support` `strict_docs` feature so docs builds with `-D warnings` do not fail on `unexpected_cfgs`.

## Non-goals

- No runtime behavior changes.
- No package-boundary ledger changes.
- No support-tier promotion.
- No clippy-policy activation.

## Source-of-truth impact

- Roadmap: refreshed release-blocker state and MSRV.
- Proposal/spec/ADR: unchanged, linked from existing plans.
- Plan: records #759 closeout and keeps the release gate explicit.
- Active manifest: adds #759 to completed release-gate work.
- Support tiers: unchanged.
- Policy ledger: unchanged.

## User impact

Users and maintainers can see that the package graph collapse is no longer open-ended release work; the remaining obligation is to keep the package-boundary release gate green.

## Agent impact

Agents should move on to `clippy-policy-refresh` and `product-proof-refresh` rather than re-planning the completed microcrate transition.

## Proof commands

```bash
python -c "import tomllib; tomllib.load(open('policy/package-boundary.toml','rb')); tomllib.load(open('policy/doc-artifacts.toml','rb')); tomllib.load(open('.adze/goals/active.toml','rb')); print('toml ok')"
python -c "import tomllib; tomllib.load(open('glr-test-support/Cargo.toml','rb')); tomllib.load(open('.adze/goals/active.toml','rb')); print('toml ok')"
cargo run -q -p xtask -- check-package-boundary --release-gate
RUSTDOCFLAGS='-D warnings' cargo doc -p glr-test-support --all-features --no-deps
git diff --check
```

Note: `PACKAGE_BOUNDARY_RELEASE_GATE=1 ./scripts/validate-release-surface.sh` was not run locally because this Windows shell does not expose `bash`/`jq` in `PATH`; the package-boundary release-gate condition it wraps passed.

## Rollback

Revert this commit.
