### PR TITLE
ci(policy): run source-of-truth checks in policy lane

### DIFF
--- a/.github/workflows/ci-policy.yml
+++ b/.github/workflows/ci-policy.yml
@@ -60,3 +60,55 @@ jobs:
             cat target/ci-lane-whitelist.log || true;
             echo '```';
           } >> "$GITHUB_STEP_SUMMARY"
+
+  source-of-truth:
+    name: Source of Truth
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Tree-sitter development libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libtree-sitter-dev pkg-config
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: adze-xtask-${{ hashFiles('Cargo.lock') }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Build xtask
+        run: cargo build -p xtask --bin xtask
+      - name: Check doc-artifacts ledger
+        run: |
+          set -o pipefail
+          mkdir -p target/policy
+          cargo run -q -p xtask -- check-doc-artifacts --mode blocking 2>&1 | tee target/policy/doc-artifacts.log
+      - name: Check active goal manifest
+        run: |
+          set -o pipefail
+          cargo run -q -p xtask -- check-active-goal --mode blocking 2>&1 | tee target/policy/active-goal.log
+      - name: Upload source-of-truth receipts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: source-of-truth-receipts
+          path: |
+            target/policy/doc-artifacts.log
+            target/policy/active-goal.log
+          if-no-files-found: warn
+      - name: Append to step summary
+        if: always()
+        run: |
+          {
+            echo "## Source of Truth";
+            echo "";
+            echo "### Doc Artifacts";
+            echo '```';
+            cat target/policy/doc-artifacts.log || true;
+            echo '```';
+            echo "";
+            echo "### Active Goal";
+            echo '```';
+            cat target/policy/active-goal.log || true;
+            echo '```';
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Runs the new source-of-truth validators from #773 in the CI policy workflow.

## Production delta

- Adds one `Source of Truth` policy job to `.github/workflows/ci-policy.yml`.
- Builds `xtask` once, then runs:
  - `cargo run -q -p xtask -- check-doc-artifacts --mode blocking`
  - `cargo run -q -p xtask -- check-active-goal --mode blocking`
- Uploads log receipts for both checks.
- Writes both check outputs into the GitHub step summary.

## CI economics

This replaces the earlier two-job shape with one combined job so the policy lane only installs dependencies and builds `xtask` once for both source-of-truth checks.

## Non-goals

- No runtime/parser changes.
- No branch-protection promotion in this PR.
- No changes to the artifact ledger or active goal manifest.

## Proof commands

```bash
cargo run -q -p xtask -- check-doc-artifacts --mode blocking
cargo run -q -p xtask -- check-active-goal --mode blocking
git diff --check main...HEAD
```

Current local output:

```text
doc-artifacts: 21 artifacts registered
doc-artifacts: all checks passed (0 warnings)
active-goal: 24 work items in campaign 'Adze 0.9.0 contract convergence'
  complete: 24, active: 0, ready: 0, blocked: 0
active-goal: all checks passed (0 warnings)
```

## Rollback

Revert this workflow-only PR. The xtask commands from #773 can remain available locally.