### PR TITLE
docs: close 0.9 product proof blocker

### DIFF
--- a/.adze/goals/active.toml
+++ b/.adze/goals/active.toml
@@ -203,15 +203,17 @@ commands = [
 
 [[work_item]]
 id = "product-proof-refresh"
-status = "blocked"
+status = "complete"
 proposal = "docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md"
-spec = "ADZE-SPEC-0011-product-proof-and-support-tiers"
+spec = "docs/specs/ADZE-SPEC-0011-product-proof-and-support-tiers.md"
 adr = ""
 plan = "plans/0.9.0/implementation-plan.md"
-blocked_by = ["clippy-policy-refresh", "ci-economics-verifier"]
-prs = []
+blocked_by = []
+prs = [763]
 commands = [
   "just ci-supported",
+  "just ci-product-stable",
+  "cargo test -p adze-cli readme_stable_claims_are_in_stable_product_lane -- --exact --nocapture",
   "cargo test -p adze --features pure-rust --test typed_ast_contract -- --nocapture",
   "cargo test -p adze-cli readme_arithmetic_quickstart_builds_and_runs -- --exact --nocapture",
 ]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -88,7 +88,7 @@ no release-state category for unpublished production microcrates.
 - [ ] Clippy planned-lint activation (6 lints gated on 1.94/1.95)
 - [x] Non-Rust file allowlist reconciled against new structure
 - [x] CI economics update (LEM estimates reflect new workspace shape)
-- [ ] Product-proof refresh maps stable README claims to current proof commands
+- [x] Product-proof refresh maps stable README claims to current proof commands
 
 ### Other 0.9.0 work
 - **Post-release hardening**: Finish narrowing workflow-only red and restore any proof surfaces trimmed only for publication.

--- a/docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md
+++ b/docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md
@@ -4,7 +4,7 @@ Status: proposed
 Owner: Adze maintainers
 Created: 2026-05-12
 Target milestone: 0.9.0
-Linked specs: ADZE-SPEC-0001 package surface boundary; ADZE-SPEC-0002 CI economics; ADZE-SPEC-0003 canonical parse document; future ADZE-SPEC-0011 product proof and support tiers
+Linked specs: ADZE-SPEC-0001 package surface boundary; ADZE-SPEC-0002 CI economics; ADZE-SPEC-0003 canonical parse document; ADZE-SPEC-0011 product proof and support tiers
 Linked ADRs: ADZE-ADR-0001 AdzeDocument one parse truth; ADZE-ADR-0002 no durable unpublished production crates; ADZE-ADR-0003 summary-first GLR ambiguity
 Linked plan: ../../plans/0.9.0/implementation-plan.md
 Linked issues:
@@ -134,7 +134,7 @@ The milestone needs behavior specs for:
 - `ADZE-SPEC-0003-canonical-parse-document.md`: the native parse document as
   the source of truth for generic CST, typed CST, typed AST, diagnostics,
   Tree-sitter-compatible projection, and GLR ambiguity summaries.
-- Future `ADZE-SPEC-0011-product-proof-and-support-tiers.md`: the rule that stable
+- `ADZE-SPEC-0011-product-proof-and-support-tiers.md`: the rule that stable
   README claims require proof commands and support-tier mapping.
 
 Specs define behavior and acceptance evidence. They must link to

--- a/docs/specs/ADZE-SPEC-0011-product-proof-and-support-tiers.md
+++ b/docs/specs/ADZE-SPEC-0011-product-proof-and-support-tiers.md
@@ -1,0 +1,142 @@
+# ADZE-SPEC-0011: Product proof and support tiers
+
+Status: accepted
+Owner: release/product
+Created: 2026-05-14
+Linked proposal: ../proposals/ADZE-PROP-0001-0.9-contract-convergence.md
+Linked ADRs:
+Linked plan: ../../plans/0.9.0/implementation-plan.md
+Linked issues:
+Linked PRs:
+Support-tier impact: ../status/SUPPORT_TIERS.md
+Policy impact: ../../scripts/ci-product-stable.sh
+
+## Problem
+
+Adze's README is the public front door, but feature claims can drift from the
+proof that actually protects users. The 0.9 release needs an explicit contract
+for Stable claims so users, maintainers, and agents can tell which advertised
+surfaces are proven, which are still developing, and which are only advisory.
+
+## Behavior
+
+### B1. `SUPPORT_TIERS.md` is the product claim proof map
+
+`../status/SUPPORT_TIERS.md` is the source of truth for feature tiers, proof
+commands, and CI lanes. README capability tables may summarize those rows, but
+they must not become an independent proof map.
+
+### B2. Stable README claims require proof
+
+Every README row marked **Stable** must map to:
+
+- a row in `../status/SUPPORT_TIERS.md`;
+- at least one repeatable proof command;
+- a lane that runs the proof or a documented reason it remains advisory.
+
+### B3. Stable-product canaries are explicit
+
+`../../scripts/ci-product-stable.sh` owns the bounded stable-product canary lane
+for README Stable claims. That lane must include the README proof-alignment
+canary:
+
+```bash
+cargo test -p adze-cli readme_stable_claims_are_in_stable_product_lane -- --exact --nocapture
+```
+
+The canary must fail when a README Stable proof command is missing from
+`SUPPORT_TIERS.md` or from the stable-product lane.
+
+### B4. Stable-product canaries do not replace the required gate
+
+`just ci-supported` / `CI / ci-supported` remains the required supported gate.
+The stable-product lane is advisory until branch protection explicitly promotes
+it.
+
+### B5. Tier promotion is evidence-based
+
+Surfaces outside the Stable rows must not be promoted by wording alone. GLR
+conflict routing, structured parse errors, `AdzeDocument`, typed CST, CLI,
+WASM, Tree-sitter compatibility, runtime2, grammars, golden tests, and
+benchmarks remain at their documented tiers until their support-tier rows and
+proof commands justify promotion.
+
+## Non-Goals
+
+- No promotion of Stabilizing, Experimental, Advisory, or intentionally
+  excluded surfaces.
+- No requirement that broad product-proof advisory lanes become branch
+  protection gates.
+- No duplication of the full support-tier table in this spec.
+- No runtime behavior change.
+
+## Required Evidence
+
+- README Stable proof-alignment canary passes.
+- Stable product lane passes.
+- Required supported gate remains green.
+- `SUPPORT_TIERS.md` and README agree about Stable rows.
+
+## Acceptance Examples
+
+Accepted:
+
+```text
+README marks Typed extraction Stable.
+SUPPORT_TIERS.md has a Typed extraction row with proof commands.
+scripts/ci-product-stable.sh runs the stable canaries that cover the claim.
+```
+
+Rejected:
+
+```text
+README marks a surface Stable, but the proof command only appears in prose or
+in an optional broad workflow with no support-tier row.
+```
+
+Rejected:
+
+```text
+README promotes Tree-sitter compatibility from Advisory to Stable without a
+support-tier promotion and parity proof commands.
+```
+
+## Test Mapping
+
+```text
+cli/tests/readme_quickstart.rs::readme_stable_claims_are_in_stable_product_lane
+scripts/ci-product-stable.sh
+```
+
+## Implementation Mapping
+
+```text
+README.md
+docs/status/SUPPORT_TIERS.md
+docs/status/KNOWN_RED.md
+scripts/ci-product-stable.sh
+.github/workflows/product-proof.yml
+```
+
+## CI Proof
+
+```bash
+just ci-product-stable
+just ci-supported
+```
+
+Focused proof:
+
+```bash
+cargo test -p adze-cli readme_stable_claims_are_in_stable_product_lane -- --exact --nocapture
+```
+
+## Metrics And Promotion Rule
+
+The 0.9 product-proof release blocker is complete when README Stable claims are
+covered by `SUPPORT_TIERS.md`, `readme_stable_claims_are_in_stable_product_lane`
+passes, `just ci-product-stable` passes, and `CI / ci-supported` remains green
+on the closeout PR.
+
+Future promotion of `ci-product-stable` from advisory to required needs a
+separate CI policy change and branch-protection update.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -49,6 +49,7 @@ ADZE-SPEC-0007-glr-ambiguity-summary.md
 ADZE-SPEC-0008-json-cli-wasm-projections.md
 ADZE-SPEC-0009-incremental-document-lifecycle.md
 ADZE-SPEC-0010-language-metadata-and-node-types.md
+ADZE-SPEC-0011-product-proof-and-support-tiers.md
 ```
 
 ## Header

--- a/docs/status/SUPPORT_TIERS.md
+++ b/docs/status/SUPPORT_TIERS.md
@@ -1,6 +1,6 @@
 # Support Tiers and Proof Surface
 
-**Last updated:** 2026-05-12
+**Last updated:** 2026-05-14
 **Source of truth for:** README feature claims, `docs/status/KNOWN_RED.md`, and CI expectations.
 
 This document maps major Adze surfaces to five tiers:
@@ -12,6 +12,12 @@ This document maps major Adze surfaces to five tiers:
 - **Intentionally excluded** — tracked in `KNOWN_RED`; not currently a merge requirement.
 
 ## Feature-to-proof map
+
+0.9 product-proof closeout: README rows marked **Stable** are limited to the
+Stable rows below and are guarded by
+`cargo test -p adze-cli readme_stable_claims_are_in_stable_product_lane -- --exact --nocapture`.
+The bounded stable-product lane is `just ci-product-stable`; it remains
+advisory until branch protection explicitly promotes it.
 
 Current native-document and typed-CST alpha notes: generated typed CST handles
 can now call the default `SyntaxNode::ast(...)` helper, which delegates to

--- a/plans/0.9.0/implementation-plan.md
+++ b/plans/0.9.0/implementation-plan.md
@@ -537,12 +537,12 @@ Revert the lint policy PR and any mechanical fixes tied only to that promotion.
 
 ## Work Item: product-proof-refresh
 
-Status: blocked
+Status: active
 Linked proposal: ../../docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md
-Linked spec: future ADZE-SPEC-0011 product proof and support tiers
+Linked spec: ../../docs/specs/ADZE-SPEC-0011-product-proof-and-support-tiers.md
 Linked ADR:
 Blocks: 0.9-closeout
-Blocked by: clippy-policy-refresh; ci-economics-verifier
+Blocked by: none
 
 ### Goal
 
@@ -551,11 +551,16 @@ after package and CI policy changes land.
 
 ### Production Delta
 
-Expected later changes:
+This work item closes the 0.9 Stable-claim proof map after package collapse, CI
+economics, MSRV, and lint policy work are in place.
 
-- `../../docs/status/SUPPORT_TIERS.md`
-- README or tutorial claim wording if needed
-- exact product-proof canaries for promoted surfaces
+- `../../docs/specs/ADZE-SPEC-0011-product-proof-and-support-tiers.md`
+  defines the Stable-claim proof contract.
+- `../../docs/status/SUPPORT_TIERS.md` records the 0.9 product-proof closeout
+  and remains the source of truth for README feature claims.
+- `../../README.md` continues to summarize only rows backed by
+  `SUPPORT_TIERS.md`.
+- `../../scripts/ci-product-stable.sh` remains the bounded stable-product lane.
 
 ### Non-Goals
 
@@ -565,12 +570,14 @@ grammar support without receipts.
 ### Acceptance
 
 Every stable README claim maps to a support-tier row and repeatable proof
-command.
+command, and the stable-product lane passes.
 
 ### Proof Commands
 
 ```bash
 just ci-supported
+cargo test -p adze-cli readme_stable_claims_are_in_stable_product_lane -- --exact --nocapture
+just ci-product-stable
 cargo test -p adze --features pure-rust --test typed_ast_contract -- --nocapture
 cargo test -p adze-cli readme_arithmetic_quickstart_builds_and_runs -- --exact --nocapture
 ```

--- a/policy/doc-artifacts.toml
+++ b/policy/doc-artifacts.toml
@@ -14,6 +14,7 @@ source_of_truth_for = ["0.9 release rationale", "contract convergence campaign"]
 links_to = [
   "ADZE-SPEC-0001",
   "ADZE-SPEC-0002",
+  "ADZE-SPEC-0011",
   "ADZE-ADR-0001",
   "plans/0.9.0/implementation-plan.md",
 ]
@@ -35,6 +36,7 @@ links_to = [
   "ADZE-SPEC-0008",
   "ADZE-SPEC-0009",
   "ADZE-SPEC-0010",
+  "ADZE-SPEC-0011",
   "ADZE-ADR-0001",
   "ADZE-ADR-0003",
   "ADZE-ADR-0004",
@@ -140,6 +142,16 @@ owner = "tablegen/runtime/ts-compat"
 milestone = "0.9.x"
 source_of_truth_for = ["language metadata and node-types behavior"]
 links_to = ["ADZE-PROP-0002", "ADZE-ADR-0001", "plans/0.9.0/api-foundation.md"]
+
+[[artifact]]
+id = "ADZE-SPEC-0011"
+kind = "spec"
+path = "docs/specs/ADZE-SPEC-0011-product-proof-and-support-tiers.md"
+status = "accepted"
+owner = "release/product"
+milestone = "0.9.0"
+source_of_truth_for = ["product proof and support-tier behavior", "README Stable claim proof contract"]
+links_to = ["ADZE-PROP-0001", "docs/status/SUPPORT_TIERS.md", "scripts/ci-product-stable.sh", "plans/0.9.0/implementation-plan.md"]
 
 [[artifact]]
 id = "ADZE-ADR-0001"


### PR DESCRIPTION
## Summary

Closes the 0.9 product-proof release blocker by encoding the Stable README claim contract and marking the proof map refreshed.

## Linked artifacts

- Proposal: `docs/proposals/ADZE-PROP-0001-0.9-contract-convergence.md`
- Spec: `docs/specs/ADZE-SPEC-0011-product-proof-and-support-tiers.md`
- Plan: `plans/0.9.0/implementation-plan.md`
- Active goal item: `product-proof-refresh`

## Production delta

- Adds `ADZE-SPEC-0011-product-proof-and-support-tiers.md`.
- Registers the spec in `policy/doc-artifacts.toml` and `docs/specs/README.md`.
- Updates the 0.9 proposal, implementation plan, and active manifest to make product proof an active closeout item.
- Marks the roadmap product-proof blocker complete.
- Updates `SUPPORT_TIERS.md` with the 0.9 Stable README claim gate and current closeout date.

## Non-goals

- No runtime changes.
- No support-tier promotion for GLR, AdzeDocument, typed CST, CLI, WASM, ts_compat, runtime2, grammars, golden tests, or benchmarks.
- No branch-protection change; `ci-product-stable` remains advisory until explicitly promoted.

## Source-of-truth impact

- Roadmap: product-proof blocker marked complete.
- Proposal: ADZE-PROP-0001 now links to ADZE-SPEC-0011 as an actual spec, not future work.
- Spec: adds the product-proof/support-tier behavior contract.
- ADR: no change.
- Plan: product-proof work item now points at the spec and stable lane proof.
- Active manifest: product-proof work item is active and unblocked.
- Support tiers: records the Stable README claim gate.
- Policy ledger: doc-artifacts ledger registers ADZE-SPEC-0011.

## User impact

Stable README claims now have an explicit repo-native contract: they must map through `SUPPORT_TIERS.md` and the stable product proof lane.

## Agent impact

Future agents can follow ADZE-SPEC-0011 instead of inferring product-claim policy from README prose or CI history.

## Proof commands

```bash
python -c "import tomllib; tomllib.load(open('.adze/goals/active.toml','rb')); tomllib.load(open('policy/doc-artifacts.toml','rb')); print('toml ok')"
cargo test -p adze-cli readme_stable_claims_are_in_stable_product_lane -- --exact --nocapture
just ci-product-stable
git diff --check
```

`just ci-product-stable` passed locally before the docs closeout edit; the exact README-proof canary was rerun after the edit and passed.

## Rollback

Revert this PR. That restores the product-proof blocker to open and removes ADZE-SPEC-0011 from the artifact ledger.