### PR TITLE
docs: align SRP release gate guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,9 @@ Add to `~/.bashrc` or `~/.zshrc` for persistence:
 export RUSTC_WRAPPER=sccache
 ```
 
-sccache caches compiled artifacts, significantly reducing rebuild times. This is especially helpful for the 75-crate workspace.
+sccache caches compiled artifacts, significantly reducing rebuild times. This is
+still useful for the post-collapse 28-package workspace, especially after
+`cargo clean` or toolchain updates.
 
 ### Linting
 
@@ -122,7 +124,9 @@ These are checked by `just ci-supported`:
 
 - **`runtime2/`** — Production GLR runtime with Tree-sitter compatible API
 - **`grammars/`** — Language implementations: `python`, `javascript`, `go`, `python-simple`, `test-vec-wrapper`
-- **`crates/`** — 47 governance-as-code micro-crates (concurrency, BDD, policy, parser contracts)
+- **`crates/`** — durable support crates after the microcrate-to-SRP collapse:
+  `bdd-governance-core`, `common-type-ops-core`, `linecol-core`,
+  `parsetable-metadata`, plus the excluded `ts-c-harness`
 - **`tools/ts-bridge/`** — Tree-sitter parse table extraction (excluded from workspace)
 - **`cli/`**, **`lsp-generator/`**, **`playground/`**, **`wasm-demo/`** — Developer tools
 - **`golden-tests/`** — Tree-sitter parity validation
@@ -194,7 +198,7 @@ Enforced via `[workspace.lints.rust]`:
 | `pure-rust-ci.yml` | Pure-Rust implementation |
 | `core-tests.yml` | Core crate testing |
 | `golden-tests.yml` | Tree-sitter parity |
-| `microcrate-ci.yml` | Governance micro-crates |
+| `microcrate-ci.yml` | Post-collapse support/governance risk packs |
 | `fuzz.yml` | Fuzz testing |
 | `benchmarks.yml` | Performance benchmarks |
 
@@ -238,7 +242,7 @@ If all pass, the PR is ready for review.
 
 - `justfile` — Development recipes
 - `rust-toolchain.toml` — Toolchain pinning
-- `Cargo.toml` — Workspace root with 75 members
+- `Cargo.toml` — Workspace root with 28 members
 - `.githooks/pre-commit` — Pre-commit checks (install via `.githooks/install.sh`)
 - `docs/status/KNOWN_RED.md` — Intentional CI exclusions
 - `scripts/test-matrix.sh` — Feature matrix testing

--- a/docs/reference/PUBLISH_CHECKLIST.md
+++ b/docs/reference/PUBLISH_CHECKLIST.md
@@ -1,38 +1,55 @@
 # Publish Checklist
 
-How to publish the core Adze crates to crates.io.
+How to publish the Adze release surface to crates.io.
 
 ## Publish Order
 
-Crates **must** be published in dependency order. Each crate must be
-available on the registry before its dependents can be packaged.
+Crates **must** be published in dependency order. The source of truth for the
+release surface and publish order is:
+
+```text
+scripts/release-crates.txt
+```
+
+The 0.9 microcrate-to-SRP transition is complete. Temporary
+`owner-module-migration-target` packages are not allowed in the release surface;
+the release gate must pass before publishing.
+
+```bash
+cargo run -q -p xtask -- check-package-boundary --release-gate
+PACKAGE_BOUNDARY_RELEASE_GATE=1 ./scripts/validate-release-surface.sh
+```
+
+Durable support crates that remain standalone are recorded by
+`docs/adr/ADZE-ADR-0005-durable-published-support-crates.md` and must remain in
+the release surface while core crates depend on them:
+
+- `adze-bdd-governance-core`
+- `adze-linecol-core`
+- `adze-parsetable-metadata`
+
+The following table is a compact dependency reminder for the core pipeline, not
+the complete release surface.
 
 | Step | Crate | Directory | Key deps |
 |------|-------|-----------|----------|
 | 1 | `adze-common` | `common/` | *(external only)* |
 | 2 | `adze-ir` | `ir/` | *(external only)* |
-| 3 | `adze-glr-core` | `glr-core/` | `adze-ir` |
-| 4 | `adze-tablegen` | `tablegen/` | `adze-ir`, `adze-glr-core`, `adze-bdd-governance-core`, `adze-parsetable-metadata` |
-| 5 | `adze-macro` | `macro/` | `adze-common` |
-| 6 | `adze-tool` | `tool/` | `adze-common`, `adze-ir`, `adze-glr-core`, `adze-tablegen` |
-| 7 | `adze` | `runtime/` | `adze-macro`, `adze-ir`, `adze-glr-core`, `adze-tablegen`, microcrates |
-
-### Prerequisite micro-crates
-
-Several governance/infrastructure micro-crates must be published **before**
-the core crates that depend on them. The full set (in order) is:
-
-1. All `adze-concurrency-*` crates (caps-contract-core, map-core, env-core,
-   init-core, caps-core, etc.)
-2. `adze-linecol-core`
-3. `adze-bdd-governance-core`
-4. `adze-parsetable-metadata`
+| 3 | durable support crates | `crates/*` | see `ADZE-ADR-0005` |
+| 4 | `adze-glr-core` | `glr-core/` | `adze-ir` |
+| 5 | `adze-tablegen` | `tablegen/` | `adze-ir`, `adze-glr-core`, durable support crates |
+| 6 | `adze-macro` | `macro/` | `adze-common` |
+| 7 | `adze-tool` | `tool/` | `adze-common`, `adze-ir`, `adze-glr-core`, `adze-tablegen` |
+| 8 | `adze` | `runtime/` | `adze-macro`, `adze-ir`, `adze-glr-core`, `adze-tablegen`, durable support crates |
 
 ## Pre-publish verification
 
 ```bash
 # Run the automated check (metadata + cargo package --list)
 ./scripts/check-publish.sh
+
+# Validate the release surface and the microcrate-to-SRP release gate
+PACKAGE_BOUNDARY_RELEASE_GATE=1 ./scripts/validate-release-surface.sh
 
 # Full packaging test (requires all deps on crates.io already)
 cargo package --allow-dirty -p <crate>
@@ -63,21 +80,23 @@ git status  # should be clean
 # 2. Update versions for the release you are cutting
 #    For example: 0.8.0 -> 0.9.0, including Cargo.toml files and cross-references.
 
-# 3. Run the publish check
+# 3. Run the publish and release-surface checks
 ./scripts/check-publish.sh
+PACKAGE_BOUNDARY_RELEASE_GATE=1 ./scripts/validate-release-surface.sh
 
 # 4. Commit the version bump
 git commit -am "release: vX.Y.Z"
 git tag vX.Y.Z
 
-# 5. Publish in order (wait for each to appear on crates.io)
-cargo publish -p adze-common
-cargo publish -p adze-ir
-cargo publish -p adze-glr-core
-cargo publish -p adze-tablegen
-cargo publish -p adze-macro
-cargo publish -p adze-tool
-cargo publish -p adze
+# 5. Publish in scripts/release-crates.txt order.
+#    Prefer the release helper; otherwise publish each listed crate manually and
+#    wait for each to appear on crates.io before publishing dependents.
+./scripts/release.sh
+# or:
+# while read -r crate; do
+#   [[ -z "$crate" || "$crate" == \#* ]] && continue
+#   cargo publish -p "$crate"
+# done < scripts/release-crates.txt
 
 # 6. Push tags
 git push origin main --tags

--- a/docs/status/FRICTION_LOG.md
+++ b/docs/status/FRICTION_LOG.md
@@ -123,11 +123,18 @@ If it happens twice, it's not "user error". It's friction we own until we remove
 ### FR-009 - Slow Workspace Build
 
 **Area:** dev loop
-**Symptom:** `cargo check --workspace` or `cargo build` takes 10+ minutes on standard hardware due to 47 microcrates in `crates/` plus the full core pipeline.
+**Symptom:** `cargo check --workspace` or `cargo build` historically took 10+
+minutes on standard hardware when the workspace included 47 governance/support
+microcrates plus the full core pipeline.
 **Expected:** Developers can iterate quickly on individual crates.
-**Actual:** Full workspace builds are prohibitively slow for local development.
-**Fix:** Use per-crate `cargo check -p <crate>` for iteration; consider workspace partitioning.
-**Status:** Open
+**Actual:** The 0.9 microcrate-to-SRP collapse reduced the workspace to 28
+packages, but full workspace builds can still be heavier than focused
+iteration because grammar/tooling/golden surfaces remain outside the core
+supported lane.
+**Fix:** Use per-crate `cargo check -p <crate>` and `just ci-supported` for
+routine iteration. Keep the package-boundary release gate green so temporary
+microcrates do not return before release.
+**Status:** Mitigated
 
 ### FR-010 - `pure_parser.rs` Parse Errors
 

--- a/docs/status/KNOWN_RED.md
+++ b/docs/status/KNOWN_RED.md
@@ -1,6 +1,6 @@
 # Known red
 
-**Last updated:** 2026-05-07
+**Last updated:** 2026-05-14
 
 This file tracks intentional exclusions from the supported lane:
 
@@ -56,7 +56,11 @@ These are intentionally excluded for now because they are prototypes, platform-s
 - `golden-tests/` (useful contract, but can be heavy and multi-language)
 - `benchmarks/` (signal, not merge-blocking)
 - `grammars/*` (valuable, but not yet a stable published surface)
-- `crates/*` (47 BDD/governance microcrates; structure stable, READMEs added)
+- `crates/*` support surfaces are not part of the required `ci-supported`
+  lane unless one is also a core pipeline dependency. The 0.9
+  microcrate-to-SRP collapse is complete; release readiness is guarded by
+  `cargo run -q -p xtask -- check-package-boundary --release-gate`, which
+  fails if a temporary owner-module migration target returns.
 
 ### Not in the supported lane (workflows)
 These may run as optional signal (nightly/manual/canary), but are not required for merge:


### PR DESCRIPTION
## Summary

Aligns current-facing docs with the completed microcrate-to-SRP transition before the next release.

## Linked artifacts

- Spec: `docs/specs/ADZE-SPEC-0001-package-surface-boundary.md`
- ADRs: `docs/adr/ADZE-ADR-0002-no-durable-unpublished-production-crates.md`, `docs/adr/ADZE-ADR-0005-durable-published-support-crates.md`
- Plan: `plans/0.9.0/microcrate-collapse.md`
- Policy: `policy/package-boundary.toml`

## Production delta

- Updates `AGENTS.md` from the stale 75-crate / 47-microcrate wording to the post-collapse 28-package workspace.
- Updates `docs/status/KNOWN_RED.md` so `crates/*` exclusion language points at the package-boundary release gate.
- Marks the old slow-workspace friction entry as mitigated by the SRP collapse.
- Updates `docs/reference/PUBLISH_CHECKLIST.md` so publishing follows `scripts/release-crates.txt` and the package-boundary release gate instead of old prerequisite microcrate guidance.

## Non-goals

- No runtime changes.
- No package-boundary ledger changes.
- No publish script behavior changes.

## Source-of-truth impact

- Roadmap: unchanged; already records the completed release-blocking SRP collapse.
- Spec/ADR/Plan: unchanged; this PR aligns secondary docs with them.
- Support tiers: unchanged.
- Policy ledger: unchanged.

## Proof commands

```bash
git diff --check HEAD~1..HEAD
cargo run -q -p xtask -- check-package-boundary
cargo run -q -p xtask -- check-package-boundary --release-gate
```

## Rollback

Revert this docs-only commit.