### PR TITLE
Add Rust migration candidates to file policy

### DIFF
--- a/docs/FILE_POLICY.md
+++ b/docs/FILE_POLICY.md
@@ -49,6 +49,13 @@ The check runs in **advisory** mode for now: it writes
 `target/policy/file-policy.md` and `target/policy/file-policy.json` but does
 not fail CI. Once the baseline is settled, this will flip to blocking.
 
+The same report now includes a **Rust migration candidates** section. These are
+non-Rust files that are executable repository logic (shell/Python/JavaScript
+scripts, hooks, release helpers) or production `grammar.js` definitions that can
+be moved toward the Rust-first core design. Tooling candidates should normally
+land as `xtask` subcommands; grammar candidates should normally land as Rust
+annotation-driven grammar crates.
+
 ## Adding a new non-Rust file
 
 1. Try Rust first. Many YAML configs and shell scripts can be replaced with

--- a/xtask/src/policy/file_policy.rs
+++ b/xtask/src/policy/file_policy.rs
@@ -51,6 +51,7 @@ pub struct FileReport {
     pub allowlist_size: usize,
     pub unallowlisted: Vec<String>,
     pub unused_entries: Vec<UnusedEntry>,
+    pub rust_migration_candidates: Vec<RustMigrationCandidate>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -58,6 +59,16 @@ pub struct UnusedEntry {
     pub glob: String,
     pub kind: String,
     pub owner: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RustMigrationCandidate {
+    pub path: String,
+    pub kind: String,
+    pub owner: String,
+    pub current_language: String,
+    pub suggested_home: String,
+    pub reason: String,
 }
 
 pub fn run_check(mode: Mode) -> Result<()> {
@@ -100,8 +111,11 @@ pub fn run_check(mode: Mode) -> Result<()> {
             report.unallowlisted.push(path.clone());
         } else {
             report.matched += 1;
-            for m in matches {
-                used.insert(m);
+            for m in &matches {
+                used.insert(*m);
+            }
+            if let Some(candidate) = rust_migration_candidate(path, &matches, &entries) {
+                report.rust_migration_candidates.push(candidate);
             }
         }
     }
@@ -148,6 +162,110 @@ pub fn run_check(mode: Mode) -> Result<()> {
             }
             Ok(())
         }
+    }
+}
+
+fn rust_migration_candidate(
+    path: &str,
+    matches: &[usize],
+    entries: &[AllowEntry],
+) -> Option<RustMigrationCandidate> {
+    let entry = most_specific_entry(matches, entries)?;
+    if !is_rust_migration_surface(path, entry) {
+        return None;
+    }
+    Some(RustMigrationCandidate {
+        path: path.to_string(),
+        kind: entry.kind.clone(),
+        owner: entry.owner.clone(),
+        current_language: current_language(path),
+        suggested_home: suggested_home(path, entry),
+        reason: migration_reason(path, entry),
+    })
+}
+
+fn most_specific_entry<'a>(matches: &[usize], entries: &'a [AllowEntry]) -> Option<&'a AllowEntry> {
+    matches
+        .iter()
+        .filter_map(|idx| entries.get(*idx))
+        .max_by_key(|entry| {
+            entry
+                .glob
+                .as_deref()
+                .or(entry.path.as_deref())
+                .map(str::len)
+                .unwrap_or_default()
+        })
+}
+
+fn is_rust_migration_surface(path: &str, entry: &AllowEntry) -> bool {
+    if entry.classification == "generated" || entry.classification == "config" {
+        return false;
+    }
+
+    if is_grammar_definition(path) {
+        return entry.surface == "grammar" || entry.kind.contains("grammar");
+    }
+
+    if is_shell_like(path) {
+        return entry.classification == "tooling"
+            || entry.surface == "tooling"
+            || entry.surface == "build"
+            || entry.surface == "release";
+    }
+
+    false
+}
+
+fn is_shell_like(path: &str) -> bool {
+    matches!(
+        extension(path),
+        Some("sh" | "py" | "js" | "ts" | "mjs" | "cjs")
+    ) && !path.starts_with("book/book/")
+}
+
+fn is_grammar_definition(path: &str) -> bool {
+    path.ends_with("grammar.js")
+}
+
+fn extension(path: &str) -> Option<&str> {
+    Path::new(path).extension().and_then(|ext| ext.to_str())
+}
+
+fn current_language(path: &str) -> String {
+    match extension(path) {
+        Some("sh") => "shell".to_string(),
+        Some("py") => "python".to_string(),
+        Some("js" | "mjs" | "cjs") => "javascript".to_string(),
+        Some("ts") => "typescript".to_string(),
+        Some(other) => other.to_string(),
+        None => "unknown".to_string(),
+    }
+}
+
+fn suggested_home(path: &str, entry: &AllowEntry) -> String {
+    if is_grammar_definition(path) {
+        return "Rust grammar crate using Adze annotations".to_string();
+    }
+    if path.starts_with(".githooks/") {
+        return "xtask lint/preflight subcommand plus thin hook shim".to_string();
+    }
+    if path.starts_with("scripts/") || entry.surface == "tooling" || entry.surface == "release" {
+        return "xtask subcommand".to_string();
+    }
+    "core Rust crate or xtask command".to_string()
+}
+
+fn migration_reason(path: &str, entry: &AllowEntry) -> String {
+    if is_grammar_definition(path) {
+        "Tree-sitter JavaScript grammar definitions are production grammar surface area; moving them into Rust annotations keeps grammar design in the core pipeline.".to_string()
+    } else if path.starts_with("scripts/") || path.starts_with(".githooks/") {
+        "Repository automation is executable logic; moving it into xtask gives it Rust types, Cargo dependencies, and workspace test coverage.".to_string()
+    } else {
+        format!(
+            "{} is a non-Rust {} surface owned by {}; consider a Rust implementation when this file changes.",
+            path, entry.surface, entry.owner
+        )
     }
 }
 
