### PR TITLE
plans: close language schema node types slice

### DIFF
--- a/.adze/goals/active.toml
+++ b/.adze/goals/active.toml
@@ -367,15 +367,16 @@ commands = [
 
 [[work_item]]
 id = "language-schema-node-types"
-status = "ready"
+status = "complete"
 proposal = "docs/proposals/ADZE-PROP-0002-api-foundation.md"
 spec = "docs/specs/ADZE-SPEC-0010-language-metadata-and-node-types.md"
 adr = "docs/adr/ADZE-ADR-0001-adze-document-one-parse-truth.md"
 plan = "plans/0.9.0/api-foundation.md"
 blocked_by = []
-prs = []
+prs = [776]
 commands = [
   "cargo test -p adze-tablegen node_types -- --nocapture",
-  "cargo test -p adze --features \"pure-rust,ts-compat\" --test ts_compat_node_types -- --nocapture",
+  "cargo test -p adze --features \"pure-rust,ts-compat\" --test ts_compat_language_metadata -- --nocapture",
+  "cargo test -p adze --features \"pure-rust,ts-compat\" --test ts_compat_language_fields -- --nocapture",
   "git diff --check",
 ]

--- a/plans/0.9.0/api-foundation.md
+++ b/plans/0.9.0/api-foundation.md
@@ -269,9 +269,10 @@ git diff --check
 
 ## Work Item: language-schema-node-types
 
-Status: ready
+Status: complete
 Linked spec: ../../docs/specs/ADZE-SPEC-0010-language-metadata-and-node-types.md
 Blocked by: none
+PR: #776
 
 ### Goal
 
@@ -282,7 +283,8 @@ by typed CST and Tree-sitter compatibility.
 
 ```bash
 cargo test -p adze-tablegen node_types -- --nocapture
-cargo test -p adze --features "pure-rust,ts-compat" --test ts_compat_node_types -- --nocapture
+cargo test -p adze --features "pure-rust,ts-compat" --test ts_compat_language_metadata -- --nocapture
+cargo test -p adze --features "pure-rust,ts-compat" --test ts_compat_language_fields -- --nocapture
 git diff --check
 ```
 


### PR DESCRIPTION
## Summary

Closes the language schema and node-types API-foundation slice after the tablegen node-types and ts_compat language metadata proofs passed.

## Linked artifacts

- Proposal: `docs/proposals/ADZE-PROP-0002-api-foundation.md`
- Spec: `docs/specs/ADZE-SPEC-0010-language-metadata-and-node-types.md`
- ADR: `docs/adr/ADZE-ADR-0001-adze-document-one-parse-truth.md`
- Plan: `plans/0.9.0/api-foundation.md`
- Active goal item: `language-schema-node-types`

## Production delta

- Marks `language-schema-node-types` complete in `plans/0.9.0/api-foundation.md` and `.adze/goals/active.toml`.
- Records PR #776 for the slice.
- Replaces the stale `ts_compat_node_types` proof command with the actual `ts_compat_language_metadata` and `ts_compat_language_fields` canaries.

## Non-goals

- No runtime behavior changes.
- No node-types support-tier promotion.
- No Tree-sitter query compatibility claim.

## Source-of-truth impact

- Roadmap: unchanged.
- Proposal: unchanged.
- Spec: unchanged.
- ADR: unchanged.
- Plan: closes one API-foundation work item and fixes its stale proof command.
- Active manifest: closes one work item and fixes its stale proof command.
- Support tiers: unchanged.
- Policy ledger: unchanged.

## User impact

No direct API change; this records that language metadata and node-types proof coverage is complete for the API-foundation lane.

## Agent impact

Agents now have a real proof command set for language metadata and node-types rather than a non-existent `ts_compat_node_types` target.

## Proof commands

```bash
cargo test -p adze-tablegen node_types -- --nocapture
cargo test -p adze --features "pure-rust,ts-compat" --test ts_compat_language_metadata -- --nocapture
cargo test -p adze --features "pure-rust,ts-compat" --test ts_compat_language_fields -- --nocapture
python -c "import tomllib; tomllib.load(open('.adze/goals/active.toml','rb')); print('active toml ok')"
git diff --check
```

## Rollback

Revert this PR to mark the work item ready again and restore the previous command list.