### PR TITLE
docs(status): record public promotion merge

### DIFF
--- a/.adze/goals/active.toml
+++ b/.adze/goals/active.toml
@@ -70,14 +70,16 @@ commands = [
 
 [[work_item]]
 id = "public-promotion-blocker-watch"
-status = "active"
+status = "complete"
 proposal = "ADZE-PROP-0005-release-promotion-readiness"
 spec = "ADZE-SPEC-0011"
 adr = "ADZE-ADR-0001"
 plan = "plans/release-promotion/public-promotion-pr-plan.md"
+prs = [795]
 commands = [
   "gh pr view 795 --repo EffortlessMetrics/adze --json state,mergeable,headRefOid,reviewDecision,autoMergeRequest",
   "gh pr checks 795 --repo EffortlessMetrics/adze",
+  "gh workflow run ci.yml --repo EffortlessMetrics/adze --ref public/promote-swarm-2026-05-19 -f run_full_ci=false -f run_ci_supported_examples=false",
   "just ci-product-stable",
   "just check-publishable",
 ]

--- a/docs/status/NOW_NEXT_LATER.md
+++ b/docs/status/NOW_NEXT_LATER.md
@@ -1,7 +1,7 @@
 # Now / Next / Later
 
-**Last updated:** 2026-05-19
-**Status:** **Residual product trust hardening active** — `adze-swarm` is the operating repo, public `adze` remains release/public-intake, and the remaining blockers in [`PRODUCT_OBJECTIVE_AUDIT.md`](./PRODUCT_OBJECTIVE_AUDIT.md) must stay explicitly proved or bounded before any public promotion. Toolkit excellence is complete with closeout recorded in [`../../plans/toolkit-excellence/closeout.md`](../../plans/toolkit-excellence/closeout.md). Release promotion readiness is closed out in [`../../plans/release-promotion/closeout.md`](../../plans/release-promotion/closeout.md), and any public promotion still requires a fresh explicit execution goal using [`../../plans/release-promotion/public-promotion-pr-plan.md`](../../plans/release-promotion/public-promotion-pr-plan.md).
+**Last updated:** 2026-05-20
+**Status:** **Residual product trust hardening active** — `adze-swarm` remains the operating repo for follow-up product-proof work, public promotion PR #795 has merged into public `adze`, and the remaining blockers in [`PRODUCT_OBJECTIVE_AUDIT.md`](./PRODUCT_OBJECTIVE_AUDIT.md) must stay explicitly proved or bounded before any tag, publish, or release-workflow work. Toolkit excellence is complete with closeout recorded in [`../../plans/toolkit-excellence/closeout.md`](../../plans/toolkit-excellence/closeout.md). Release promotion readiness is closed out in [`../../plans/release-promotion/closeout.md`](../../plans/release-promotion/closeout.md).
 
 Adze status and rolling execution plan. For recurring pain points, see [`docs/status/FRICTION_LOG.md`](./FRICTION_LOG.md). For API stability guarantees per crate, see [`docs/status/API_STABILITY.md`](./API_STABILITY.md). For support-tier proof commands, see [`docs/status/SUPPORT_TIERS.md`](./SUPPORT_TIERS.md).
 
@@ -38,7 +38,7 @@ Adze status and rolling execution plan. For recurring pain points, see [`docs/st
 - [x] Fix parser-v4 external-scanner emitted-token spans and record the focused dispatch/range plus diagnostic-document canaries.
 - [x] Add first parser-generated external-token grammar diagnostic-document proof while keeping full parser-generated external-scanner recovery explicitly future work.
 - [x] Supersede public promotion PR #794 with refreshed public promotion PR #795 after `adze-swarm` advanced through the residual product-trust fixes and promotion-receipt refreshes.
-- [ ] Keep public promotion PR #795 parked for review unless a reviewer approves it; all checks are green and squash auto-merge is enabled, but public promotion has not completed.
+- [x] Merge public promotion PR #795 into public `adze` after the required public branch-protection context was corrected to `Rust Small Result` and the legacy `ci-supported` dispatch receipt passed.
 
 ### Toolkit excellence campaign
 - [x] Consolidate the source-of-truth guardrails into one PR and close duplicate source-of-truth PRs.
@@ -80,18 +80,19 @@ Adze status and rolling execution plan. For recurring pain points, see [`docs/st
       This is evidence for the README Stable claim lane, not a
       branch-protection change.
 - [x] Latest local stable-product receipt: `just ci-product-stable` passed on
-      2026-05-20 from current `adze-swarm/main` at commit `e965cba2` after
-      residual product-trust PRs #295-#310. This refreshes the advisory
+      2026-05-20 from current `adze-swarm/main` at commit `464a32a9` after
+      residual product-trust PRs #295-#311. This refreshes the advisory
       README-stable, clean-room quickstart, downstream fixture, typed AST,
       precedence, and serialization proof from the current swarm state.
 - [x] Objective-level completion audit exists in
       [`PRODUCT_OBJECTIVE_AUDIT.md`](./PRODUCT_OBJECTIVE_AUDIT.md), including
-      the remaining `cargo install adze-cli`, branch-protection, and public
-      promotion gaps.
+      the remaining `cargo install adze-cli`, advisory stable-product lane, and
+      support-tier limitation gaps.
 - [x] Latest release-surface package receipts: `just package-local adze-cli`
       and `just check-publishable` passed on 2026-05-19 from `adze-swarm`;
-      `just check-publishable` was refreshed again on 2026-05-20 at commit
-      `e965cba2` after residual product-trust PRs #309-#310.
+      `just check-publishable` was refreshed again on 2026-05-20 at commits
+      `e965cba2` after residual product-trust PRs #309-#310 and `464a32a9`
+      after PR #311.
       These are package verification receipts, not crates.io install or publish
       claims.
 

--- a/docs/status/PRODUCT_OBJECTIVE_AUDIT.md
+++ b/docs/status/PRODUCT_OBJECTIVE_AUDIT.md
@@ -1,6 +1,6 @@
 # Product Objective Audit
 
-**Last updated:** 2026-05-19
+**Last updated:** 2026-05-20
 **Status:** incomplete; use this as an audit checklist, not as a support-tier
 promotion. The active execution lane is
 [`../../plans/product-gap-burn-down/implementation-plan.md`](../../plans/product-gap-burn-down/implementation-plan.md).
@@ -41,7 +41,7 @@ Adze should be release-readable as a Rust parser generator where:
 | Parse errors are useful instead of incidental. | `SUPPORT_TIERS.md` Structured parse errors and External scanners rows; `PRODUCT_PROOF_MAP.md` parse-error claim; CLI recovery diagnostics proof. | Stabilizing with spans, excerpts, expected tokens, UTF-8, EOF, multiline, no-panic, generated-parser matrix canaries, and object-like `parse_document()`/JSON recovery proof for separator, UTF-8, multiline value, and multiline EOF cases. External-scanner dispatch now has focused parser-v4 proof for emitted-token byte spans/text, rejection of scanner tokens that are invalid in the parser state, direct parser-v4 `parse_document()` diagnostic-document behavior for bad input in an external-scanner grammar shape, and generated external-token grammar diagnostic-document behavior for malformed input. | Full parser-generated external-scanner recovery coverage remains future work; any Stable promotion still needs support-tier review. |
 | Every Stable README claim maps to proof. | README capability table; `SUPPORT_TIERS.md`; `readme_stable_claims_are_in_stable_product_lane`; `scripts/ci-product-stable.sh`. | Covered by current proof map and stable-product canaries. | The stable-product lane is still advisory, not branch-protection required. |
 | Experimental/developing surfaces are clearly labeled. | README capability table; `SUPPORT_TIERS.md`; `KNOWN_RED.md`; `PRODUCT_PROOF_MAP.md`. | Covered for runtime2, broader grammars, WASM, Tree-sitter interop, CLI, benchmarks, typed CST, incremental, and JSON. | Re-check after any README, support-tier, or release-facing wording change. |
-| Product works under ordinary user pressure and fails clearly. | Downstream starter fixture; README/tutorial/book quickstart canaries; CLI document JSON recovery diagnostics. | Partially covered by local/downstream fixtures and CLI recovery smoke. | Published CLI install, public promotion, and any future crates.io release surface need fresh receipts. |
+| Product works under ordinary user pressure and fails clearly. | Downstream starter fixture; README/tutorial/book quickstart canaries; CLI document JSON recovery diagnostics; public promotion PR #795. | Covered for local/downstream fixtures, CLI recovery smoke, and public repository promotion. | Published CLI install and any future crates.io release surface need fresh receipts. |
 
 ## Commands And Receipts
 
@@ -63,9 +63,9 @@ passed on 2026-05-19 from current `adze-swarm/main` after PR #281, commit
 advisory canaries skipped under the stable-only default. This is evidence for
 the README Stable claim lane; it is not a branch-protection change.
 
-Local receipt after residual product-trust PRs #295-#310: `just
+Local receipt after residual product-trust PRs #295-#311: `just
 ci-product-stable` passed on 2026-05-20 from `adze-swarm/main` at commit
-`e965cba2`, and the refreshed public promotion PR later passed the hosted
+`464a32a9`, and the refreshed public promotion PR later passed the hosted
 `ci-product stable canaries` job. These receipts cover README stable proof
 alignment, bounded published CLI install-claim wording, clean-room README/
 Getting Started/book quickstarts, checked-in downstream demo, standalone
@@ -126,30 +126,32 @@ just check-publishable
 
 `just check-publishable` passed on 2026-05-19 from `adze-swarm/main` after
 PR #253, again at commit `b613ebbb` after residual product-trust PRs
-#295-#301, and again on 2026-05-20 at commit `e965cba2` after PRs #309-#310.
+#295-#301, again on 2026-05-20 at commit `e965cba2` after PRs #309-#310, and
+again on 2026-05-20 at commit `464a32a9` after PR #311.
 It verifies publish-order metadata and `cargo package --list` for
 the core publish surface (`adze-common`, `adze-ir`, `adze-glr-core`,
 `adze-tablegen`, `adze-macro`, `adze-tool`, `adze-cli`, and `adze`). This is
 package metadata/file-list evidence only; it does not publish crates or prove
 registry installation.
 
-Current public promotion PR receipt:
+Current public promotion receipt:
 
 Public `EffortlessMetrics/adze#795` supersedes closed/unmerged public PR #794.
-It was opened from the explicit public promotion execution decision after the
-promotion branch was refreshed to the current `adze-swarm/main` tree. Verify
-the exact public head SHA live before review or merge because each accepted
-`adze-swarm` refresh can advance the promotion source. The refreshed public
-PR #795 check set passed on
-2026-05-20, including `Rust Small Result`, `Supported Rust Gate`, `PR Gate
+It was opened from the explicit public promotion execution decision, refreshed
+to `adze-swarm/main` commit `464a32a9`, and merged into public `main` on
+2026-05-20 as squash commit `a0d593e8`. The promoted public tree matches the
+`adze-swarm/main` tree at `464a32a9`. The refreshed public PR #795 check set
+passed on 2026-05-20, including `Rust Small Result`, `Supported Rust Gate`, `PR Gate
 Success`, `Source of Truth`, `CI Lane Whitelist`, `GLR Invariants`, `Coverage
 Lite`, `ci-product stable canaries`, `Test Core Crates`, `Test Runtime Crates`,
 and `Test Pure Rust Implementation`.
 
-This is a ready-for-review public promotion receipt, not a completed
-promotion. PR #795 remains open, mergeable, not draft, and has squash
-auto-merge enabled. The public merge state is blocked by the public `main`
-branch requirement for one approving review, not by failed CI.
+The public `main` branch-protection context was corrected from stale
+`ci-supported` to `Rust Small Result`, matching `.github/settings.yml` in the
+promoted tree. Before that correction, a manual `CI` workflow dispatch on the
+promotion branch also passed the legacy `ci-supported` job. No release tag,
+crate publish, signing, or Cargo-token workflow change happened as part of the
+promotion.
 
 Current first-use / CLI boundary receipts:
 
@@ -190,11 +192,6 @@ Do not mark the product objective complete while any of these are true:
 - `cargo install adze-cli` has no crates.io install receipt.
 - `ci-product-stable` is advisory and not a required branch-protection gate.
 - Full parser-generated external-scanner recovery coverage remains future work.
-- Public promotion has not happened. Public PR #795 is open, refreshed through
-  the latest source-side example-crate proof fix, green, and auto-merge-enabled, but
-  it still requires one public approving review before it can merge. Public
-  `EffortlessMetrics/adze` remains release/public-intake until promotion is
-  accepted.
 - GLR conflict routing, structured parse errors, Tree-sitter compatibility,
   query compatibility, CLI document output, and `AdzeDocument` are not all
   Stable; their current tiers and limitations are recorded in
@@ -202,11 +199,9 @@ Do not mark the product objective complete while any of these are true:
 
 ## Next Concrete Actions
 
-1. Review and approve public `EffortlessMetrics/adze#795`, or leave it parked
-   as the explicit green promotion PR until review is available. If
-   `adze-swarm/main` advances before review, refresh or supersede #795 again
-   before merge. If it merges, record a promotion closeout and refresh
-   public/main before any tag, publish, or release-workflow work.
+1. Refresh public `main` locally before any tag, publish, or release-workflow
+   work. Public promotion PR #795 has merged, but it did not publish crates or
+   prove registry installation.
 2. Run the crates.io install receipt after publish and before any doc claims
    `cargo install adze-cli` as the supported quickstart. The current local
    package receipt and verifier dry run are publish-readiness evidence only.

--- a/plans/release-promotion/promotion-execution-plan.md
+++ b/plans/release-promotion/promotion-execution-plan.md
@@ -197,6 +197,32 @@ Promotion boundary:
 - The public promotion branch must be refreshed from current `adze-swarm/main`
   if the swarm branch advances again before review/merge.
 
+### Fresh Receipt - 2026-05-20 Public Promotion Merge
+
+Public `EffortlessMetrics/adze#795` was refreshed from `adze-swarm/main` at
+commit `464a32a9` after PR #311 and merged into public `main` on 2026-05-20 as
+squash commit `a0d593e8`.
+
+Proof results:
+
+- `gh pr view 795 --repo EffortlessMetrics/adze --json state,mergedAt,mergeCommit,headRefOid`: passed; #795 is merged and the promoted head was `bcfddbd4`.
+- `gh pr checks 795 --repo EffortlessMetrics/adze`: passed after the final branch refresh.
+- `gh workflow run ci.yml --repo EffortlessMetrics/adze --ref public/promote-swarm-2026-05-19 -f run_full_ci=false -f run_ci_supported_examples=false`: passed and emitted the legacy public `ci-supported` context.
+- `just ci-product-stable`: passed from current `adze-swarm/main`.
+- `just check-publishable`: passed for `adze-common`, `adze-ir`,
+  `adze-glr-core`, `adze-tablegen`, `adze-macro`, `adze-tool`, `adze-cli`, and
+  `adze`.
+
+Promotion boundary:
+
+- The public branch-protection required context was corrected from stale
+  `ci-supported` to `Rust Small Result`, matching `.github/settings.yml` in
+  the promoted tree.
+- No release tag, crate publish, signing workflow, Cargo-token workflow, or
+  new Stable claim was added by this promotion.
+- Public `main` must be refreshed locally before any follow-up tag, publish,
+  release-workflow, or crates.io install-receipt work.
+
 ### Rollback
 
 Record defer if any proof fails and do not open a public PR.
@@ -344,17 +370,19 @@ was opened from a superseded decision.
 
 ## Public Promotion PR Receipt
 
-Status: ready for manual public review
+Status: merged
 Current public PR: EffortlessMetrics/adze#795
 Superseded public PR: EffortlessMetrics/adze#794 (closed/unmerged)
 Public branch: `public/promote-swarm-2026-05-19`
-Public head: verify live before review or merge
+Public head before merge: `bcfddbd4`
+Public merge commit: `a0d593e8`
 Prepared: 2026-05-20
+Merged: 2026-05-20
 
 ### Scope
 
-PR #795 is the current explicit public promotion PR prepared from this execution
-decision. It promotes the current `adze-swarm` source, documentation, proof
+PR #795 was the explicit public promotion PR prepared from this execution
+decision. It promoted the current `adze-swarm` source, documentation, proof
 maps, CI receipts, product fixtures, and support-tier-aligned claim boundaries
 into public `EffortlessMetrics/adze`.
 
@@ -408,11 +436,10 @@ the pure-rust matrix, and performance regression tests.
 
 ### Current Boundary
 
-PR #795 is open, mergeable, and not draft. Squash auto-merge is enabled. The
-public merge state is blocked by normal public review/merge controls, not by a
-failed CI receipt. Public PR #794 is closed/unmerged and superseded by #795.
+PR #795 is merged. Public PR #794 is closed/unmerged and superseded by #795.
+The live public `main` tree now matches the `adze-swarm/main` tree at commit
+`464a32a9`.
 
-If #795 is merged, record a promotion closeout and refresh public/main before
-starting any follow-up public release, tag, or publish work. If #795 is closed
-or superseded, record the reason and keep public `adze` as release/public-intake
-only.
+Refresh public/main before starting any follow-up public release, tag, publish,
+or crates.io install-receipt work. The promotion itself did not tag a release,
+publish crates, or prove `cargo install adze-cli`.


### PR DESCRIPTION
## Summary

Ports the `adze-swarm` status closeout that records public promotion PR #795 as merged.

## Production delta

Status/source-of-truth docs only:

- `.adze/goals/active.toml`
- `docs/status/NOW_NEXT_LATER.md`
- `docs/status/PRODUCT_OBJECTIVE_AUDIT.md`
- `plans/release-promotion/promotion-execution-plan.md`

## Non-goals

- No runtime changes.
- No release tag.
- No crate publish.
- No crates.io `cargo install adze-cli` claim.
- No support-tier promotion.

## Proof commands

Already passed in `adze-swarm#312` before this public sync:

```bash
git diff --check
cargo run -q -p xtask -- check-active-goal --mode blocking
cargo run -q -p xtask -- check-doc-artifacts --mode blocking
```

Public gate expected:

```text
Rust Small Result
```

## Rollback

Revert this status-only PR if the recorded public promotion receipt is inaccurate. This does not revert the already-merged promotion PR #795.