### PR TITLE
plans: close document json schema alpha slice

### DIFF
--- a/.adze/goals/active.toml
+++ b/.adze/goals/active.toml
@@ -353,13 +353,13 @@ commands = [
 
 [[work_item]]
 id = "document-json-schema-alpha"
-status = "ready"
+status = "complete"
 proposal = "docs/proposals/ADZE-PROP-0002-api-foundation.md"
 spec = "docs/specs/ADZE-SPEC-0008-json-cli-wasm-projections.md"
 adr = "docs/adr/ADZE-ADR-0004-schema-versioned-projections.md"
 plan = "plans/0.9.0/api-foundation.md"
 blocked_by = []
-prs = []
+prs = [775]
 commands = [
   "cargo test -p adze --features \"pure-rust,serialization\" --test adze_document_json -- --nocapture",
   "git diff --check",

--- a/plans/0.9.0/api-foundation.md
+++ b/plans/0.9.0/api-foundation.md
@@ -250,9 +250,10 @@ git diff --check
 
 ## Work Item: document-json-schema-alpha
 
-Status: ready
+Status: complete
 Linked spec: ../../docs/specs/ADZE-SPEC-0008-json-cli-wasm-projections.md
 Blocked by: none
+PR: #775
 
 ### Goal
 


### PR DESCRIPTION
## Summary

Closes the document JSON schema alpha API-foundation slice after the `adze_document_json` proof passed.

## Linked artifacts

- Proposal: `docs/proposals/ADZE-PROP-0002-api-foundation.md`
- Spec: `docs/specs/ADZE-SPEC-0008-json-cli-wasm-projections.md`
- ADR: `docs/adr/ADZE-ADR-0004-schema-versioned-projections.md`
- Plan: `plans/0.9.0/api-foundation.md`
- Active goal item: `document-json-schema-alpha`

## Production delta

- Marks `document-json-schema-alpha` complete in `plans/0.9.0/api-foundation.md` and `.adze/goals/active.toml`.
- Records PR #775 for the slice.

## Non-goals

- No runtime behavior changes.
- No JSON schema stabilization or support-tier promotion.
- No CLI/WASM output changes.

## Source-of-truth impact

- Roadmap: unchanged.
- Proposal: unchanged.
- Spec: unchanged.
- ADR: unchanged.
- Plan: closes one API-foundation work item.
- Active manifest: closes one work item.
- Support tiers: unchanged.
- Policy ledger: unchanged.

## User impact

No direct API change; this records that the schema-versioned document JSON alpha proof slice is complete.

## Agent impact

Agents can build later CLI/WASM projection work assuming the document JSON alpha proof is closed.

## Proof commands

```bash
cargo test -p adze --features "pure-rust,serialization" --test adze_document_json -- --nocapture
python -c "import tomllib; tomllib.load(open('.adze/goals/active.toml','rb')); print('active toml ok')"
git diff --check
```

## Rollback

Revert this PR to mark the work item ready again.