### PR TITLE
plans: close parse fast path document slice

### DIFF
--- a/.adze/goals/active.toml
+++ b/.adze/goals/active.toml
@@ -280,13 +280,13 @@ commands = [
 
 [[work_item]]
 id = "parse-fast-path-delegates-to-document"
-status = "ready"
+status = "complete"
 proposal = "docs/proposals/ADZE-PROP-0002-api-foundation.md"
 spec = "docs/specs/ADZE-SPEC-0004-typed-cst-and-ast-projections.md"
 adr = "docs/adr/ADZE-ADR-0001-adze-document-one-parse-truth.md"
 plan = "plans/0.9.0/api-foundation.md"
 blocked_by = []
-prs = []
+prs = [768]
 commands = [
   "cargo test -p adze --features pure-rust --test typed_ast_contract typed_ast_contract_parse_document_ast_matches_parse -- --exact --nocapture",
   "git diff --check",

--- a/plans/0.9.0/api-foundation.md
+++ b/plans/0.9.0/api-foundation.md
@@ -154,9 +154,10 @@ git diff --check
 
 ## Work Item: parse-fast-path-delegates-to-document
 
-Status: ready
+Status: complete
 Linked spec: ../../docs/specs/ADZE-SPEC-0004-typed-cst-and-ast-projections.md
 Blocked by: none
+PR: #768
 
 ### Goal
 


### PR DESCRIPTION
## Summary

Closes the `parse-fast-path-delegates-to-document` work item from the Adze API foundation lane.

## Linked artifacts

- Proposal: `docs/proposals/ADZE-PROP-0002-api-foundation.md`
- Spec: `docs/specs/ADZE-SPEC-0004-typed-cst-and-ast-projections.md`
- ADR: `docs/adr/ADZE-ADR-0001-adze-document-one-parse-truth.md`
- Plan: `plans/0.9.0/api-foundation.md`
- Active goal item: `parse-fast-path-delegates-to-document`

## Production delta

- Marks the parse fast-path/document AST equivalence slice complete in the API foundation plan and active manifest.
- Records the exact canary proving `grammar::parse(source)` returns the same typed AST as `grammar::parse_document(source).ast()` for the supported fixture.

## Non-goals

- No runtime behavior changes.
- No parser/codegen changes.
- No support-tier promotion.

## Source-of-truth impact

- Roadmap: unchanged.
- Proposal: implements part of `ADZE-PROP-0002`.
- Spec: closes the `ADZE-SPEC-0004` typed AST projection fast-path proof slice.
- ADR: follows `ADZE-ADR-0001` by keeping typed AST extraction document-backed.
- Plan: `parse-fast-path-delegates-to-document` is complete for #768.
- Active manifest: the work item is complete.
- Support tiers: unchanged.
- Policy ledger: unchanged.

## User impact

The simple `parse()` front door is now explicitly tied to the document-backed AST projection proof.

## Agent impact

Agents can move to the remaining projection slices without rechecking whether `parse()` and `doc.ast()` already have an equivalence canary.

## Proof commands

```bash
cargo test -p adze --features pure-rust --test typed_ast_contract typed_ast_contract_parse_document_ast_matches_parse -- --exact --nocapture
python -c "import tomllib; tomllib.load(open('.adze/goals/active.toml','rb')); print('active toml ok')"
git diff --check
```

## Rollback

Revert this plan/manifest closeout PR. Runtime behavior is unchanged.