### PR TITLE
xtask: add doc-artifact and active-goal source-of-truth checkers

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -281,6 +281,18 @@ enum Commands {
         #[arg(long, default_value = "advisory")]
         mode: String,
     },
+    /// Validate policy/doc-artifacts.toml: paths exist, IDs unique, links resolve.
+    CheckDocArtifacts {
+        /// Operating mode: advisory (warnings only) | blocking (fail on errors).
+        #[arg(long, default_value = "blocking")]
+        mode: String,
+    },
+    /// Validate .adze/goals/active.toml: fields present, IDs unique, references valid.
+    CheckActiveGoal {
+        /// Operating mode: advisory (warnings only) | blocking (fail on errors).
+        #[arg(long, default_value = "blocking")]
+        mode: String,
+    },
     /// Compute the CI plan for the current PR (LEM + lane selection).
     ///
     /// Reads policy/ci-lane-whitelist.toml and policy/ci-risk-packs.toml,
@@ -543,6 +555,12 @@ fn main() -> Result<()> {
         Commands::CheckCiLaneWhitelist { mode } => {
             let mode = policy::Mode::parse(&mode)?;
             policy::ci_lane_whitelist::run_check(mode)?;
+        }
+        Commands::CheckDocArtifacts { mode } => {
+            policy::doc_artifacts::run(&mode)?;
+        }
+        Commands::CheckActiveGoal { mode } => {
+            policy::active_goal::run(&mode)?;
         }
         Commands::CiPlan {
             base,

--- a/xtask/src/policy.rs
+++ b/xtask/src/policy.rs
@@ -5,12 +5,36 @@
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 
+pub mod active_goal;
 pub mod ci_lane_whitelist;
+pub mod doc_artifacts;
 pub mod file_policy;
 pub mod lint_policy;
 pub mod no_panic;
 pub mod package_boundary;
 pub mod report;
+
+/// Simple mode for source-of-truth checks that only distinguish advisory
+/// reporting from blocking enforcement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SimpleCheckMode {
+    /// Report findings, never fail.
+    Advisory,
+    /// Fail on errors.
+    Blocking,
+}
+
+impl SimpleCheckMode {
+    pub fn parse(s: &str) -> Result<Self> {
+        match s {
+            "advisory" => Ok(SimpleCheckMode::Advisory),
+            "blocking" | "blocking-allowlist" | "blocking-strict" => Ok(SimpleCheckMode::Blocking),
+            other => {
+                anyhow::bail!("unknown source-of-truth mode: {other} (expected advisory|blocking)")
+            }
+        }
+    }
+}
 
 /// Where the checks write their JSON/Markdown artefacts.
 pub fn report_dir(workspace_root: &Path) -> PathBuf {

--- a/xtask/src/policy/active_goal.rs
+++ b/xtask/src/policy/active_goal.rs
@@ -1,0 +1,251 @@
+//! Active goal manifest checker.
+//!
+//! Validates `.adze/goals/active.toml`:
+//! - parses correctly
+//! - top-level id/title/status/owner exist
+//! - work_item IDs are unique
+//! - ready items have commands
+//! - blocked items have blocked_by
+//! - complete items have PR references
+//! - referenced paths exist
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use super::{SimpleCheckMode, workspace_root};
+
+const GOAL_PATH: &str = ".adze/goals/active.toml";
+
+const VALID_STATUSES: &[&str] = &["active", "complete", "paused", "superseded"];
+
+const VALID_WORK_ITEM_STATUSES: &[&str] = &["ready", "active", "blocked", "complete", "superseded"];
+
+#[derive(Debug, Default, Deserialize)]
+struct GoalFile {
+    #[serde(default)]
+    id: String,
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    status: String,
+    #[serde(default)]
+    owner: String,
+    #[serde(default)]
+    created: String,
+    #[serde(default)]
+    objective: String,
+    #[serde(default)]
+    end_state: Vec<String>,
+    #[serde(default, rename = "work_item")]
+    work_items: Vec<WorkItem>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct WorkItem {
+    #[serde(default)]
+    id: String,
+    #[serde(default)]
+    status: String,
+    #[serde(default)]
+    proposal: String,
+    #[serde(default)]
+    spec: String,
+    #[serde(default)]
+    adr: String,
+    #[serde(default)]
+    plan: String,
+    #[serde(default)]
+    blocked_by: Vec<String>,
+    #[serde(default)]
+    prs: Vec<u64>,
+    #[serde(default)]
+    commands: Vec<String>,
+}
+
+pub fn run(mode: &str) -> Result<()> {
+    let mode = SimpleCheckMode::parse(mode)?;
+    let root = workspace_root()?;
+    let goal_path = root.join(GOAL_PATH);
+
+    let raw = std::fs::read_to_string(&goal_path)
+        .with_context(|| format!("reading {}", goal_path.display()))?;
+
+    let file: GoalFile = toml::from_str(&raw).with_context(|| format!("parsing {}", GOAL_PATH))?;
+
+    let mut errors: Vec<String> = Vec::new();
+    let mut warnings: Vec<String> = Vec::new();
+
+    // Top-level required fields
+    if file.id.is_empty() {
+        errors.push("missing top-level id".into());
+    }
+    if file.title.is_empty() {
+        errors.push("missing top-level title".into());
+    }
+    if file.status.is_empty() {
+        errors.push("missing top-level status".into());
+    }
+    if file.owner.is_empty() {
+        errors.push("missing top-level owner".into());
+    }
+    if file.end_state.is_empty() {
+        warnings.push("empty end_state".into());
+    }
+
+    // Status validation
+    if !file.status.is_empty() && !VALID_STATUSES.contains(&file.status.as_str()) {
+        errors.push(format!("invalid campaign status '{}'", file.status));
+    }
+
+    // Work item ID uniqueness
+    let mut seen_ids: BTreeSet<String> = BTreeSet::new();
+    let mut all_item_ids: BTreeSet<&str> = BTreeSet::new();
+    for item in &file.work_items {
+        if !seen_ids.insert(item.id.clone()) {
+            errors.push(format!("duplicate work_item id: {}", item.id));
+        }
+        all_item_ids.insert(&item.id);
+    }
+
+    // Per work-item checks
+    for item in &file.work_items {
+        // Required fields
+        if item.id.is_empty() {
+            errors.push("work_item with empty id".into());
+            continue;
+        }
+        if item.status.is_empty() {
+            errors.push(format!("work_item {} missing status", item.id));
+        }
+
+        // Status validation
+        if !item.status.is_empty() && !VALID_WORK_ITEM_STATUSES.contains(&item.status.as_str()) {
+            errors.push(format!(
+                "work_item {} has invalid status '{}'",
+                item.id, item.status
+            ));
+        }
+
+        // Ready/active items should have commands
+        if (item.status == "ready" || item.status == "active") && item.commands.is_empty() {
+            warnings.push(format!(
+                "work_item {} is '{}' but has no commands",
+                item.id, item.status
+            ));
+        }
+
+        // Blocked items must have blocked_by
+        if item.status == "blocked" && item.blocked_by.is_empty() {
+            warnings.push(format!(
+                "work_item {} is 'blocked' but has no blocked_by",
+                item.id
+            ));
+        }
+
+        // blocked_by references must be valid work_item IDs
+        for blocker in &item.blocked_by {
+            if !all_item_ids.contains(blocker.as_str()) {
+                errors.push(format!(
+                    "work_item {} blocked_by '{}' is not a known work_item id",
+                    item.id, blocker
+                ));
+            }
+        }
+
+        // Complete items should have PRs or proof
+        if item.status == "complete" && item.prs.is_empty() && item.commands.is_empty() {
+            warnings.push(format!(
+                "work_item {} is 'complete' but has no prs or commands",
+                item.id
+            ));
+        }
+
+        // Referenced paths should exist
+        for ref_path in [&item.proposal, &item.spec, &item.adr, &item.plan]
+            .into_iter()
+            .filter(|p| !p.is_empty())
+        {
+            // Strip known prefix patterns to get the actual file path
+            let path_to_check = if ref_path.starts_with("docs/")
+                || ref_path.starts_with("plans/")
+                || ref_path.starts_with("policy/")
+            {
+                root.join(ref_path)
+            } else if ref_path.starts_with("ADZE-") {
+                // Short artifact ID reference, not a file path — skip path check
+                continue;
+            } else {
+                root.join(ref_path)
+            };
+
+            if !path_to_check.exists() {
+                warnings.push(format!(
+                    "work_item {} references path '{}' which does not exist",
+                    item.id, ref_path
+                ));
+            }
+        }
+    }
+
+    // Report
+    println!(
+        "active-goal: {} work items in campaign '{}'",
+        file.work_items.len(),
+        file.title
+    );
+
+    let complete = file
+        .work_items
+        .iter()
+        .filter(|i| i.status == "complete")
+        .count();
+    let ready = file
+        .work_items
+        .iter()
+        .filter(|i| i.status == "ready")
+        .count();
+    let active = file
+        .work_items
+        .iter()
+        .filter(|i| i.status == "active")
+        .count();
+    let blocked = file
+        .work_items
+        .iter()
+        .filter(|i| i.status == "blocked")
+        .count();
+    println!(
+        "  complete: {}, active: {}, ready: {}, blocked: {}",
+        complete, active, ready, blocked
+    );
+
+    for w in &warnings {
+        eprintln!("  warning: {w}");
+    }
+    for e in &errors {
+        eprintln!("  error: {e}");
+    }
+
+    if errors.is_empty() {
+        println!(
+            "active-goal: all checks passed ({} warnings)",
+            warnings.len()
+        );
+        Ok(())
+    } else if mode == SimpleCheckMode::Advisory {
+        eprintln!(
+            "active-goal: advisory mode reported {} errors in {}",
+            errors.len(),
+            GOAL_PATH
+        );
+        Ok(())
+    } else {
+        anyhow::bail!(
+            "active-goal: {} errors found in {}",
+            errors.len(),
+            GOAL_PATH
+        )
+    }
+}

--- a/xtask/src/policy/doc_artifacts.rs
+++ b/xtask/src/policy/doc_artifacts.rs
@@ -1,0 +1,212 @@
+//! Document artifact ledger checker.
+//!
+//! Validates `policy/doc-artifacts.toml`:
+//! - parses correctly
+//! - every listed artifact path exists
+//! - artifact IDs are unique
+//! - linked artifact IDs and paths resolve
+//! - kind values are valid
+//! - status values are valid
+//! - required header fields exist
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use super::{SimpleCheckMode, workspace_root};
+
+const POLICY_PATH: &str = "policy/doc-artifacts.toml";
+
+const VALID_KINDS: &[&str] = &["proposal", "spec", "adr", "plan", "goal", "handoff"];
+const VALID_STATUSES: &[&str] = &[
+    "proposed",
+    "accepted",
+    "implemented",
+    "active",
+    "complete",
+    "superseded",
+    "paused",
+];
+
+#[derive(Debug, Default, Deserialize)]
+struct DocArtifactsFile {
+    #[serde(default)]
+    schema_version: String,
+    #[serde(default)]
+    policy: String,
+    #[serde(default)]
+    owner: String,
+    #[serde(default)]
+    status: String,
+    #[serde(default, rename = "artifact")]
+    artifacts: Vec<ArtifactEntry>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ArtifactEntry {
+    id: String,
+    kind: String,
+    path: String,
+    status: String,
+    owner: String,
+    #[serde(default)]
+    milestone: String,
+    #[serde(default)]
+    source_of_truth_for: Vec<String>,
+    #[serde(default)]
+    links_to: Vec<String>,
+}
+
+pub fn run(mode: &str) -> Result<()> {
+    let mode = SimpleCheckMode::parse(mode)?;
+    let root = workspace_root()?;
+    let policy_path = root.join(POLICY_PATH);
+
+    let raw = std::fs::read_to_string(&policy_path)
+        .with_context(|| format!("reading {}", policy_path.display()))?;
+
+    let file: DocArtifactsFile =
+        toml::from_str(&raw).with_context(|| format!("parsing {}", POLICY_PATH))?;
+
+    let mut errors: Vec<String> = Vec::new();
+    let mut warnings: Vec<String> = Vec::new();
+
+    // Header fields
+    if file.schema_version.is_empty() {
+        errors.push("missing schema_version".into());
+    }
+    if file.policy.is_empty() {
+        errors.push("missing policy".into());
+    }
+    if file.status.is_empty() {
+        errors.push("missing status".into());
+    }
+
+    // ID uniqueness
+    let mut seen_ids: BTreeSet<String> = BTreeSet::new();
+    for art in &file.artifacts {
+        if !seen_ids.insert(art.id.clone()) {
+            errors.push(format!("duplicate artifact ID: {}", art.id));
+        }
+    }
+
+    // Build ID set for link resolution
+    let all_ids: BTreeSet<&str> = file.artifacts.iter().map(|a| a.id.as_str()).collect();
+
+    // Per-artifact checks
+    for art in &file.artifacts {
+        // Required fields
+        if art.id.is_empty() {
+            errors.push("artifact with empty id".into());
+        }
+        if art.kind.is_empty() {
+            errors.push(format!("artifact {} missing kind", art.id));
+        }
+        if art.path.is_empty() {
+            errors.push(format!("artifact {} missing path", art.id));
+        }
+        if art.status.is_empty() {
+            errors.push(format!("artifact {} missing status", art.id));
+        }
+        if art.owner.is_empty() {
+            errors.push(format!("artifact {} missing owner", art.id));
+        }
+
+        // Kind validation
+        if !VALID_KINDS.contains(&art.kind.as_str()) {
+            errors.push(format!(
+                "artifact {} has invalid kind '{}'",
+                art.id, art.kind
+            ));
+        }
+
+        // Status validation
+        if !VALID_STATUSES.contains(&art.status.as_str()) {
+            errors.push(format!(
+                "artifact {} has invalid status '{}'",
+                art.id, art.status
+            ));
+        }
+
+        // Path existence
+        let artifact_path = root.join(&art.path);
+        if !artifact_path.exists() {
+            errors.push(format!(
+                "artifact {} path does not exist: {}",
+                art.id, art.path
+            ));
+        }
+
+        // Kind-path consistency
+        if !art.path.is_empty() && !art.kind.is_empty() {
+            let path_matches_kind = match art.kind.as_str() {
+                "proposal" => art.path.contains("proposals/"),
+                "spec" => art.path.contains("specs/"),
+                "adr" => art.path.contains("adr/"),
+                "plan" => art.path.contains("plans/"),
+                "goal" => art.path.contains(".adze/goals/"),
+                "handoff" => art.path.contains("handoffs/"),
+                _ => true,
+            };
+            if !path_matches_kind {
+                warnings.push(format!(
+                    "artifact {} kind '{}' may not match path '{}'",
+                    art.id, art.kind, art.path
+                ));
+            }
+        }
+
+        // Link resolution
+        for link in &art.links_to {
+            if !all_ids.contains(link.as_str()) {
+                // Links can also be paths or external refs (not artifact IDs)
+                let link_path = root.join(link);
+                if !link_path.exists()
+                    && !link.starts_with("docs/")
+                    && !link.starts_with("policy/")
+                    && !link.starts_with("scripts/")
+                {
+                    warnings.push(format!(
+                        "artifact {} links_to '{}' which is not a known artifact ID or existing path",
+                        art.id, link
+                    ));
+                }
+            }
+        }
+    }
+
+    // Report
+    println!(
+        "doc-artifacts: {} artifacts registered",
+        file.artifacts.len()
+    );
+
+    for w in &warnings {
+        eprintln!("  warning: {w}");
+    }
+    for e in &errors {
+        eprintln!("  error: {e}");
+    }
+
+    if errors.is_empty() {
+        println!(
+            "doc-artifacts: all checks passed ({} warnings)",
+            warnings.len()
+        );
+        Ok(())
+    } else if mode == SimpleCheckMode::Advisory {
+        eprintln!(
+            "doc-artifacts: advisory mode reported {} errors in {}",
+            errors.len(),
+            POLICY_PATH
+        );
+        Ok(())
+    } else {
+        anyhow::bail!(
+            "doc-artifacts: {} errors found in {}",
+            errors.len(),
+            POLICY_PATH
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Adds lightweight xtask validators for the Adze source-of-truth stack:

- `cargo run -q -p xtask -- check-doc-artifacts`
- `cargo run -q -p xtask -- check-active-goal`

## Production delta

- Registers two new `xtask` subcommands.
- Adds `policy/doc-artifacts.toml` validation for parseability, unique IDs, existing artifact paths, valid kind/status values, kind/path consistency, and resolvable links.
- Adds `.adze/goals/active.toml` validation for required campaign fields, unique work-item IDs, valid statuses, blocked-by references, proof/command expectations, and linked path existence.
- Supports explicit `--mode advisory` and `--mode blocking` for the source-of-truth checks; CI can use `--mode blocking`.

## Non-goals

- No runtime/parser behavior changes.
- No CI workflow hook in this PR; #774 wires these commands into CI policy after this lands.
- No semantic judgment about whether a proposal/spec/ADR is correct; these are structural guardrails.

## Source-of-truth impact

- Makes the docs/proposal/spec/ADR/plan/goal stack machine-checkable enough for routine PRs.
- Does not change `SUPPORT_TIERS.md` or policy-ledger ownership.

## Proof commands

```bash
cargo fmt -p xtask -- --check
cargo check -p xtask
cargo run -q -p xtask -- check-doc-artifacts --mode blocking
cargo run -q -p xtask -- check-active-goal --mode blocking
git diff --check main...HEAD
```

Current local output:

```text
doc-artifacts: 21 artifacts registered
doc-artifacts: all checks passed (0 warnings)
active-goal: 24 work items in campaign 'Adze 0.9.0 contract convergence'
  complete: 24, active: 0, ready: 0, blocked: 0
active-goal: all checks passed (0 warnings)
```

## Rollback

Revert this PR; #774 should not merge unless these commands exist.