### PR TITLE
Refactor static language generator helpers

### DIFF
--- a/tablegen/src/lib.rs
+++ b/tablegen/src/lib.rs
@@ -11,6 +11,7 @@
 #![cfg_attr(feature = "strict_docs", deny(missing_docs))]
 #![cfg_attr(not(feature = "strict_docs"), allow(missing_docs))]
 
+mod static_language;
 mod test_helpers;
 mod util;
 
@@ -90,9 +91,11 @@ pub use validation::{LanguageValidator, ValidationError};
 
 // use indexmap::IndexMap; // Currently unused
 use adze_glr_core::*;
+#[cfg(not(test))]
+use adze_ir::Grammar;
+#[cfg(test)]
 use adze_ir::*;
 use proc_macro2::TokenStream;
-use quote::quote;
 
 // Tree-sitter backend selection will be done in the relevant modules
 
@@ -134,203 +137,27 @@ impl StaticLanguageGenerator {
 
     /// Generate NODE_TYPES JSON string
     pub fn generate_node_types(&self) -> String {
-        use serde_json::json;
-
-        let mut types = Vec::new();
-
-        // Generate node types for non-terminal rules
-        for (symbol_id, rules) in &self.grammar.rules {
-            let rule_name = self
-                .grammar
-                .rule_names
-                .get(symbol_id)
-                .cloned()
-                .unwrap_or_else(|| format!("rule_{}", symbol_id.0));
-
-            // Skip hidden rules (those starting with underscore)
-            if rule_name.starts_with('_') {
-                continue;
-            }
-
-            let mut node_type = json!({
-                "type": rule_name,
-                "named": true
-            });
-
-            // Collect fields from all rules for this symbol
-            let mut all_fields = serde_json::Map::new();
-            let mut has_children = false;
-
-            for rule in rules {
-                // Add fields if this rule has any
-                for (field_id, _position) in &rule.fields {
-                    if let Some(field_name) = self.grammar.fields.get(field_id) {
-                        all_fields.insert(
-                            field_name.clone(),
-                            json!({
-                                "multiple": false,
-                                "required": true,
-                                "types": []
-                            }),
-                        );
-                    }
-                }
-
-                // Check if rule has children
-                if !rule.rhs.is_empty() {
-                    has_children = true;
-                }
-            }
-
-            // Add fields if any
-            if !all_fields.is_empty() {
-                node_type["fields"] = json!(all_fields);
-            }
-
-            // Add children if any rule has RHS
-            if has_children {
-                let mut children = serde_json::Map::new();
-                children.insert("multiple".to_string(), json!(false));
-                children.insert("required".to_string(), json!(true));
-                // TODO: Add proper child types based on rule.rhs
-                children.insert("types".to_string(), json!([]));
-                node_type["children"] = json!(children);
-            }
-
-            // Check if this is a supertype
-            if self.grammar.supertypes.contains(symbol_id) {
-                node_type["subtypes"] = json!([]);
-            }
-
-            types.push(node_type);
-        }
-
-        // Generate node types for named tokens
-        for (_, token) in &self.grammar.tokens {
-            if !token.name.starts_with('_') && matches!(&token.pattern, TokenPattern::Regex(_)) {
-                types.push(json!({
-                    "type": token.name,
-                    "named": true
-                }));
-            }
-        }
-
-        // Generate node types for external tokens
-        for external in &self.grammar.externals {
-            if !external.name.starts_with('_') {
-                types.push(json!({
-                    "type": external.name,
-                    "named": true
-                }));
-            }
-        }
-
-        serde_json::to_string_pretty(&json!(types)).unwrap_or_else(|_| "[]".to_string())
+        static_language::node_types::generate(&self.grammar)
     }
 
     #[allow(dead_code)]
     fn generate_symbol_names(&self) -> Vec<String> {
-        let mut names = Vec::new();
-
-        // Add terminal symbols
-        for (_, token) in &self.grammar.tokens {
-            names.push(token.name.clone());
-        }
-
-        // Add non-terminal symbols (rules)
-        for (symbol_id, _) in &self.grammar.rules {
-            names.push(format!("rule_{}", symbol_id.0));
-        }
-
-        // Add external symbols
-        for external in &self.grammar.externals {
-            names.push(external.name.clone());
-        }
-
-        names
+        static_language::symbols::symbol_names(&self.grammar)
     }
 
     #[allow(dead_code)]
     fn generate_symbol_metadata(&self) -> Vec<TokenStream> {
-        let mut metadata = Vec::new();
-
-        // Generate metadata for each terminal symbol
-        for (_, token) in &self.grammar.tokens {
-            // Hidden tokens start with underscore
-            let visible = !token.name.starts_with('_');
-            // Anonymous tokens (string literals) are unnamed, regex tokens can be named
-            let named = matches!(&token.pattern, TokenPattern::Regex(_)) && visible;
-            let supertype = false;
-
-            metadata.push(quote! {
-                adze::ffi::TSSymbolMetadata {
-                    visible: #visible,
-                    named: #named,
-                    supertype: #supertype,
-                }
-            });
-        }
-
-        // Add metadata for non-terminals (rules)
-        for (symbol_id, _rule) in &self.grammar.rules {
-            // For now, use generated rule names until we have proper symbol mapping
-            let rule_name = format!("rule_{}", symbol_id.0);
-            // Hidden rules start with underscore
-            let visible = !rule_name.starts_with('_');
-            // Non-terminals are named unless they're hidden
-            let named = visible;
-            // Check if this rule is in the supertypes list
-            let supertype = self.grammar.supertypes.contains(symbol_id);
-
-            metadata.push(quote! {
-                adze::ffi::TSSymbolMetadata {
-                    visible: #visible,
-                    named: #named,
-                    supertype: #supertype,
-                }
-            });
-        }
-
-        // Add metadata for external symbols
-        for external in &self.grammar.externals {
-            // External tokens are typically visible and named
-            let visible = !external.name.starts_with('_');
-            let named = visible;
-            let supertype = false;
-
-            metadata.push(quote! {
-                adze::ffi::TSSymbolMetadata {
-                    visible: #visible,
-                    named: #named,
-                    supertype: #supertype,
-                }
-            });
-        }
-
-        metadata
+        static_language::symbols::symbol_metadata(&self.grammar)
     }
 
     #[allow(dead_code)]
     fn generate_field_names(&self) -> Vec<String> {
-        // Fields must be in lexicographic order (already validated in Grammar)
-        self.grammar.fields.values().cloned().collect()
+        static_language::symbols::field_names(&self.grammar)
     }
 
     #[allow(dead_code)]
     fn generate_uncompressed_tables(&self) -> (TokenStream, TokenStream) {
-        // Generate uncompressed action and goto tables
-        let action_entries = self.generate_action_table_entries();
-        let goto_entries = self.generate_goto_table_entries();
-
-        let action_table = quote! {
-            static ACTION_TABLE: &[&[adze::ffi::TSParseActionEntry]] = &[#(#action_entries),*];
-        };
-
-        let goto_table = quote! {
-            static GOTO_TABLE: &[&[u16]] = &[#(#goto_entries),*];
-        };
-
-        (action_table, goto_table)
+        static_language::table_tokens::uncompressed_tables(&self.parse_table)
     }
 
     #[allow(dead_code)]
@@ -338,13 +165,7 @@ impl StaticLanguageGenerator {
         &self,
         compressed: &CompressedTables,
     ) -> (TokenStream, TokenStream) {
-        // Generate compressed tables using Tree-sitter's format
-
-        if self.parse_table.state_count < compressed.small_table_threshold {
-            self.generate_small_compressed_tables(compressed)
-        } else {
-            self.generate_large_compressed_tables(compressed)
-        }
+        static_language::compression_tokens::compressed_tables(&self.parse_table, compressed)
     }
 
     #[allow(dead_code)]
@@ -352,26 +173,7 @@ impl StaticLanguageGenerator {
         &self,
         compressed: &CompressedTables,
     ) -> (TokenStream, TokenStream) {
-        // Generate Tree-sitter's small table format
-        // Action table: flat array of u16 values with encoded actions
-        // Goto table: flat array of u16 state IDs
-
-        let action_entries = self.generate_small_action_entries(&compressed.action_table);
-        let goto_entries = self.generate_small_goto_entries(&compressed.goto_table);
-
-        let action_count = compressed.action_table.data.len();
-        let goto_count = self.count_goto_entries(&compressed.goto_table);
-
-        let action_table = quote! {
-            static SMALL_PARSE_TABLE: &[u16; #action_count] = &[#(#action_entries),*];
-            static SMALL_PARSE_TABLE_MAP: &[u16] = &[/* row offsets */];
-        };
-
-        let goto_table = quote! {
-            static GOTO_TABLE: &[u16; #goto_count] = &[#(#goto_entries),*];
-        };
-
-        (action_table, goto_table)
+        static_language::compression_tokens::small_compressed_tables(compressed)
     }
 
     #[allow(dead_code)]
@@ -379,9 +181,7 @@ impl StaticLanguageGenerator {
         &self,
         compressed: &CompressedTables,
     ) -> (TokenStream, TokenStream) {
-        // For large tables, use pointer arrays
-        // This is rarely needed but essential for grammars like C++
-        self.generate_small_compressed_tables(compressed) // Simplified for now
+        static_language::compression_tokens::large_compressed_tables(compressed)
     }
 
     #[allow(dead_code)]
@@ -389,189 +189,27 @@ impl StaticLanguageGenerator {
         &self,
         action_table: &CompressedActionTable,
     ) -> Vec<TokenStream> {
-        let mut entries = Vec::new();
-        let compressor = TableCompressor::new();
-
-        for entry in &action_table.data {
-            if let Ok(encoded) = compressor.encode_action_small(&entry.action) {
-                let symbol = entry.symbol;
-                entries.push(quote! { #symbol }); // Symbol index
-                entries.push(quote! { #encoded }); // Encoded action
-            }
-        }
-
-        entries
+        static_language::compression_tokens::small_action_entries(action_table)
     }
 
     #[allow(dead_code)]
     fn generate_small_goto_entries(&self, goto_table: &CompressedGotoTable) -> Vec<TokenStream> {
-        let mut entries = Vec::new();
-
-        for entry in &goto_table.data {
-            match entry {
-                CompressedGotoEntry::Single(state) => {
-                    entries.push(quote! { #state });
-                }
-                CompressedGotoEntry::RunLength { state, count } => {
-                    // Expand run-length encoded entries
-                    for _ in 0..*count {
-                        entries.push(quote! { #state });
-                    }
-                }
-            }
-        }
-
-        entries
+        static_language::compression_tokens::small_goto_entries(goto_table)
     }
 
     #[allow(dead_code)]
     fn count_goto_entries(&self, goto_table: &CompressedGotoTable) -> usize {
-        goto_table
-            .data
-            .iter()
-            .map(|entry| match entry {
-                CompressedGotoEntry::Single(_) => 1,
-                CompressedGotoEntry::RunLength { count, .. } => *count as usize,
-            })
-            .sum()
+        static_language::compression_tokens::count_goto_entries(goto_table)
     }
 
     #[allow(dead_code)]
     fn generate_action_table_entries(&self) -> Vec<TokenStream> {
-        let mut entries = Vec::new();
-
-        for state_actions in &self.parse_table.action_table {
-            let actions: Vec<TokenStream> = state_actions
-                .iter()
-                .flat_map(|action_cell| {
-                    // For each action cell, generate entries for all actions
-                    action_cell.iter().map(|action| {
-                        match action {
-                            Action::Shift(state) => {
-                                let state_id = state.0;
-                                quote! {
-                                    adze::ffi::TSParseActionEntry {
-                                        type_: adze::ffi::TSParseActionType::Shift,
-                                        state: #state_id,
-                                        symbol: 0,
-                                        child_count: 0,
-                                        dynamic_precedence: 0,
-                                        fragile: false,
-                                    }
-                                }
-                            }
-                            Action::Reduce(rule) => {
-                                let rule_id = rule.0;
-                                quote! {
-                                    adze::ffi::TSParseActionEntry {
-                                        type_: adze::ffi::TSParseActionType::Reduce,
-                                        state: 0,
-                                        symbol: #rule_id,
-                                        child_count: 0, // Will be filled with actual child count
-                                        dynamic_precedence: 0,
-                                        fragile: false,
-                                    }
-                                }
-                            }
-                            Action::Accept => {
-                                quote! {
-                                    adze::ffi::TSParseActionEntry {
-                                        type_: adze::ffi::TSParseActionType::Accept,
-                                        state: 0,
-                                        symbol: 0,
-                                        child_count: 0,
-                                        dynamic_precedence: 0,
-                                        fragile: false,
-                                    }
-                                }
-                            }
-                            Action::Error => {
-                                quote! {
-                                    adze::ffi::TSParseActionEntry {
-                                        type_: adze::ffi::TSParseActionType::Error,
-                                        state: 0,
-                                        symbol: 0,
-                                        child_count: 0,
-                                        dynamic_precedence: 0,
-                                        fragile: false,
-                                    }
-                                }
-                            }
-                            Action::Recover => {
-                                // Treat Recover as Error for FFI compatibility
-                                quote! {
-                                    adze::ffi::TSParseActionEntry {
-                                        type_: adze::ffi::TSParseActionType::Error,
-                                        state: 0,
-                                        symbol: 0,
-                                        child_count: 0,
-                                        dynamic_precedence: 0,
-                                        fragile: false,
-                                    }
-                                }
-                            }
-                            Action::Fork(actions) => {
-                                // For GLR fork points, we'll need to handle multiple actions
-                                // For now, just take the first action
-                                if let Some(Action::Shift(state)) = actions.first() {
-                                    let state_id = state.0;
-                                    quote! {
-                                        adze::ffi::TSParseActionEntry {
-                                            type_: adze::ffi::TSParseActionType::Shift,
-                                            state: #state_id,
-                                            symbol: 0,
-                                            child_count: 0,
-                                            dynamic_precedence: 0,
-                                            fragile: false,
-                                        }
-                                    }
-                                } else {
-                                    quote! {
-                                        adze::ffi::TSParseActionEntry {
-                                            type_: adze::ffi::TSParseActionType::Error,
-                                            state: 0,
-                                            symbol: 0,
-                                            child_count: 0,
-                                            dynamic_precedence: 0,
-                                            fragile: false,
-                                        }
-                                    }
-                                }
-                            }
-                            _ => {
-                                // Unknown action type // Expected: V for Recover
-                                quote! {
-                                    adze::ffi::TSParseActionEntry {
-                                        type_: adze::ffi::TSParseActionType::Error,
-                                        state: 0,
-                                        symbol: 0,
-                                        child_count: 0,
-                                        dynamic_precedence: 0,
-                                        fragile: false,
-                                    }
-                                }
-                            }
-                        }
-                    })
-                })
-                .collect();
-
-            entries.push(quote! { &[#(#actions),*] });
-        }
-
-        entries
+        static_language::table_tokens::action_table_entries(&self.parse_table)
     }
 
     #[allow(dead_code)]
     fn generate_goto_table_entries(&self) -> Vec<TokenStream> {
-        let mut entries = Vec::new();
-
-        for state_gotos in &self.parse_table.goto_table {
-            let gotos: Vec<u16> = state_gotos.iter().map(|state| state.0).collect();
-            entries.push(quote! { &[#(#gotos),*] });
-        }
-
-        entries
+        static_language::table_tokens::goto_table_entries(&self.parse_table)
     }
 
     /// Apply table compression

--- a/tablegen/src/static_language/compression_tokens.rs
+++ b/tablegen/src/static_language/compression_tokens.rs
@@ -1,0 +1,95 @@
+//! TokenStream generation for compressed parse and goto tables.
+
+use crate::{
+    CompressedActionTable, CompressedGotoEntry, CompressedGotoTable, CompressedTables,
+    TableCompressor,
+};
+use adze_glr_core::ParseTable;
+use proc_macro2::TokenStream;
+use quote::quote;
+
+pub(crate) fn compressed_tables(
+    parse_table: &ParseTable,
+    compressed: &CompressedTables,
+) -> (TokenStream, TokenStream) {
+    // Generate compressed tables using Tree-sitter's format
+    if parse_table.state_count < compressed.small_table_threshold {
+        small_compressed_tables(compressed)
+    } else {
+        large_compressed_tables(compressed)
+    }
+}
+
+pub(crate) fn small_compressed_tables(compressed: &CompressedTables) -> (TokenStream, TokenStream) {
+    // Generate Tree-sitter's small table format
+    // Action table: flat array of u16 values with encoded actions
+    // Goto table: flat array of u16 state IDs
+    let action_entries = small_action_entries(&compressed.action_table);
+    let goto_entries = small_goto_entries(&compressed.goto_table);
+
+    let action_count = compressed.action_table.data.len();
+    let goto_count = count_goto_entries(&compressed.goto_table);
+
+    let action_table = quote! {
+        static SMALL_PARSE_TABLE: &[u16; #action_count] = &[#(#action_entries),*];
+        static SMALL_PARSE_TABLE_MAP: &[u16] = &[/* row offsets */];
+    };
+
+    let goto_table = quote! {
+        static GOTO_TABLE: &[u16; #goto_count] = &[#(#goto_entries),*];
+    };
+
+    (action_table, goto_table)
+}
+
+pub(crate) fn large_compressed_tables(compressed: &CompressedTables) -> (TokenStream, TokenStream) {
+    // For large tables, use pointer arrays.
+    // This is rarely needed but essential for grammars like C++.
+    small_compressed_tables(compressed) // Simplified for now
+}
+
+pub(crate) fn small_action_entries(action_table: &CompressedActionTable) -> Vec<TokenStream> {
+    let mut entries = Vec::new();
+    let compressor = TableCompressor::new();
+
+    for entry in &action_table.data {
+        if let Ok(encoded) = compressor.encode_action_small(&entry.action) {
+            let symbol = entry.symbol;
+            entries.push(quote! { #symbol }); // Symbol index
+            entries.push(quote! { #encoded }); // Encoded action
+        }
+    }
+
+    entries
+}
+
+pub(crate) fn small_goto_entries(goto_table: &CompressedGotoTable) -> Vec<TokenStream> {
+    let mut entries = Vec::new();
+
+    for entry in &goto_table.data {
+        match entry {
+            CompressedGotoEntry::Single(state) => {
+                entries.push(quote! { #state });
+            }
+            CompressedGotoEntry::RunLength { state, count } => {
+                // Expand run-length encoded entries
+                for _ in 0..*count {
+                    entries.push(quote! { #state });
+                }
+            }
+        }
+    }
+
+    entries
+}
+
+pub(crate) fn count_goto_entries(goto_table: &CompressedGotoTable) -> usize {
+    goto_table
+        .data
+        .iter()
+        .map(|entry| match entry {
+            CompressedGotoEntry::Single(_) => 1,
+            CompressedGotoEntry::RunLength { count, .. } => *count as usize,
+        })
+        .sum()
+}

--- a/tablegen/src/static_language/mod.rs
+++ b/tablegen/src/static_language/mod.rs
@@ -1,0 +1,6 @@
+//! Single-responsibility helpers for [`StaticLanguageGenerator`].
+
+pub(crate) mod compression_tokens;
+pub(crate) mod node_types;
+pub(crate) mod symbols;
+pub(crate) mod table_tokens;

--- a/tablegen/src/static_language/node_types.rs
+++ b/tablegen/src/static_language/node_types.rs
@@ -1,0 +1,96 @@
+//! NODE_TYPES JSON generation for static language output.
+
+use adze_ir::{Grammar, TokenPattern};
+use serde_json::json;
+
+pub(crate) fn generate(grammar: &Grammar) -> String {
+    let mut types = Vec::new();
+
+    // Generate node types for non-terminal rules
+    for (symbol_id, rules) in &grammar.rules {
+        let rule_name = grammar
+            .rule_names
+            .get(symbol_id)
+            .cloned()
+            .unwrap_or_else(|| format!("rule_{}", symbol_id.0));
+
+        // Skip hidden rules (those starting with underscore)
+        if rule_name.starts_with('_') {
+            continue;
+        }
+
+        let mut node_type = json!({
+            "type": rule_name,
+            "named": true
+        });
+
+        // Collect fields from all rules for this symbol
+        let mut all_fields = serde_json::Map::new();
+        let mut has_children = false;
+
+        for rule in rules {
+            // Add fields if this rule has any
+            for (field_id, _position) in &rule.fields {
+                if let Some(field_name) = grammar.fields.get(field_id) {
+                    all_fields.insert(
+                        field_name.clone(),
+                        json!({
+                            "multiple": false,
+                            "required": true,
+                            "types": []
+                        }),
+                    );
+                }
+            }
+
+            // Check if rule has children
+            if !rule.rhs.is_empty() {
+                has_children = true;
+            }
+        }
+
+        // Add fields if any
+        if !all_fields.is_empty() {
+            node_type["fields"] = json!(all_fields);
+        }
+
+        // Add children if any rule has RHS
+        if has_children {
+            let mut children = serde_json::Map::new();
+            children.insert("multiple".to_string(), json!(false));
+            children.insert("required".to_string(), json!(true));
+            // TODO: Add proper child types based on rule.rhs
+            children.insert("types".to_string(), json!([]));
+            node_type["children"] = json!(children);
+        }
+
+        // Check if this is a supertype
+        if grammar.supertypes.contains(symbol_id) {
+            node_type["subtypes"] = json!([]);
+        }
+
+        types.push(node_type);
+    }
+
+    // Generate node types for named tokens
+    for token in grammar.tokens.values() {
+        if !token.name.starts_with('_') && matches!(&token.pattern, TokenPattern::Regex(_)) {
+            types.push(json!({
+                "type": token.name,
+                "named": true
+            }));
+        }
+    }
+
+    // Generate node types for external tokens
+    for external in &grammar.externals {
+        if !external.name.starts_with('_') {
+            types.push(json!({
+                "type": external.name,
+                "named": true
+            }));
+        }
+    }
+
+    serde_json::to_string_pretty(&json!(types)).unwrap_or_else(|_| "[]".to_string())
+}

--- a/tablegen/src/static_language/symbols.rs
+++ b/tablegen/src/static_language/symbols.rs
@@ -1,0 +1,90 @@
+//! Symbol and field metadata token generation.
+
+use adze_ir::{Grammar, TokenPattern};
+use proc_macro2::TokenStream;
+use quote::quote;
+
+pub(crate) fn symbol_names(grammar: &Grammar) -> Vec<String> {
+    let mut names = Vec::new();
+
+    // Add terminal symbols
+    for token in grammar.tokens.values() {
+        names.push(token.name.clone());
+    }
+
+    // Add non-terminal symbols (rules)
+    for symbol_id in grammar.rules.keys() {
+        names.push(format!("rule_{}", symbol_id.0));
+    }
+
+    // Add external symbols
+    for external in &grammar.externals {
+        names.push(external.name.clone());
+    }
+
+    names
+}
+
+pub(crate) fn symbol_metadata(grammar: &Grammar) -> Vec<TokenStream> {
+    let mut metadata = Vec::new();
+
+    // Generate metadata for each terminal symbol
+    for token in grammar.tokens.values() {
+        // Hidden tokens start with underscore
+        let visible = !token.name.starts_with('_');
+        // Anonymous tokens (string literals) are unnamed, regex tokens can be named
+        let named = matches!(&token.pattern, TokenPattern::Regex(_)) && visible;
+        let supertype = false;
+
+        metadata.push(quote! {
+            adze::ffi::TSSymbolMetadata {
+                visible: #visible,
+                named: #named,
+                supertype: #supertype,
+            }
+        });
+    }
+
+    // Add metadata for non-terminals (rules)
+    for symbol_id in grammar.rules.keys() {
+        // For now, use generated rule names until we have proper symbol mapping
+        let rule_name = format!("rule_{}", symbol_id.0);
+        // Hidden rules start with underscore
+        let visible = !rule_name.starts_with('_');
+        // Non-terminals are named unless they're hidden
+        let named = visible;
+        // Check if this rule is in the supertypes list
+        let supertype = grammar.supertypes.contains(symbol_id);
+
+        metadata.push(quote! {
+            adze::ffi::TSSymbolMetadata {
+                visible: #visible,
+                named: #named,
+                supertype: #supertype,
+            }
+        });
+    }
+
+    // Add metadata for external symbols
+    for external in &grammar.externals {
+        // External tokens are typically visible and named
+        let visible = !external.name.starts_with('_');
+        let named = visible;
+        let supertype = false;
+
+        metadata.push(quote! {
+            adze::ffi::TSSymbolMetadata {
+                visible: #visible,
+                named: #named,
+                supertype: #supertype,
+            }
+        });
+    }
+
+    metadata
+}
+
+pub(crate) fn field_names(grammar: &Grammar) -> Vec<String> {
+    // Fields must be in lexicographic order (already validated in Grammar)
+    grammar.fields.values().cloned().collect()
+}

--- a/tablegen/src/static_language/table_tokens.rs
+++ b/tablegen/src/static_language/table_tokens.rs
@@ -1,0 +1,133 @@
+//! TokenStream generation for uncompressed parse and goto tables.
+
+use adze_glr_core::{Action, ParseTable};
+use proc_macro2::TokenStream;
+use quote::quote;
+
+pub(crate) fn uncompressed_tables(parse_table: &ParseTable) -> (TokenStream, TokenStream) {
+    // Generate uncompressed action and goto tables
+    let action_entries = action_table_entries(parse_table);
+    let goto_entries = goto_table_entries(parse_table);
+
+    let action_table = quote! {
+        static ACTION_TABLE: &[&[adze::ffi::TSParseActionEntry]] = &[#(#action_entries),*];
+    };
+
+    let goto_table = quote! {
+        static GOTO_TABLE: &[&[u16]] = &[#(#goto_entries),*];
+    };
+
+    (action_table, goto_table)
+}
+
+pub(crate) fn action_table_entries(parse_table: &ParseTable) -> Vec<TokenStream> {
+    let mut entries = Vec::new();
+
+    for state_actions in &parse_table.action_table {
+        let actions: Vec<TokenStream> = state_actions
+            .iter()
+            .flat_map(|action_cell| {
+                // For each action cell, generate entries for all actions
+                action_cell.iter().map(action_entry)
+            })
+            .collect();
+
+        entries.push(quote! { &[#(#actions),*] });
+    }
+
+    entries
+}
+
+fn action_entry(action: &Action) -> TokenStream {
+    match action {
+        Action::Shift(state) => {
+            let state_id = state.0;
+            quote! {
+                adze::ffi::TSParseActionEntry {
+                    type_: adze::ffi::TSParseActionType::Shift,
+                    state: #state_id,
+                    symbol: 0,
+                    child_count: 0,
+                    dynamic_precedence: 0,
+                    fragile: false,
+                }
+            }
+        }
+        Action::Reduce(rule) => {
+            let rule_id = rule.0;
+            quote! {
+                adze::ffi::TSParseActionEntry {
+                    type_: adze::ffi::TSParseActionType::Reduce,
+                    state: 0,
+                    symbol: #rule_id,
+                    child_count: 0, // Will be filled with actual child count
+                    dynamic_precedence: 0,
+                    fragile: false,
+                }
+            }
+        }
+        Action::Accept => {
+            quote! {
+                adze::ffi::TSParseActionEntry {
+                    type_: adze::ffi::TSParseActionType::Accept,
+                    state: 0,
+                    symbol: 0,
+                    child_count: 0,
+                    dynamic_precedence: 0,
+                    fragile: false,
+                }
+            }
+        }
+        Action::Error | Action::Recover => {
+            // Treat Recover as Error for FFI compatibility
+            error_entry()
+        }
+        Action::Fork(actions) => {
+            // For GLR fork points, we'll need to handle multiple actions.
+            // For now, just take the first shift action.
+            if let Some(Action::Shift(state)) = actions.first() {
+                let state_id = state.0;
+                quote! {
+                    adze::ffi::TSParseActionEntry {
+                        type_: adze::ffi::TSParseActionType::Shift,
+                        state: #state_id,
+                        symbol: 0,
+                        child_count: 0,
+                        dynamic_precedence: 0,
+                        fragile: false,
+                    }
+                }
+            } else {
+                error_entry()
+            }
+        }
+        _ => {
+            // Unknown action type // Expected: V for Recover
+            error_entry()
+        }
+    }
+}
+
+fn error_entry() -> TokenStream {
+    quote! {
+        adze::ffi::TSParseActionEntry {
+            type_: adze::ffi::TSParseActionType::Error,
+            state: 0,
+            symbol: 0,
+            child_count: 0,
+            dynamic_precedence: 0,
+            fragile: false,
+        }
+    }
+}
+
+pub(crate) fn goto_table_entries(parse_table: &ParseTable) -> Vec<TokenStream> {
+    let mut entries = Vec::new();
+
+    for state_gotos in &parse_table.goto_table {
+        let gotos: Vec<u16> = state_gotos.iter().map(|state| state.0).collect();
+        entries.push(quote! { &[#(#gotos),*] });
+    }
+
+    entries
+}


### PR DESCRIPTION
### Motivation
- Reduce complexity and size of `tablegen/src/lib.rs` by extracting single-responsibility helpers for static-language generation. 
- Make NODE_TYPES, symbol metadata, and table-token generation easier to inspect, test, and maintain by moving them into focused modules. 

### Description
- Introduce a new `tablegen/src/static_language` module with four submodules: `node_types`, `symbols`, `table_tokens`, and `compression_tokens`, implementing the previously inline helper logic. 
- Delegate `StaticLanguageGenerator` helper methods (NODE_TYPES JSON, symbol names/metadata/fields, uncompressed table tokens, and compressed table token generation/counting) to the new submodules while keeping the public API unchanged. 
- Move large helper implementations out of `tablegen/src/lib.rs` into the corresponding files: `node_types.rs`, `symbols.rs`, `table_tokens.rs`, and `compression_tokens.rs`. 
- Adjust imports to avoid unused-import warnings in non-test builds and preserve test visibility of `adze_ir` types via `#[cfg(test)]` where needed. 

### Testing
- Ran `cargo fmt --all -- --check` which succeeded. 
- Ran `cargo clippy -p adze-tablegen -- -D warnings` which succeeded with no warnings. 
- Ran unit and crate tests with `cargo test -p adze-tablegen` and `cargo test -p adze-tablegen --lib`, and all tests for the `adze-tablegen` crate passed (tests completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07e7491bc88333843b9435e57d48bd)