@@ -254,11 +372,29 @@ fn write_reports(dir: &Path, report: &FileReport) -> Result<()> {
         "- unused allowlist entries: {}\n",
         report.unused_entries.len()
     ));
+    md.push_str(&format!(
+        "- Rust migration candidates: {}\n",
+        report.rust_migration_candidates.len()
+    ));
 
     if !report.unallowlisted.is_empty() {
         md.push_str("\n## Unallowlisted (top 100)\n\n");
         for p in report.unallowlisted.iter().take(100) {
             md.push_str(&format!("- `{p}`\n"));
+        }
+    }
+    if !report.rust_migration_candidates.is_empty() {
+        md.push_str("\n## Rust migration candidates (top 100)\n\n");
+        md.push_str("| path | current | suggested home | owner | why |\n|---|---|---|---|---|\n");
+        for candidate in report.rust_migration_candidates.iter().take(100) {
+            md.push_str(&format!(
+                "| `{}` | {} | {} | {} | {} |\n",
+                candidate.path,
+                candidate.current_language,
+                candidate.suggested_home,
+                candidate.owner,
+                candidate.reason
+            ));
         }
     }
     if !report.unused_entries.is_empty() {
@@ -279,4 +415,60 @@ fn print_summary(report: &FileReport) {
     println!("  matched:          {}", report.matched);
     println!("  unallowlisted:    {}", report.unallowlisted.len());
     println!("  unused entries:   {}", report.unused_entries.len());
+    println!(
+        "  Rust migrations:  {}",
+        report.rust_migration_candidates.len()
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(kind: &str, surface: &str, classification: &str) -> AllowEntry {
+        AllowEntry {
+            glob: Some("scripts/**".to_string()),
+            path: None,
+            kind: kind.to_string(),
+            owner: "core/build".to_string(),
+            surface: surface.to_string(),
+            classification: classification.to_string(),
+            reason: "test entry".to_string(),
+            covered_by: Vec::new(),
+            expires: None,
+            retired: None,
+            generated_by: None,
+        }
+    }
+
+    #[test]
+    fn rust_migration_candidate_accepts_tooling_scripts() {
+        let entries = vec![entry("shell_tooling", "tooling", "tooling")];
+        let candidate = rust_migration_candidate("scripts/check.sh", &[0], &entries)
+            .expect("tooling script should be a migration candidate");
+
+        assert_eq!(candidate.current_language, "shell");
+        assert_eq!(candidate.suggested_home, "xtask subcommand");
+    }
+
+    #[test]
+    fn rust_migration_candidate_skips_language_fixtures() {
+        let entries = vec![entry("language_fixture", "fixtures", "test")];
+        let candidate = rust_migration_candidate("fixtures/example.py", &[0], &entries);
+
+        assert!(candidate.is_none());
+    }
+
+    #[test]
+    fn rust_migration_candidate_routes_grammar_js_to_rust_grammar() {
+        let entries = vec![entry("grammar_input", "grammar", "production")];
+        let candidate = rust_migration_candidate("grammars/example/grammar.js", &[0], &entries)
+            .expect("production grammar.js should be a migration candidate");
+
+        assert_eq!(candidate.current_language, "javascript");
+        assert_eq!(
+            candidate.suggested_home,
+            "Rust grammar crate using Adze annotations"
+        );
+    }
 }


### PR DESCRIPTION
### Motivation
- Provide visibility into non-Rust files that are good candidates to be migrated into the Rust-first core design (xtask subcommands, Rust grammar crates, or thin hook shims). 
- Encourage replacing executable repository logic (scripts, hooks, release helpers) and production `grammar.js` surfaces with typed, testable Rust implementations.

### Description
- Extend `FileReport` with a `rust_migration_candidates` list and add a `RustMigrationCandidate` struct to capture `path`, `kind`, `owner`, `current_language`, `suggested_home`, and `reason` in `xtask/src/policy/file_policy.rs`.
- Implement detection and classification logic (`rust_migration_candidate`, `most_specific_entry`, `is_rust_migration_surface`, `is_shell_like`, `is_grammar_definition`, `extension`, `current_language`, `suggested_home`, `migration_reason`) to identify tooling/grammar migration candidates.
- Emit candidates into the Markdown/JSON report and terminal summary produced by the `cargo xtask check-file-policy` flow and document the new report section in `docs/FILE_POLICY.md`.
- Add unit tests covering tooling-script candidates, fixture exclusions, and `grammar.js` routing.

### Testing
- Ran `cargo xtask check-file-policy`, which completed successfully and produced the updated report (report showed migration candidates). 
- Ran `cargo test -p xtask`, all tests passed (new tests included), e.g. `41 passed; 0 failed`.
- Ran `cargo clippy -p xtask -- -D warnings`, which completed without warnings/errors.
- Ran `cargo fmt --all -- --check`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d16ed5dc8333ae09aef15e86d4b5)