### PR TITLE
test(cli): align README capability tiers with support tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Support tiers, proof commands, and CI lanes are tracked in [`docs/status/SUPPORT
 | **Stabilizing** | Implemented and tested, but missing broader product proof before stable promotion |
 | **Experimental** | Implemented, but outside the supported contract; behavior may change |
 | **Advisory** | Useful non-blocking signal from optional CI, smoke tests, or examples |
+| **Intentionally excluded** | Tracked proof signal outside current product claims until explicitly reclassified |
 
 ### Capability table
 
@@ -128,7 +129,7 @@ Support tiers, proof commands, and CI lanes are tracked in [`docs/status/SUPPORT
 | WASM | **Advisory** | `cargo check --manifest-path wasm-demo/Cargo.toml --target wasm32-unknown-unknown` |
 | Tree-sitter interop | **Advisory** | `./scripts/smoke-link.sh ts-bridge` |
 | Tree-sitter compatibility API | **Advisory** | `cargo test -p adze --features "pure-rust,ts-compat" --test ts_compat_node_error -- --nocapture` |
-| runtime2 | **Advisory** | `cargo test --manifest-path runtime2/Cargo.toml --features test-utils --test basic language_smoke_exposes_metadata_queries -- --exact --nocapture` |
+| runtime2 | **Intentionally excluded** | `cargo test --manifest-path runtime2/Cargo.toml --features test-utils --test basic language_smoke_exposes_metadata_queries -- --exact --nocapture` |
 | Grammars | **Advisory** | `cargo test -p adze-python test_python_language_exists -- --exact` |
 | Golden tests | **Advisory** | `cargo test -p adze-golden-tests javascript_canary_expression_golden --features javascript-grammar -- --nocapture` |
 | Benchmarks | **Advisory** | `cargo test -p adze-benchmarks --test verify_fixture_parsing verify_parse_bench_uses_real_parser_workload -- --exact --nocapture` |

--- a/cli/tests/readme_quickstart.rs
+++ b/cli/tests/readme_quickstart.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -317,26 +318,66 @@ fn readme_stable_claims_are_in_stable_product_lane() {
     let readme = include_str!("../../README.md");
     let support_tiers = include_str!("../../docs/status/SUPPORT_TIERS.md");
     let stable_lane = include_str!("../../scripts/ci-product-stable.sh");
-    let proof_commands = readme_stable_proof_commands(readme);
+    let stable_rows: Vec<_> = readme_capability_rows(readme)
+        .into_iter()
+        .filter(|row| row.tier == "stable")
+        .collect();
 
     assert!(
-        !proof_commands.is_empty(),
+        !stable_rows.is_empty(),
         "README capability table should include Stable proof commands"
     );
 
-    for command in proof_commands {
+    for row in stable_rows {
+        for command in row.proof_commands {
+            assert!(
+                support_tiers.contains(&command),
+                "README Stable proof command must be documented in docs/status/SUPPORT_TIERS.md:\n{command}"
+            );
+
+            if is_required_gate(&command) {
+                continue;
+            }
+
+            assert!(
+                stable_lane.contains(&command),
+                "README Stable proof command must be present in scripts/ci-product-stable.sh:\n{command}"
+            );
+        }
+    }
+}
+
+#[test]
+fn readme_capability_rows_match_support_tiers() {
+    let readme = include_str!("../../README.md");
+    let support_tiers = include_str!("../../docs/status/SUPPORT_TIERS.md");
+    let readme_rows = readme_capability_rows(readme);
+    let support_rows = support_tier_rows(support_tiers);
+
+    assert!(
+        !readme_rows.is_empty(),
+        "README capability table should include product surface rows"
+    );
+
+    for row in readme_rows {
         assert!(
-            support_tiers.contains(&command),
-            "README Stable proof command must be documented in docs/status/SUPPORT_TIERS.md:\n{command}"
+            !row.proof_commands.is_empty(),
+            "README capability row should name at least one proof command: {}",
+            row.surface
         );
 
-        if is_required_gate(&command) {
-            continue;
-        }
+        let key = surface_lookup_key(&row.surface);
+        let Some(support_tier) = support_rows.get(&key) else {
+            panic!(
+                "README capability surface must exist in docs/status/SUPPORT_TIERS.md: {}",
+                row.surface
+            );
+        };
 
-        assert!(
-            stable_lane.contains(&command),
-            "README Stable proof command must be present in scripts/ci-product-stable.sh:\n{command}"
+        assert_eq!(
+            &row.tier, support_tier,
+            "README capability tier must match docs/status/SUPPORT_TIERS.md for {}",
+            row.surface
         );
     }
 }
@@ -434,8 +475,15 @@ edition = "2024"
     )
 }
 
-fn readme_stable_proof_commands(readme: &str) -> Vec<String> {
-    let mut commands = Vec::new();
+#[derive(Debug)]
+struct CapabilityRow {
+    surface: String,
+    tier: String,
+    proof_commands: Vec<String>,
+}
+
+fn readme_capability_rows(readme: &str) -> Vec<CapabilityRow> {
+    let mut rows = Vec::new();
     let mut in_capability_table = false;
 
     for line in readme.lines() {
@@ -452,29 +500,78 @@ fn readme_stable_proof_commands(readme: &str) -> Vec<String> {
             continue;
         }
 
-        if !line.starts_with('|') || !line.contains("| **Stable** |") {
+        if !line.starts_with('|') {
             continue;
         }
 
-        let columns: Vec<&str> = line.split('|').collect();
-        assert!(
-            columns.len() >= 4,
-            "README Stable capability row should have a proof column: {line}"
-        );
+        let columns = markdown_columns(line);
+        if columns.len() < 3 || is_markdown_separator(&columns) || columns[0] == "Surface" {
+            continue;
+        }
 
-        let proof = columns[3];
+        let proof = columns[2];
         let row_commands = inline_code_spans(proof);
-        assert!(
-            !row_commands.is_empty(),
-            "README Stable capability row should name at least one proof command: {line}"
-        );
-
-        commands.extend(row_commands);
+        rows.push(CapabilityRow {
+            surface: columns[0].to_string(),
+            tier: tier_lookup_key(columns[1]),
+            proof_commands: row_commands,
+        });
     }
 
-    commands.sort();
-    commands.dedup();
-    commands
+    rows
+}
+
+fn support_tier_rows(support_tiers: &str) -> BTreeMap<String, String> {
+    let mut rows = BTreeMap::new();
+
+    for line in support_tiers.lines() {
+        if !line.starts_with('|') {
+            continue;
+        }
+
+        let columns = markdown_columns(line);
+        if columns.len() < 2 || is_markdown_separator(&columns) || columns[0] == "Surface" {
+            continue;
+        }
+
+        rows.entry(surface_lookup_key(columns[0]))
+            .or_insert_with(|| tier_lookup_key(columns[1]));
+    }
+
+    rows
+}
+
+fn markdown_columns(line: &str) -> Vec<&str> {
+    line.trim()
+        .trim_matches('|')
+        .split('|')
+        .map(str::trim)
+        .collect()
+}
+
+fn is_markdown_separator(columns: &[&str]) -> bool {
+    columns
+        .iter()
+        .all(|column| !column.is_empty() && column.chars().all(|ch| matches!(ch, '-' | ':' | ' ')))
+}
+
+fn surface_lookup_key(surface: &str) -> String {
+    surface
+        .split(" (")
+        .next()
+        .unwrap_or(surface)
+        .replace('`', "")
+        .trim()
+        .to_ascii_lowercase()
+}
+
+fn tier_lookup_key(tier: &str) -> String {
+    let cleaned = tier.replace('*', "").trim().to_ascii_lowercase();
+    if cleaned.starts_with("stable") {
+        "stable".to_string()
+    } else {
+        cleaned
+    }
 }
 
 fn inline_code_spans(text: &str) -> Vec<String> {

--- a/scripts/ci-product-stable.sh
+++ b/scripts/ci-product-stable.sh
@@ -9,6 +9,7 @@ fi
 # Stable product canaries map to README Stable claims only.
 # Broader stabilizing/advisory surfaces remain in scripts/ci-product.sh.
 CANARIES=(
+  "README capability tier alignment|cargo test -p adze-cli readme_capability_rows_match_support_tiers -- --exact --nocapture"
   "README stable proof alignment|cargo test -p adze-cli readme_stable_claims_are_in_stable_product_lane -- --exact --nocapture"
   "typed extraction exact value|cargo test -p adze --features pure-rust --test typed_ast_contract typed_ast_contract_left_associative_addition -- --exact --nocapture"
   "typed extraction repeated-parse determinism|cargo test -p adze --features pure-rust --test typed_ast_contract typed_ast_contract_repeated_parse_is_deterministic -- --exact --nocapture"


### PR DESCRIPTION
## Summary

Aligns the README capability table with `docs/status/SUPPORT_TIERS.md` and adds a table-level canary so README capability tiers cannot drift from the support-tier source of truth.

## Production delta

- Adds `Intentionally excluded` to the README tier legend.
- Changes the README `runtime2` capability row from `Advisory` to `Intentionally excluded`, matching `SUPPORT_TIERS.md`.
- Adds `readme_capability_rows_match_support_tiers` and includes it in `scripts/ci-product-stable.sh`.

## Non-goals

- No runtime behavior changes.
- No support-tier promotion or demotion beyond README alignment to the existing source of truth.
- No branch protection, release, publish, signing, or Cargo-token workflow changes.

## Proof commands

```bash
cargo test -p adze-cli readme_capability_rows_match_support_tiers -- --exact --nocapture
cargo test -p adze-cli readme_stable_claims_are_in_stable_product_lane -- --exact --nocapture
cargo fmt -p adze-cli --check
cargo clippy -p adze-cli --tests -- -D warnings
just ci-product-stable
git diff --check
```

Note: `just fmt` currently hits Windows `os error 206` in this checkout, so the touched Rust package was checked with `cargo fmt -p adze-cli --check`.

## Rollback

Revert this PR to remove the README tier alignment canary and restore the previous README capability row.
