### PR TITLE
plans: close document ambiguity summary slice

### DIFF
--- a/.adze/goals/active.toml
+++ b/.adze/goals/active.toml
@@ -339,13 +339,13 @@ commands = [
 
 [[work_item]]
 id = "document-ambiguity-summary"
-status = "ready"
+status = "complete"
 proposal = "docs/proposals/ADZE-PROP-0002-api-foundation.md"
 spec = "docs/specs/ADZE-SPEC-0007-glr-ambiguity-summary.md"
 adr = "docs/adr/ADZE-ADR-0003-summary-first-glr-ambiguity.md"
 plan = "plans/0.9.0/api-foundation.md"
 blocked_by = []
-prs = []
+prs = [772]
 commands = [
   "cargo test -p adze --features \"pure-rust,glr,runtime-e2e\" --test test_e2e_ambiguous_grammar_glr generated_ambiguous_expr_parse_document_reports_ambiguity_summary -- --exact --nocapture",
   "git diff --check",

--- a/plans/0.9.0/api-foundation.md
+++ b/plans/0.9.0/api-foundation.md
@@ -232,9 +232,10 @@ git diff --check
 
 ## Work Item: document-ambiguity-summary
 
-Status: ready
+Status: complete
 Linked spec: ../../docs/specs/ADZE-SPEC-0007-glr-ambiguity-summary.md
 Blocked by: none
+PR: #772
 
 ### Goal
 


### PR DESCRIPTION
## Summary

Closes the document ambiguity summary API-foundation slice after the GLR parse_document ambiguity canary passed.

## Linked artifacts

- Proposal: `docs/proposals/ADZE-PROP-0002-api-foundation.md`
- Spec: `docs/specs/ADZE-SPEC-0007-glr-ambiguity-summary.md`
- ADR: `docs/adr/ADZE-ADR-0003-summary-first-glr-ambiguity.md`
- Plan: `plans/0.9.0/api-foundation.md`
- Active goal item: `document-ambiguity-summary`

## Production delta

- Marks `document-ambiguity-summary` complete in `plans/0.9.0/api-foundation.md` and `.adze/goals/active.toml`.
- Records PR #772 for the slice.

## Non-goals

- No runtime behavior changes.
- No full forest API stabilization.
- No GLR support-tier promotion.

## Source-of-truth impact

- Roadmap: unchanged.
- Proposal: unchanged.
- Spec: unchanged.
- ADR: unchanged.
- Plan: closes one API-foundation work item.
- Active manifest: closes one work item.
- Support tiers: unchanged.
- Policy ledger: unchanged.

## User impact

No direct API change; this records that the summary-first GLR ambiguity document proof slice is complete.

## Agent impact

Agents can treat document ambiguity summaries as proven for this slice and move on to JSON and language-schema closeouts.

## Proof commands

```bash
cargo test -p adze --features "pure-rust,glr,runtime-e2e" --test test_e2e_ambiguous_grammar_glr generated_ambiguous_expr_parse_document_reports_ambiguity_summary -- --exact --nocapture
python -c "import tomllib; tomllib.load(open('.adze/goals/active.toml','rb')); print('active toml ok')"
git diff --check
```

## Rollback

Revert this PR to mark the work item ready again.