### PR TITLE
plans: close generated parse_document canonical slice

### DIFF
--- a/.adze/goals/active.toml
+++ b/.adze/goals/active.toml
@@ -265,13 +265,13 @@ commands = [
 
 [[work_item]]
 id = "generated-parse-document-canonical"
-status = "ready"
+status = "complete"
 proposal = "docs/proposals/ADZE-PROP-0002-api-foundation.md"
 spec = "docs/specs/ADZE-SPEC-0003-canonical-parse-document.md"
 adr = "docs/adr/ADZE-ADR-0001-adze-document-one-parse-truth.md"
 plan = "plans/0.9.0/api-foundation.md"
 blocked_by = []
-prs = []
+prs = [767]
 commands = [
   "cargo test -p adze --features pure-rust --test typed_ast_contract -- --nocapture",
   "cargo test -p adze --features pure-rust --test typed_cst_generated_document -- --nocapture",
@@ -279,13 +279,27 @@ commands = [
 ]
 
 [[work_item]]
-id = "typed-cst-schema-generation"
-status = "blocked"
+id = "parse-fast-path-delegates-to-document"
+status = "ready"
 proposal = "docs/proposals/ADZE-PROP-0002-api-foundation.md"
 spec = "docs/specs/ADZE-SPEC-0004-typed-cst-and-ast-projections.md"
 adr = "docs/adr/ADZE-ADR-0001-adze-document-one-parse-truth.md"
 plan = "plans/0.9.0/api-foundation.md"
-blocked_by = ["generated-parse-document-canonical"]
+blocked_by = []
+prs = []
+commands = [
+  "cargo test -p adze --features pure-rust --test typed_ast_contract typed_ast_contract_parse_document_ast_matches_parse -- --exact --nocapture",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "typed-cst-schema-generation"
+status = "ready"
+proposal = "docs/proposals/ADZE-PROP-0002-api-foundation.md"
+spec = "docs/specs/ADZE-SPEC-0004-typed-cst-and-ast-projections.md"
+adr = "docs/adr/ADZE-ADR-0001-adze-document-one-parse-truth.md"
+plan = "plans/0.9.0/api-foundation.md"
+blocked_by = []
 prs = []
 commands = [
   "cargo test -p adze --features pure-rust --test typed_cst_generated_document -- --nocapture",
@@ -295,12 +309,12 @@ commands = [
 
 [[work_item]]
 id = "document-diagnostics-store"
-status = "blocked"
+status = "ready"
 proposal = "docs/proposals/ADZE-PROP-0002-api-foundation.md"
 spec = "docs/specs/ADZE-SPEC-0005-diagnostics-and-recovery.md"
 adr = "docs/adr/ADZE-ADR-0001-adze-document-one-parse-truth.md"
 plan = "plans/0.9.0/api-foundation.md"
-blocked_by = ["generated-parse-document-canonical"]
+blocked_by = []
 prs = []
 commands = [
   "cargo test -p adze --features \"pure-rust,glr\" --test generated_parse_errors -- --nocapture",
@@ -325,12 +339,12 @@ commands = [
 
 [[work_item]]
 id = "document-ambiguity-summary"
-status = "blocked"
+status = "ready"
 proposal = "docs/proposals/ADZE-PROP-0002-api-foundation.md"
 spec = "docs/specs/ADZE-SPEC-0007-glr-ambiguity-summary.md"
 adr = "docs/adr/ADZE-ADR-0003-summary-first-glr-ambiguity.md"
 plan = "plans/0.9.0/api-foundation.md"
-blocked_by = ["generated-parse-document-canonical"]
+blocked_by = []
 prs = []
 commands = [
   "cargo test -p adze --features \"pure-rust,glr,runtime-e2e\" --test test_e2e_ambiguous_grammar_glr generated_ambiguous_expr_parse_document_reports_ambiguity_summary -- --exact --nocapture",

--- a/plans/0.9.0/api-foundation.md
+++ b/plans/0.9.0/api-foundation.md
@@ -134,9 +134,10 @@ git diff --check
 
 ## Work Item: generated-parse-document-canonical
 
-Status: ready
+Status: complete
 Linked spec: ../../docs/specs/ADZE-SPEC-0003-canonical-parse-document.md
 Blocked by: none
+PR: #767
 
 ### Goal
 
@@ -155,7 +156,7 @@ git diff --check
 
 Status: ready
 Linked spec: ../../docs/specs/ADZE-SPEC-0004-typed-cst-and-ast-projections.md
-Blocked by: generated-parse-document-canonical
+Blocked by: none
 
 ### Goal
 
@@ -173,7 +174,7 @@ git diff --check
 
 Status: ready
 Linked spec: ../../docs/specs/ADZE-SPEC-0004-typed-cst-and-ast-projections.md
-Blocked by: generated-parse-document-canonical
+Blocked by: none
 
 ### Goal
 
@@ -191,7 +192,7 @@ git diff --check
 
 Status: ready
 Linked spec: ../../docs/specs/ADZE-SPEC-0005-diagnostics-and-recovery.md
-Blocked by: generated-parse-document-canonical
+Blocked by: none
 
 ### Goal
 
@@ -229,7 +230,7 @@ git diff --check
 
 Status: ready
 Linked spec: ../../docs/specs/ADZE-SPEC-0007-glr-ambiguity-summary.md
-Blocked by: generated-parse-document-canonical
+Blocked by: none
 
 ### Goal
 


### PR DESCRIPTION
## Summary

Closes the `generated-parse-document-canonical` work item from the Adze API foundation lane.

## Linked artifacts

- Proposal: `docs/proposals/ADZE-PROP-0002-api-foundation.md`
- Spec: `docs/specs/ADZE-SPEC-0003-canonical-parse-document.md`
- ADR: `docs/adr/ADZE-ADR-0001-adze-document-one-parse-truth.md`
- Plan: `plans/0.9.0/api-foundation.md`
- Active goal item: `generated-parse-document-canonical`

## Production delta

- Marks generated `parse_document()` canonical output complete in the API foundation plan and active manifest.
- Records the proof commands that validate generated grammar document output through typed AST and typed CST canaries.
- Unblocks the dependent PR-sized items: `parse-fast-path-delegates-to-document`, `typed-cst-schema-generation`, `document-diagnostics-store`, and `document-ambiguity-summary`.
- Adds the missing active manifest entry for `parse-fast-path-delegates-to-document`.

## Non-goals

- No runtime behavior changes.
- No parser/codegen changes.
- No support-tier promotion.
- No JSON, CLI, WASM, GLR, or Tree-sitter query changes.

## Source-of-truth impact

- Roadmap: unchanged.
- Proposal: implements part of `ADZE-PROP-0002`.
- Spec: closes the `ADZE-SPEC-0003` generated grammar `parse_document()` proof slice.
- ADR: follows `ADZE-ADR-0001` by keeping generated grammar output centered on `AdzeDocument`.
- Plan: `generated-parse-document-canonical` is complete for #767.
- Active manifest: dependent API foundation slices are now ready.
- Support tiers: unchanged.
- Policy ledger: unchanged.

## User impact

Generated grammar `parse_document()` is now recorded as a proven API-foundation slice rather than an implicit implementation detail.

## Agent impact

Agents can pick the next ready work item directly from `.adze/goals/active.toml` without re-deriving which document-projection slices are unblocked.

## Proof commands

```bash
cargo test -p adze --features pure-rust --test typed_ast_contract -- --nocapture
cargo test -p adze --features pure-rust --test typed_cst_generated_document -- --nocapture
python -c "import tomllib; tomllib.load(open('.adze/goals/active.toml','rb')); print('active toml ok')"
cargo fmt -p adze -- --check
git diff --check
```

## Rollback

Revert this plan/manifest closeout PR. Runtime behavior is unchanged.