### PR TITLE
xtask: satisfy source-of-truth clippy checks

### DIFF
--- a/xtask/src/policy/active_goal.rs
+++ b/xtask/src/policy/active_goal.rs
@@ -12,7 +12,6 @@
 use anyhow::{Context, Result};
 use serde::Deserialize;
 use std::collections::BTreeSet;
-use std::path::Path;
 
 use super::{SimpleCheckMode, workspace_root};
 
@@ -89,6 +88,12 @@ pub fn run(mode: &str) -> Result<()> {
     }
     if file.owner.is_empty() {
         errors.push("missing top-level owner".into());
+    }
+    if file.created.is_empty() {
+        errors.push("missing top-level created".into());
+    }
+    if file.objective.trim().is_empty() {
+        errors.push("missing top-level objective".into());
     }
     if file.end_state.is_empty() {
         warnings.push("empty end_state".into());

--- a/xtask/src/policy/doc_artifacts.rs
+++ b/xtask/src/policy/doc_artifacts.rs
@@ -11,8 +11,7 @@
 
 use anyhow::{Context, Result};
 use serde::Deserialize;
-use std::collections::{BTreeMap, BTreeSet};
-use std::path::Path;
+use std::collections::BTreeSet;
 
 use super::{SimpleCheckMode, workspace_root};
 
@@ -79,6 +78,9 @@ pub fn run(mode: &str) -> Result<()> {
     if file.policy.is_empty() {
         errors.push("missing policy".into());
     }
+    if file.owner.is_empty() {
+        errors.push("missing owner".into());
+    }
     if file.status.is_empty() {
         errors.push("missing status".into());
     }
@@ -111,6 +113,15 @@ pub fn run(mode: &str) -> Result<()> {
         }
         if art.owner.is_empty() {
             errors.push(format!("artifact {} missing owner", art.id));
+        }
+        if art.milestone.is_empty() {
+            warnings.push(format!("artifact {} missing milestone", art.id));
+        }
+        if art.source_of_truth_for.is_empty() {
+            warnings.push(format!(
+                "artifact {} missing source_of_truth_for entries",
+                art.id
+            ));
         }
 
         // Kind validation


### PR DESCRIPTION
## Summary
- removes unused imports in source-of-truth policy checkers
- validates previously ignored manifest/ledger fields so clippy stays clean under broad workspace checks
- keeps doc-artifact and active-goal checks at zero warnings

## Linked artifacts
- Spec: ADZE-SPEC-0001 package surface boundary / source-of-truth release gate rails
- Plan: plans/0.9.0/implementation-plan.md
- Active goal: .adze/goals/active.toml source-of-truth checker work items

## Production delta
`xtask` policy checkers now read and validate the source-of-truth metadata they deserialize instead of leaving broad clippy warnings on advisory CI.

## Non-goals
- no runtime/parser behavior changes
- no policy TOML changes
- no support-tier promotion

## Proof commands
```bash
cargo fmt -p xtask -- --check
cargo clippy -p xtask --all-targets -- -D warnings
cargo run -q -p xtask -- check-doc-artifacts --mode blocking
cargo run -q -p xtask -- check-active-goal --mode blocking
cargo clippy --workspace --all-targets -- -D warnings
cargo test -p xtask -- --nocapture
git diff --check
```

## Support-tier impact
None.

## Policy impact
Strengthens policy checkers by requiring top-level active-goal `created`/`objective` and doc-artifact `owner`, while keeping current ledgers green.

## Rollback
Revert this PR; the policy checkers return to the previous validation behavior and broad clippy warnings.