### PR TITLE
xtask: report Rust migration candidates in file-policy

### DIFF
--- a/docs/FILE_POLICY.md
+++ b/docs/FILE_POLICY.md
@@ -49,6 +49,13 @@ The check runs in **advisory** mode for now: it writes
 `target/policy/file-policy.md` and `target/policy/file-policy.json` but does
 not fail CI. Once the baseline is settled, this will flip to blocking.
 
+The same report includes a **Rust migration candidates** section. These are
+non-Rust files that are executable repository logic, production grammar
+definitions, or durable tooling surfaces that should move toward `xtask`, a
+Rust grammar crate, or an owner module when touched. Fixtures, generated files,
+docs, and platform-required configuration remain registered without becoming
+migration targets.
+
 ## Adding a new non-Rust file
 
 1. Try Rust first. Many YAML configs and shell scripts can be replaced with

--- a/xtask/src/policy/file_policy.rs
+++ b/xtask/src/policy/file_policy.rs
@@ -51,6 +51,18 @@ pub struct FileReport {
     pub allowlist_size: usize,
     pub unallowlisted: Vec<String>,
     pub unused_entries: Vec<UnusedEntry>,
+    pub rust_migration_candidates: Vec<RustMigrationCandidate>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RustMigrationCandidate {
+    pub path: String,
+    pub kind: String,
+    pub owner: String,
+    pub current_surface: String,
+    pub migration_target: String,
+    pub reason: String,
+    pub covered_by: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -66,16 +78,17 @@ pub fn run_check(mode: Mode) -> Result<()> {
     let entries = load_allowlist(&root)?;
 
     let mut builders = Vec::new();
-    for (idx, entry) in entries.iter().enumerate() {
+    for (entry_idx, entry) in entries.iter().enumerate() {
         if let Some(glob) = entry.glob.as_deref().or(entry.path.as_deref()) {
             match Glob::new(glob) {
-                Ok(g) => builders.push((idx, g)),
+                Ok(g) => builders.push((entry_idx, g)),
                 Err(err) => {
                     eprintln!("warning: invalid glob `{glob}` in non-rust-allowlist.toml: {err}");
                 }
             }
         }
     }
+    let pattern_to_entry_idx: Vec<usize> = builders.iter().map(|(idx, _)| *idx).collect();
     let mut gsb = GlobSetBuilder::new();
     for (_, g) in &builders {
         gsb.add(g.clone());
@@ -100,8 +113,15 @@ pub fn run_check(mode: Mode) -> Result<()> {
             report.unallowlisted.push(path.clone());
         } else {
             report.matched += 1;
+            let mut matched_entries = Vec::new();
             for m in matches {
-                used.insert(m);
+                if let Some(entry_idx) = pattern_to_entry_idx.get(m).copied() {
+                    used.insert(entry_idx);
+                    matched_entries.push((entry_idx, &entries[entry_idx]));
+                }
+            }
+            if let Some(candidate) = rust_migration_candidate(path, &matched_entries) {
+                report.rust_migration_candidates.push(candidate);
             }
         }
     }
@@ -254,6 +274,10 @@ fn write_reports(dir: &Path, report: &FileReport) -> Result<()> {
         "- unused allowlist entries: {}\n",
         report.unused_entries.len()
     ));
+    md.push_str(&format!(
+        "- rust migration candidates: {}\n",
+        report.rust_migration_candidates.len()
+    ));
 
     if !report.unallowlisted.is_empty() {
         md.push_str("\n## Unallowlisted (top 100)\n\n");
@@ -269,8 +293,88 @@ fn write_reports(dir: &Path, report: &FileReport) -> Result<()> {
         }
     }
 
+    if !report.rust_migration_candidates.is_empty() {
+        md.push_str("\n## Rust migration candidates\n\n");
+        md.push_str("These matched non-Rust tooling surfaces are good candidates to move into `xtask` or a core Rust crate. Fixture, generated, docs, and platform-required configuration files are intentionally excluded.\n\n");
+        md.push_str(
+            "| path | kind | owner | target | reason | covered by |\n|---|---|---|---|---|---|\n",
+        );
+        for c in &report.rust_migration_candidates {
+            md.push_str(&format!(
+                "| `{}` | {} | {} | {} | {} | {} |\n",
+                c.path,
+                c.kind,
+                c.owner,
+                c.migration_target,
+                c.reason,
+                c.covered_by.join("<br>")
+            ));
+        }
+    }
+
     std::fs::write(dir.join("file-policy.md"), md)?;
     Ok(())
+}
+
+fn rust_migration_candidate(
+    path: &str,
+    matched_entries: &[(usize, &AllowEntry)],
+) -> Option<RustMigrationCandidate> {
+    let entry = matched_entries
+        .iter()
+        .map(|(_, entry)| *entry)
+        .find(|entry| is_migratable_entry(path, entry))?;
+    Some(RustMigrationCandidate {
+        path: path.to_owned(),
+        kind: entry.kind.clone(),
+        owner: entry.owner.clone(),
+        current_surface: entry.surface.clone(),
+        migration_target: migration_target_for(path, entry).to_owned(),
+        reason: entry.reason.clone(),
+        covered_by: entry.covered_by.clone(),
+    })
+}
+
+fn is_migratable_entry(path: &str, entry: &AllowEntry) -> bool {
+    if entry.retired.unwrap_or(false) || entry.classification == "generated" {
+        return false;
+    }
+    if matches!(
+        entry.classification.as_str(),
+        "docs" | "fixtures" | "test" | "config"
+    ) {
+        return false;
+    }
+    let has_tool_extension = matches!(
+        Path::new(path).extension().and_then(|ext| ext.to_str()),
+        Some("sh" | "py" | "js")
+    );
+    let is_tool_surface = matches!(
+        entry.surface.as_str(),
+        "tooling" | "release" | "ci" | "build"
+    );
+    let is_tool_kind = entry.kind.contains("tooling")
+        || entry.kind.contains("orchestrator")
+        || entry.kind == "web_demo";
+    has_tool_extension && is_tool_surface && is_tool_kind
+}
+
+fn migration_target_for(path: &str, entry: &AllowEntry) -> &'static str {
+    if path.starts_with("scripts/ci/") {
+        "xtask CI planning/reporting module"
+    } else if path.starts_with("scripts/") {
+        "xtask policy/build subcommand"
+    } else if path.starts_with("runtime/build-wasm") {
+        "runtime/core WASM build subcommand"
+    } else if path.starts_with("golden-tests/") {
+        "xtask golden-test command"
+    } else if path.starts_with("tools/ts-bridge/") {
+        "ts-bridge Rust crate"
+    } else if entry.surface == "demo" {
+        "Rust-backed playground/demo command"
+    } else {
+        "core Rust tooling surface"
+    }
 }
 
 fn print_summary(report: &FileReport) {
@@ -278,5 +382,9 @@ fn print_summary(report: &FileReport) {
     println!("  non-rust scanned: {}", report.total_non_rust);
     println!("  matched:          {}", report.matched);
     println!("  unallowlisted:    {}", report.unallowlisted.len());
+    println!(
+        "  rust migrations:  {}",
+        report.rust_migration_candidates.len()
+    );
     println!("  unused entries:   {}", report.unused_entries.len());
 }

--- a/xtask/src/policy/file_policy.rs
+++ b/xtask/src/policy/file_policy.rs
@@ -297,14 +297,15 @@ fn write_reports(dir: &Path, report: &FileReport) -> Result<()> {
         md.push_str("\n## Rust migration candidates\n\n");
         md.push_str("These matched non-Rust tooling surfaces are good candidates to move into `xtask` or a core Rust crate. Fixture, generated, docs, and platform-required configuration files are intentionally excluded.\n\n");
         md.push_str(
-            "| path | kind | owner | target | reason | covered by |\n|---|---|---|---|---|---|\n",
+            "| path | kind | owner | surface | target | reason | covered by |\n|---|---|---|---|---|---|---|\n",
         );
         for c in &report.rust_migration_candidates {
             md.push_str(&format!(
-                "| `{}` | {} | {} | {} | {} | {} |\n",
+                "| `{}` | {} | {} | {} | {} | {} | {} |\n",
                 c.path,
                 c.kind,
                 c.owner,
+                c.current_surface,
                 c.migration_target,
                 c.reason,
                 c.covered_by.join("<br>")
@@ -345,22 +346,39 @@ fn is_migratable_entry(path: &str, entry: &AllowEntry) -> bool {
     ) {
         return false;
     }
+    if is_grammar_definition(path) {
+        return entry.surface == "grammar" || entry.kind.contains("grammar");
+    }
     let has_tool_extension = matches!(
         Path::new(path).extension().and_then(|ext| ext.to_str()),
         Some("sh" | "py" | "js")
-    );
+    ) || is_hook_script(path);
     let is_tool_surface = matches!(
         entry.surface.as_str(),
         "tooling" | "release" | "ci" | "build"
     );
     let is_tool_kind = entry.kind.contains("tooling")
+        || entry.kind.contains("hook")
         || entry.kind.contains("orchestrator")
         || entry.kind == "web_demo";
     has_tool_extension && is_tool_surface && is_tool_kind
 }
 
+fn is_grammar_definition(path: &str) -> bool {
+    path.ends_with("grammar.js")
+}
+
+fn is_hook_script(path: &str) -> bool {
+    (path.starts_with(".githooks/") || path.starts_with("hooks/"))
+        && Path::new(path).extension().and_then(|ext| ext.to_str()) != Some("md")
+}
+
 fn migration_target_for(path: &str, entry: &AllowEntry) -> &'static str {
-    if path.starts_with("scripts/ci/") {
+    if is_grammar_definition(path) {
+        "Rust grammar crate using Adze annotations"
+    } else if path.starts_with(".githooks/") || path.starts_with("hooks/") {
+        "xtask lint/preflight subcommand plus thin hook shim"
+    } else if path.starts_with("scripts/ci/") {
         "xtask CI planning/reporting module"
     } else if path.starts_with("scripts/") {
         "xtask policy/build subcommand"
@@ -387,4 +405,69 @@ fn print_summary(report: &FileReport) {
         report.rust_migration_candidates.len()
     );
     println!("  unused entries:   {}", report.unused_entries.len());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(kind: &str, surface: &str, classification: &str) -> AllowEntry {
+        AllowEntry {
+            glob: Some("scripts/**".to_string()),
+            path: None,
+            kind: kind.to_string(),
+            owner: "core/build".to_string(),
+            surface: surface.to_string(),
+            classification: classification.to_string(),
+            reason: "test entry".to_string(),
+            covered_by: vec!["cargo test -p xtask".to_string()],
+            expires: None,
+            retired: None,
+            generated_by: None,
+        }
+    }
+
+    #[test]
+    fn rust_migration_candidate_accepts_tooling_scripts() {
+        let entries = [entry("shell_tooling", "tooling", "tooling")];
+        let candidate = rust_migration_candidate("scripts/check.sh", &[(4, &entries[0])])
+            .expect("tooling script should be a migration candidate");
+
+        assert_eq!(candidate.current_surface, "tooling");
+        assert_eq!(candidate.migration_target, "xtask policy/build subcommand");
+        assert_eq!(candidate.covered_by, ["cargo test -p xtask"]);
+    }
+
+    #[test]
+    fn rust_migration_candidate_skips_fixture_scripts() {
+        let entries = [entry("language_fixture", "fixtures", "test")];
+        let candidate = rust_migration_candidate("fixtures/example.py", &[(2, &entries[0])]);
+
+        assert!(candidate.is_none());
+    }
+
+    #[test]
+    fn rust_migration_candidate_routes_grammar_js_to_rust_grammar() {
+        let entries = [entry("grammar_input", "grammar", "production")];
+        let candidate =
+            rust_migration_candidate("grammars/example/grammar.js", &[(7, &entries[0])])
+                .expect("production grammar.js should be a migration candidate");
+
+        assert_eq!(
+            candidate.migration_target,
+            "Rust grammar crate using Adze annotations"
+        );
+    }
+
+    #[test]
+    fn rust_migration_candidate_routes_extensionless_hooks_to_xtask() {
+        let entries = [entry("git_hook", "tooling", "tooling")];
+        let candidate = rust_migration_candidate(".githooks/pre-push", &[(0, &entries[0])])
+            .expect("extensionless hook should be a migration candidate");
+
+        assert_eq!(
+            candidate.migration_target,
+            "xtask lint/preflight subcommand plus thin hook shim"
+        );
+    }
 }


### PR DESCRIPTION
### Motivation

- Surface non-Rust tooling files that are good candidates to convert into Rust and move into `xtask`, Rust grammar crates, or owner modules.
- Preserve the existing non-Rust allowlist/accounting while making migration targets visible in the file-policy report.

### Description

- Adds `RustMigrationCandidate` records to the file-policy report, including path, kind, owner, current surface, migration target, reason, and proof/coverage receipts.
- Maps globset match indexes back to allowlist entries before marking entries used, preserving unused-entry accounting even when invalid or skipped patterns exist.
- Reports Rust migration candidates in JSON, Markdown, and the terminal summary.
- Documents the new report section in `docs/FILE_POLICY.md`.
- Adds unit coverage for tooling scripts, extensionless hooks, production `grammar.js`, and fixture exclusions.

### Non-goals

- Does not migrate any scripts or grammar definitions yet.
- Does not change blocking policy mode or branch protection.
- Does not touch release, publish, signing, or Cargo-token workflows.

### Testing

```bash
cargo fmt -p xtask --check
cargo test -p xtask rust_migration_candidate -- --nocapture
cargo test -p xtask
cargo clippy -p xtask --tests -- -D warnings
cargo run -q -p xtask -- check-file-policy --mode advisory
git diff --check
```
