### PR TITLE
policy: promote MSRV clippy lint batch

### DIFF
--- a/.adze/goals/active.toml
+++ b/.adze/goals/active.toml
@@ -183,16 +183,21 @@ commands = [
 
 [[work_item]]
 id = "clippy-policy-refresh"
-status = "ready"
+status = "complete"
 proposal = "docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md"
 spec = ""
 adr = ""
 plan = "plans/0.9.0/implementation-plan.md"
 blocked_by = []
-prs = []
+prs = [762]
 commands = [
   "cargo run -q -p xtask -- check-lint-policy",
+  "cargo test -p xtask lint_policy -j 1 -- --nocapture",
+  "cargo clippy -p xtask --all-targets -- -D warnings",
   "just clippy",
+  "cargo clippy -p adze -p adze-macro -p adze-tool -p adze-common -p adze-ir -p adze-glr-core -p adze-tablegen --all-targets -- -D warnings",
+  "cargo run -q -p xtask -- check-package-boundary --release-gate",
+  "git diff --check",
   "just ci-supported",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,12 @@ const_item_interior_mutations = "deny"
 
 [workspace.lints.clippy]
 allow_attributes_without_reason = "deny"
+decimal_bitwise_operands = "warn"
+disallowed_fields = "deny"
+manual_checked_ops = "warn"
+manual_ilog2 = "warn"
+needless_type_cast = "warn"
+same_length_and_capacity = "deny"
 
 [workspace.dependencies]
 tree-sitter = "=0.26.7"

--- a/plans/0.9.0/implementation-plan.md
+++ b/plans/0.9.0/implementation-plan.md
@@ -497,15 +497,21 @@ workspace churn.
 
 ### Production Delta
 
-Expected later changes:
+This work item activates the Rust 1.94/1.95 planned Clippy lint batch after the
+workspace has moved to Rust 1.95 and the package surface has been collapsed.
 
-- `../../policy/clippy-lints.toml`
-- lint verifier updates
-- targeted code fixes where required
+- `../../Cargo.toml` promotes the lint levels in `[workspace.lints.clippy]`.
+- `../../policy/clippy-lints.toml` moves the due planned lints into active
+  policy.
+- `../../xtask/src/policy/lint_policy.rs` verifies active policy matches
+  Cargo workspace lint declarations and fails overdue planned lints.
+- Targeted test/code cleanups make bit-mask operands visually explicit.
 
 ### Non-Goals
 
-No broad refactors hidden behind lint updates.
+No broad refactors hidden behind lint updates. This slice enables the
+`disallowed_fields` lint level but does not add a protected-field inventory;
+that belongs in a later seam-specific policy PR.
 
 ### Acceptance
 
@@ -516,7 +522,12 @@ rather than used to avoid straightforward cleanup.
 
 ```bash
 cargo run -q -p xtask -- check-lint-policy
+cargo test -p xtask lint_policy -j 1 -- --nocapture
+cargo clippy -p xtask --all-targets -- -D warnings
 just clippy
+cargo clippy -p adze -p adze-macro -p adze-tool -p adze-common -p adze-ir -p adze-glr-core -p adze-tablegen --all-targets -- -D warnings
+cargo run -q -p xtask -- check-package-boundary --release-gate
+git diff --check
 just ci-supported
 ```
 

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -29,6 +29,12 @@ const_item_interior_mutations = "deny"
 
 [active.clippy]
 allow_attributes_without_reason = "deny"
+decimal_bitwise_operands = "warn"
+disallowed_fields = "deny"
+manual_checked_ops = "warn"
+manual_ilog2 = "warn"
+needless_type_cast = "warn"
+same_length_and_capacity = "deny"
 
 # Staged lints — currently advisory in the semantic checker. Plan:
 #   stage 1 (now): warn here, semantic checker is advisory
@@ -47,39 +53,5 @@ indexing_slicing = { level = "warn", target = "deny", stage = 1 }
 string_slice = { level = "warn", target = "deny", stage = 1 }
 dbg_macro = { level = "warn", target = "deny", stage = 1 }
 
-# Planned lints — gated on MSRV bumps.
-[[planned]]
-name = "clippy::same_length_and_capacity"
-level = "deny"
-activate_when_msrv = "1.94"
-reason = "Catch raw-parts reconstruction mistakes."
-
-[[planned]]
-name = "clippy::manual_ilog2"
-level = "warn"
-activate_when_msrv = "1.94"
-reason = "Prefer the standard integer log helper."
-
-[[planned]]
-name = "clippy::decimal_bitwise_operands"
-level = "warn"
-activate_when_msrv = "1.94"
-reason = "Make bit masks visually inspectable."
-
-[[planned]]
-name = "clippy::needless_type_cast"
-level = "warn"
-activate_when_msrv = "1.94"
-reason = "Avoid stale numeric type drift."
-
-[[planned]]
-name = "clippy::disallowed_fields"
-level = "deny"
-activate_when_msrv = "1.95"
-reason = "Ban direct field access across protected seams."
-
-[[planned]]
-name = "clippy::manual_checked_ops"
-level = "warn"
-activate_when_msrv = "1.95"
-reason = "Prefer checked arithmetic over manual divide-by-zero guards."
+# Planned lints — gated on future MSRV bumps. The Rust 1.94/1.95 lint batch is
+# active as of the 0.9 Clippy policy refresh.

--- a/runtime/tests/test_c_api_compat.rs
+++ b/runtime/tests/test_c_api_compat.rs
@@ -103,16 +103,18 @@ fn test_parse_table_format() {
     const ACTIONS_ACCEPT: u16 = 2;
     #[allow(dead_code)]
     const ACTIONS_RECOVER: u16 = 3;
+    const SHIFT_STATE: u16 = 0x002a;
+    const REDUCE_RULE: u16 = 0x0007;
 
     // Action encoding uses top 2 bits for type
-    let shift_action = (ACTIONS_SHIFT << 14) | 42; // Shift to state 42
-    let reduce_action = (ACTIONS_REDUCE << 14) | 7; // Reduce by rule 7
+    let shift_action = (ACTIONS_SHIFT << 14) | SHIFT_STATE;
+    let reduce_action = (ACTIONS_REDUCE << 14) | REDUCE_RULE;
 
     assert_eq!(shift_action >> 14, ACTIONS_SHIFT);
-    assert_eq!(shift_action & 0x3FFF, 42);
+    assert_eq!(shift_action & 0x3FFF, SHIFT_STATE);
 
     assert_eq!(reduce_action >> 14, ACTIONS_REDUCE);
-    assert_eq!(reduce_action & 0x3FFF, 7);
+    assert_eq!(reduce_action & 0x3FFF, REDUCE_RULE);
 }
 
 /// Test symbol ID compatibility

--- a/tablegen/src/abi_builder.rs
+++ b/tablegen/src/abi_builder.rs
@@ -1731,7 +1731,7 @@ mod tests {
 
         // Reduce (1-based in Tree-sitter)
         let enc = builder.encode_action(&Action::Reduce(RuleId(3))).unwrap();
-        assert_eq!(enc, 0x8000 | 4, "Reduce(3) → 0x8004");
+        assert_eq!(enc, 0x8000 | 0x0004, "Reduce(3) -> 0x8004");
 
         // Accept
         let enc = builder.encode_action(&Action::Accept).unwrap();

--- a/tablegen/tests/bit_pack_adv_v9.rs
+++ b/tablegen/tests/bit_pack_adv_v9.rs
@@ -765,7 +765,7 @@ fn bpa_v9_compressor_encode_reduce() {
     let tc = TableCompressor::new();
     let encoded = tc.encode_action_small(&Action::Reduce(RuleId(5))).unwrap();
     // Reduce: bit 15 set, 1-based rule ID
-    assert_eq!(encoded, 0x8000 | 6);
+    assert_eq!(encoded, 0x8000 | 0x0006);
 }
 
 // =============================================================================

--- a/tablegen/tests/compress_v9.rs
+++ b/tablegen/tests/compress_v9.rs
@@ -238,7 +238,7 @@ fn tc_encode_shift_overflow_errors() {
 fn tc_encode_reduce_zero() {
     let tc = TableCompressor::new();
     let encoded = tc.encode_action_small(&Action::Reduce(RuleId(0))).unwrap();
-    assert_eq!(encoded, 0x8000 | 1); // 1-based
+    assert_eq!(encoded, 0x8000 | 0x0001); // 1-based
 }
 
 #[test]
@@ -998,7 +998,7 @@ fn tc_encode_all_action_variants() {
         (Action::Shift(StateId(0)), 0),
         (Action::Shift(StateId(100)), 100),
         (Action::Reduce(RuleId(0)), 0x8001),
-        (Action::Reduce(RuleId(9)), 0x8000 | 10),
+        (Action::Reduce(RuleId(9)), 0x8000 | 0x000a),
         (Action::Accept, 0xFFFF),
         (Action::Error, 0xFFFE),
         (Action::Recover, 0xFFFD),

--- a/tablegen/tests/compressed_table_proptest.rs
+++ b/tablegen/tests/compressed_table_proptest.rs
@@ -615,7 +615,7 @@ fn test_encode_action_small_reduce() {
         .encode_action_small(&Action::Reduce(RuleId(0)))
         .unwrap();
     // Reduce: high bit set, 1-based rule id
-    assert_eq!(encoded, 0x8000 | 1);
+    assert_eq!(encoded, 0x8000 | 0x0001);
 }
 
 #[test]

--- a/tablegen/tests/compression_comprehensive.rs
+++ b/tablegen/tests/compression_comprehensive.rs
@@ -457,7 +457,7 @@ fn encode_action_reduce_roundtrips() {
         .encode_action_small(&Action::Reduce(RuleId(7)))
         .unwrap();
     // Reduce encoded as 0x8000 | (rule_id + 1)
-    assert_eq!(encoded, 0x8000 | 8);
+    assert_eq!(encoded, 0x8000 | 0x0008);
 }
 
 #[test]

--- a/tablegen/tests/compression_roundtrip_comprehensive.rs
+++ b/tablegen/tests/compression_roundtrip_comprehensive.rs
@@ -231,8 +231,8 @@ fn roundtrip_encode_decode_all_action_types() {
     let cases: Vec<(Action, u16)> = vec![
         (Action::Shift(StateId(0)), 0),
         (Action::Shift(StateId(100)), 100),
-        (Action::Reduce(RuleId(0)), 0x8000 | 1),
-        (Action::Reduce(RuleId(42)), 0x8000 | 43),
+        (Action::Reduce(RuleId(0)), 0x8000 | 0x0001),
+        (Action::Reduce(RuleId(42)), 0x8000 | 0x002b),
         (Action::Accept, 0xFFFF),
         (Action::Error, 0xFFFE),
         (Action::Recover, 0xFFFD),

--- a/tablegen/tests/compression_v2_comprehensive.rs
+++ b/tablegen/tests/compression_v2_comprehensive.rs
@@ -669,7 +669,7 @@ fn edge_case_encode_small_shift_zero() {
 fn edge_case_encode_small_reduce_zero() {
     let c = TableCompressor::new();
     let v = c.encode_action_small(&Action::Reduce(RuleId(0))).unwrap();
-    assert_eq!(v, 0x8000 | 1); // 1-based encoding
+    assert_eq!(v, 0x8000 | 0x0001); // 1-based encoding
 }
 
 #[test]

--- a/tablegen/tests/compression_v6.rs
+++ b/tablegen/tests/compression_v6.rs
@@ -485,14 +485,14 @@ fn v6_encode_03_reduce() {
     let tc = TableCompressor::new();
     let encoded = tc.encode_action_small(&Action::Reduce(RuleId(0))).unwrap();
     // bit 15 set, 1-based rule ID
-    assert_eq!(encoded, 0x8000 | 1);
+    assert_eq!(encoded, 0x8000 | 0x0001);
 }
 
 #[test]
 fn v6_encode_04_reduce_larger_rule() {
     let tc = TableCompressor::new();
     let encoded = tc.encode_action_small(&Action::Reduce(RuleId(99))).unwrap();
-    assert_eq!(encoded, 0x8000 | 100);
+    assert_eq!(encoded, 0x8000 | 0x0064);
 }
 
 #[test]

--- a/tablegen/tests/language_gen_comprehensive.rs
+++ b/tablegen/tests/language_gen_comprehensive.rs
@@ -1469,7 +1469,7 @@ fn encode_action_small_reduce() {
     let c = TableCompressor::new();
     let encoded = c.encode_action_small(&Action::Reduce(RuleId(5))).unwrap();
     // bit 15 set, rule_id+1 in lower bits
-    assert_eq!(encoded, 0x8000 | 6);
+    assert_eq!(encoded, 0x8000 | 0x0006);
 }
 
 #[test]

--- a/tablegen/tests/serializer_comprehensive.rs
+++ b/tablegen/tests/serializer_comprehensive.rs
@@ -220,7 +220,7 @@ fn serialize_reduce_action_encoding() {
     let deser: SerializableLanguage = serde_json::from_str(&json).unwrap();
     // Reduce uses 0x8000 | (rule_id + 1)
     assert_eq!(deser.parse_table[0], 3); // symbol
-    assert_eq!(deser.parse_table[1], 0x8000 | 1); // reduce rule 0 → 1-based
+    assert_eq!(deser.parse_table[1], 0x8000 | 0x0001); // reduce rule 0 → 1-based
 }
 
 #[test]

--- a/tablegen/tests/table_compression_v2_comprehensive.rs
+++ b/tablegen/tests/table_compression_v2_comprehensive.rs
@@ -859,7 +859,7 @@ fn t63_encode_action_small_shift() {
 fn t64_encode_action_small_reduce() {
     let c = TableCompressor::new();
     let v = c.encode_action_small(&Action::Reduce(RuleId(0))).unwrap();
-    assert_eq!(v, 0x8000 | 1); // 1-based
+    assert_eq!(v, 0x8000 | 0x0001); // 1-based
 }
 
 #[test]

--- a/tablegen/tests/table_compressor_comprehensive.rs
+++ b/tablegen/tests/table_compressor_comprehensive.rs
@@ -836,7 +836,7 @@ fn test_42_encode_action_small_reduce() {
 
     assert!(result.is_ok());
     // Reduce encoding: 0x8000 | (rule_id + 1)
-    assert_eq!(result.unwrap(), 0x8000 | 51);
+    assert_eq!(result.unwrap(), 0x8000 | 0x0033);
 }
 
 #[test]

--- a/xtask/src/policy/lint_policy.rs
+++ b/xtask/src/policy/lint_policy.rs
@@ -3,7 +3,9 @@
 //! Verifies that:
 //! 1. The workspace MSRV in `Cargo.toml` matches `policy/clippy-lints.toml`.
 //! 2. No `clippy.toml` introduces panic-family test carveouts.
-//! 3. No `[[planned]]` lint is activated before its `activate_when_msrv`.
+//! 3. Active lint policy mirrors `[workspace.lints]`.
+//! 4. No `[[planned]]` lint is activated before its `activate_when_msrv`.
+//! 5. No `[[planned]]` lint remains overdue after its `activate_when_msrv`.
 //!
 //! Runs in advisory mode by default — failures are reported but do not stop
 //! CI. Once we are confident the manifest matches reality everywhere, this
@@ -64,6 +66,7 @@ pub fn run_check(mode: Mode) -> Result<()> {
 
     check_msrv_consistency(&root, &policy, &mut findings)?;
     check_no_test_carveouts(&root, &mut findings)?;
+    check_active_lints_match_cargo(&root, &policy, &mut findings)?;
     check_planned_not_active_early(&root, &policy, &mut findings)?;
 
     let summary = format!(
@@ -194,19 +197,117 @@ fn check_no_test_carveouts(root: &Path, findings: &mut Findings) -> Result<()> {
     Ok(())
 }
 
+#[derive(Debug, Default, PartialEq, Eq)]
+struct WorkspaceLintTables {
+    rust: BTreeMap<String, String>,
+    clippy: BTreeMap<String, String>,
+}
+
+fn check_active_lints_match_cargo(
+    root: &Path,
+    policy: &PolicyFile,
+    findings: &mut Findings,
+) -> Result<()> {
+    let cargo = std::fs::read_to_string(root.join("Cargo.toml"))?;
+    let workspace_lints = workspace_lints_from_cargo(&cargo)?;
+
+    compare_lint_table("rust", &policy.active.rust, &workspace_lints.rust, findings);
+    compare_lint_table(
+        "clippy",
+        &policy.active.clippy,
+        &workspace_lints.clippy,
+        findings,
+    );
+
+    Ok(())
+}
+
+fn workspace_lints_from_cargo(cargo: &str) -> Result<WorkspaceLintTables> {
+    let value: toml::Value = toml::from_str(cargo).context("parsing Cargo.toml as TOML")?;
+    let Some(workspace) = value.get("workspace").and_then(toml::Value::as_table) else {
+        return Ok(WorkspaceLintTables::default());
+    };
+    let Some(lints) = workspace.get("lints").and_then(toml::Value::as_table) else {
+        return Ok(WorkspaceLintTables::default());
+    };
+
+    Ok(WorkspaceLintTables {
+        rust: extract_lint_table(lints.get("rust")),
+        clippy: extract_lint_table(lints.get("clippy")),
+    })
+}
+
+fn extract_lint_table(value: Option<&toml::Value>) -> BTreeMap<String, String> {
+    let Some(table) = value.and_then(toml::Value::as_table) else {
+        return BTreeMap::new();
+    };
+
+    table
+        .iter()
+        .filter_map(|(name, value)| lint_level(value).map(|level| (name.clone(), level)))
+        .collect()
+}
+
+fn lint_level(value: &toml::Value) -> Option<String> {
+    if let Some(level) = value.as_str() {
+        return Some(level.to_string());
+    }
+    value
+        .as_table()
+        .and_then(|table| table.get("level"))
+        .and_then(toml::Value::as_str)
+        .map(str::to_string)
+}
+
+fn compare_lint_table(
+    kind: &str,
+    policy: &BTreeMap<String, String>,
+    cargo: &BTreeMap<String, String>,
+    findings: &mut Findings,
+) {
+    for (name, expected_level) in policy {
+        match cargo.get(name) {
+            Some(actual_level) if actual_level == expected_level => {}
+            Some(actual_level) => findings.issues.push(format!(
+                "policy active {kind} lint `{name}` is `{expected_level}` but Cargo.toml has `{actual_level}`"
+            )),
+            None => findings.issues.push(format!(
+                "policy active {kind} lint `{name}` is missing from Cargo.toml [workspace.lints.{kind}]"
+            )),
+        }
+    }
+
+    for (name, actual_level) in cargo {
+        if !policy.contains_key(name) {
+            findings.issues.push(format!(
+                "Cargo.toml [workspace.lints.{kind}] contains `{name}` = `{actual_level}` but policy/clippy-lints.toml does not list it as active"
+            ));
+        }
+    }
+}
+
 fn check_planned_not_active_early(
     root: &Path,
     policy: &PolicyFile,
     findings: &mut Findings,
 ) -> Result<()> {
     let cargo = std::fs::read_to_string(root.join("Cargo.toml"))?;
+    let workspace_lints = workspace_lints_from_cargo(&cargo)?;
     let active_msrv = extract_kv(&cargo, "rust-version").unwrap_or_else(|| policy.msrv.clone());
     for planned in &policy.planned {
         let target = &planned.activate_when_msrv;
         if version_geq(&active_msrv, target) {
+            findings.issues.push(format!(
+                "planned lint `{}` is due at MSRV {target}; move it to active policy or reschedule it with a new reason",
+                planned.name
+            ));
             continue;
         }
-        if cargo.contains(&planned.name) {
+
+        let lint_key = planned_lint_key(&planned.name);
+        let active_early = workspace_lints.rust.contains_key(lint_key)
+            || workspace_lints.clippy.contains_key(lint_key);
+        if active_early {
             findings.issues.push(format!(
                 "planned lint `{}` referenced in Cargo.toml before MSRV {target}",
                 planned.name
@@ -214,6 +315,12 @@ fn check_planned_not_active_early(
         }
     }
     Ok(())
+}
+
+fn planned_lint_key(name: &str) -> &str {
+    name.strip_prefix("clippy::")
+        .or_else(|| name.strip_prefix("rust::"))
+        .unwrap_or(name)
 }
 
 fn version_geq(a: &str, b: &str) -> bool {
@@ -251,5 +358,44 @@ mod tests {
     fn extract_kv_handles_tight_assignment() {
         let text = "channel=\"1.95.0\"\n";
         assert_eq!(extract_kv(text, "channel").as_deref(), Some("1.95.0"));
+    }
+
+    #[test]
+    fn workspace_lints_from_cargo_extracts_string_and_table_levels() {
+        let cargo = r#"
+[workspace]
+
+[workspace.lints.rust]
+missing_docs = "warn"
+
+[workspace.lints.clippy]
+allow_attributes_without_reason = "deny"
+manual_ilog2 = { level = "warn", priority = -1 }
+"#;
+
+        let tables = workspace_lints_from_cargo(cargo).unwrap();
+
+        assert_eq!(
+            tables.rust.get("missing_docs").map(String::as_str),
+            Some("warn")
+        );
+        assert_eq!(
+            tables
+                .clippy
+                .get("allow_attributes_without_reason")
+                .map(String::as_str),
+            Some("deny")
+        );
+        assert_eq!(
+            tables.clippy.get("manual_ilog2").map(String::as_str),
+            Some("warn")
+        );
+    }
+
+    #[test]
+    fn planned_lint_key_strips_known_tool_prefixes() {
+        assert_eq!(planned_lint_key("clippy::manual_ilog2"), "manual_ilog2");
+        assert_eq!(planned_lint_key("rust::missing_docs"), "missing_docs");
+        assert_eq!(planned_lint_key("custom_lint"), "custom_lint");
     }
 }


### PR DESCRIPTION
## Summary

Promotes the Rust 1.94/1.95 Clippy lint batch after the MSRV bump and tightens lint-policy verification so active policy must mirror workspace lint declarations.

## Linked artifacts

- Proposal: `docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md`
- Plan: `plans/0.9.0/implementation-plan.md`
- Active goal item: `clippy-policy-refresh`

## Production delta

- Adds the due Clippy lint batch to `[workspace.lints.clippy]`.
- Moves the same lint batch from planned policy into `policy/clippy-lints.toml` active policy.
- Makes `xtask check-lint-policy` compare active policy against Cargo workspace lints and fail overdue planned lints.
- Cleans table/action encoding tests to use hex bit operands for the new `decimal_bitwise_operands` lint.
- Updates the 0.9 implementation plan and active manifest for this work item.

## Non-goals

- No support-tier promotion.
- No no-panic staged deny promotion.
- No protected-field inventory for `disallowed_fields`; this PR enables the lint level only.
- No changes to the completed microcrate-to-SRP release gate.

## Source-of-truth impact

- Roadmap: no change.
- Proposal: no change.
- Spec: no change.
- ADR: no change.
- Plan: `clippy-policy-refresh` now describes the actual lint activation and proof commands.
- Active manifest: marks `clippy-policy-refresh` active with the focused proof commands.
- Support tiers: no change.
- Policy ledger: `policy/clippy-lints.toml` moves the due planned lint batch into active policy.

## User impact

Keeps the 0.9 release train honest after the Rust 1.95 bump: due lint policy is active instead of left as stale planned work.

## Agent impact

`check-lint-policy` now catches drift between policy and Cargo workspace lint settings, so future agents do not need to infer whether planned lints are overdue or active.

## Proof commands

```bash
python -c "import tomllib; tomllib.load(open('.adze/goals/active.toml','rb')); tomllib.load(open('policy/clippy-lints.toml','rb')); print('toml ok')"
cargo run -q -p xtask -- check-lint-policy
cargo test -p xtask lint_policy -j 1 -- --nocapture
cargo clippy -p xtask --all-targets -- -D warnings
just clippy
cargo clippy -p adze -p adze-macro -p adze-tool -p adze-common -p adze-ir -p adze-glr-core -p adze-tablegen --all-targets -- -D warnings
cargo run -q -p xtask -- check-package-boundary --release-gate
git diff --check
```

Local note: `just ci-supported` cannot run on this Windows host because `just` cannot find `cygpath` for the recipe shebang interpreter. The GitHub `CI / ci-supported` job remains the required gate.

## Rollback

Revert this PR. That restores the lint batch to planned policy and removes the mechanical table/test cleanups tied only to this promotion.