### PR TITLE
plans: close document diagnostics store slice

### DIFF
--- a/.adze/goals/active.toml
+++ b/.adze/goals/active.toml
@@ -309,13 +309,13 @@ commands = [
 
 [[work_item]]
 id = "document-diagnostics-store"
-status = "ready"
+status = "complete"
 proposal = "docs/proposals/ADZE-PROP-0002-api-foundation.md"
 spec = "docs/specs/ADZE-SPEC-0005-diagnostics-and-recovery.md"
 adr = "docs/adr/ADZE-ADR-0001-adze-document-one-parse-truth.md"
 plan = "plans/0.9.0/api-foundation.md"
 blocked_by = []
-prs = []
+prs = [770]
 commands = [
   "cargo test -p adze --features \"pure-rust,glr\" --test generated_parse_errors -- --nocapture",
   "cargo test -p adze --features \"pure-rust,glr\" --test error_display_tests -- --nocapture",

--- a/plans/0.9.0/api-foundation.md
+++ b/plans/0.9.0/api-foundation.md
@@ -192,9 +192,10 @@ git diff --check
 
 ## Work Item: document-diagnostics-store
 
-Status: ready
+Status: complete
 Linked spec: ../../docs/specs/ADZE-SPEC-0005-diagnostics-and-recovery.md
 Blocked by: none
+PR: #770
 
 ### Goal
 


### PR DESCRIPTION
## Summary

Closes the document diagnostics store API-foundation slice after the diagnostics proof commands passed.

## Linked artifacts

- Proposal: `docs/proposals/ADZE-PROP-0002-api-foundation.md`
- Spec: `docs/specs/ADZE-SPEC-0005-diagnostics-and-recovery.md`
- ADR: `docs/adr/ADZE-ADR-0001-adze-document-one-parse-truth.md`
- Plan: `plans/0.9.0/api-foundation.md`
- Active goal item: `document-diagnostics-store`

## Production delta

- Marks `document-diagnostics-store` complete in `plans/0.9.0/api-foundation.md` and `.adze/goals/active.toml`.
- Records PR #770 for the slice.

## Non-goals

- No runtime behavior changes.
- No diagnostics support-tier promotion.
- No changes to diagnostic wording or schema.

## Source-of-truth impact

- Roadmap: unchanged.
- Proposal: unchanged.
- Spec: unchanged.
- ADR: unchanged.
- Plan: closes one API-foundation work item.
- Active manifest: closes one work item.
- Support tiers: unchanged.
- Policy ledger: unchanged.

## User impact

No direct API change; this records the current diagnostics proof slice as complete so the remaining API-foundation work can build on it.

## Agent impact

Agents can treat document diagnostics storage as completed and move on to remaining ready API-foundation slices.

## Proof commands

```bash
cargo test -p adze --features "pure-rust,glr" --test generated_parse_errors -- --nocapture
cargo test -p adze --features "pure-rust,glr" --test error_display_tests -- --nocapture
python -c "import tomllib; tomllib.load(open('.adze/goals/active.toml','rb')); print('active toml ok')"
git diff --check
```

## Rollback

Revert this PR to mark the work item ready again.