### PR TITLE
docs(status): sync release install gap receipts

### DIFF
--- a/.adze/goals/active.toml
+++ b/.adze/goals/active.toml
@@ -83,3 +83,38 @@ commands = [
   "just ci-product-stable",
   "just check-publishable",
 ]
+
+[[work_item]]
+id = "release-publish-decision-preflight"
+status = "complete"
+proposal = "ADZE-PROP-0005-release-promotion-readiness"
+spec = "ADZE-SPEC-0011"
+adr = "ADZE-ADR-0001"
+plan = "plans/product-gap-burn-down/implementation-plan.md"
+commands = [
+  "cargo info adze-cli",
+  "just package-local adze-cli",
+  "cargo run -q -p xtask -- verify-crates-io-install adze-cli --bin adze --version X.Y.Z --locked --dry-run",
+  "just check-publishable",
+]
+
+[[work_item]]
+id = "explicit-release-publish-workflow"
+status = "blocked"
+blocked_by = ["release-publish-decision-preflight"]
+proposal = "ADZE-PROP-0005-release-promotion-readiness"
+spec = "ADZE-SPEC-0011"
+adr = "ADZE-ADR-0001"
+plan = "plans/product-gap-burn-down/implementation-plan.md"
+
+[[work_item]]
+id = "crates-io-cli-install-receipt"
+status = "blocked"
+blocked_by = ["explicit-release-publish-workflow"]
+proposal = "ADZE-PROP-0005-release-promotion-readiness"
+spec = "ADZE-SPEC-0011"
+adr = "ADZE-ADR-0001"
+plan = "plans/product-gap-burn-down/implementation-plan.md"
+commands = [
+  "cargo run -q -p xtask -- verify-crates-io-install adze-cli --bin adze --version X.Y.Z --locked",
+]

--- a/docs/status/KNOWN_RED.md
+++ b/docs/status/KNOWN_RED.md
@@ -1,6 +1,6 @@
 # Known red
 
-**Last updated:** 2026-05-19
+**Last updated:** 2026-05-20
 
 This file tracks intentional exclusions from the supported lane:
 
@@ -75,8 +75,10 @@ These may run as optional signal (nightly/manual/canary), but are not required f
 - Published `cargo install adze-cli` proof. `just package-local adze-cli`
   passed on 2026-05-19 and verifies the local CLI package with co-release
   patches, but current product proof still uses the repo-built CLI and
-  downstream fixtures. Treat crates.io CLI installation as release-surface work
-  until an install receipt exists.
+  downstream fixtures. `cargo info adze-cli` was refreshed outside the
+  workspace on 2026-05-20 and reported that `adze-cli` is not present in
+  crates.io. Treat crates.io CLI installation as release-surface work until an
+  install receipt exists.
 
 ---
 

--- a/docs/status/NOW_NEXT_LATER.md
+++ b/docs/status/NOW_NEXT_LATER.md
@@ -92,9 +92,16 @@ Adze status and rolling execution plan. For recurring pain points, see [`docs/st
       and `just check-publishable` passed on 2026-05-19 from `adze-swarm`;
       `just check-publishable` was refreshed again on 2026-05-20 at commits
       `e965cba2` after residual product-trust PRs #309-#310 and `464a32a9`
-      after PR #311.
+      after PR #311, then `just package-local adze-cli` and
+      `just check-publishable` were refreshed on 2026-05-20 from
+      `adze-swarm/main` at commit `390ab76f`.
       These are package verification receipts, not crates.io install or publish
       claims.
+- [x] Latest crates.io CLI install-boundary receipt: `cargo info adze-cli`
+      was refreshed outside the workspace on 2026-05-20 and reported that
+      `adze-cli` is not present in crates.io. The active goal now carries a
+      blocked `crates-io-cli-install-receipt` item so agents do not confuse
+      local package verification with a registry install receipt.
 
 ### Operational tail
 - [x] [Issue #269](https://github.com/EffortlessMetrics/adze/issues/269): pure-rust benchmark-compilation tail is removed from routine PRs; benchmark compile/performance signal remains in explicit performance and benchmark lanes.

--- a/docs/status/PRODUCT_OBJECTIVE_AUDIT.md
+++ b/docs/status/PRODUCT_OBJECTIVE_AUDIT.md
@@ -166,7 +166,8 @@ cargo run -q -p xtask -- verify-crates-io-install adze-cli --bin adze --version 
 
 `just package-local adze-cli` packages and verifies the CLI crate with local
 patches for unpublished co-release crates. It passed on 2026-05-19 from
-`adze-swarm`, producing and verifying `adze-cli v0.8.0-dev`. This is local
+`adze-swarm`, producing and verifying `adze-cli v0.8.0-dev`, and passed again
+on 2026-05-20 from `adze-swarm/main` at commit `390ab76f`. This is local
 publish-readiness evidence, not a crates.io install receipt.
 
 `cargo_install_adze_cli_claims_stay_release_surface_bounded` keeps live
@@ -175,15 +176,18 @@ quickstart until a crates.io receipt exists. It is a claim-boundary canary, not
 registry installation proof.
 
 The `cargo info adze-cli` command must be run outside the workspace when it is
-used to verify registry publication. On 2026-05-19 it reported that `adze-cli`
-could not be found in crates.io, so `cargo install adze-cli` remains a
-release-surface target rather than current product proof.
+used to verify registry publication. It reported on 2026-05-19 and again on
+2026-05-20 that `adze-cli` could not be found in crates.io, so
+`cargo install adze-cli` remains a release-surface target rather than current
+product proof.
 
 `cargo run -q -p xtask -- verify-crates-io-install adze-cli --bin adze --version
 X.Y.Z` is the post-publish receipt hook for the missing crates.io install proof.
 It installs from crates.io into an isolated temporary root and runs
 `adze --version`. The `--dry-run` mode is pre-publish command-shape evidence
 only; it does not contact crates.io and does not close the install-receipt gap.
+The dry-run command shape was refreshed on 2026-05-20 from `adze-swarm/main` at
+commit `390ab76f`.
 
 ## Current Non-Completion Reasons
 

--- a/plans/product-gap-burn-down/implementation-plan.md
+++ b/plans/product-gap-burn-down/implementation-plan.md
@@ -412,3 +412,149 @@ git diff --check
 
 Revert the status-doc refresh. Do not revert PR #298 unless the parser-v4
 external-scanner behavior itself needs to be rolled back.
+
+## Work Item: release-publish-decision-preflight
+
+Status: complete
+Linked proposal: ../../docs/proposals/ADZE-PROP-0005-release-promotion-readiness.md
+Linked spec: ../../docs/specs/ADZE-SPEC-0011-product-proof-and-support-tiers.md
+Linked ADR: ../../docs/adr/ADZE-ADR-0001-adze-document-one-parse-truth.md
+Blocks: explicit-release-publish-workflow
+Blocked by: n/a
+
+### Goal
+
+Prepare the explicit release/publish decision without publishing. This item
+refreshes the registry boundary and local publish-readiness receipts so a human
+release decision can happen from current facts.
+
+### Production Delta
+
+Source-of-truth status only unless a proof command exposes a real package or
+claim-boundary failure.
+
+### Receipt
+
+On 2026-05-20 from `adze-swarm/main` at commit `390ab76f`:
+
+- `cargo info adze-cli` reported that `adze-cli` is not present in crates.io.
+- `just package-local adze-cli` packaged and verified `adze-cli v0.8.0-dev`
+  with local co-release patches.
+- `cargo run -q -p xtask -- verify-crates-io-install adze-cli --bin adze
+  --version X.Y.Z --locked --dry-run` printed the post-publish install command
+  plan and reiterated that dry-run is not registry installation proof.
+- `just check-publishable` passed for `adze-common`, `adze-ir`,
+  `adze-glr-core`, `adze-tablegen`, `adze-macro`, `adze-tool`, `adze-cli`, and
+  `adze`.
+
+This is a release decision preflight receipt, not a publish, tag, or install
+receipt.
+
+### Non-Goals
+
+- No crate publish.
+- No release tag.
+- No signing, Cargo-token, or release-workflow mutation.
+- No README claim that `cargo install adze-cli` is the supported quickstart.
+
+### Proof Commands
+
+```bash
+cargo info adze-cli
+just package-local adze-cli
+cargo run -q -p xtask -- verify-crates-io-install adze-cli --bin adze --version X.Y.Z --locked --dry-run
+just check-publishable
+```
+
+### Rollback
+
+Revert only source-of-truth receipt updates. If proof commands expose a real
+package or claim-boundary failure, fix that in a separate focused PR.
+
+## Work Item: explicit-release-publish-workflow
+
+Status: blocked
+Linked proposal: ../../docs/proposals/ADZE-PROP-0005-release-promotion-readiness.md
+Linked spec: ../../docs/specs/ADZE-SPEC-0011-product-proof-and-support-tiers.md
+Linked ADR: ../../docs/adr/ADZE-ADR-0001-adze-document-one-parse-truth.md
+Blocks: crates-io-cli-install-receipt
+Blocked by: explicit human release/publish authorization after the completed
+preflight
+
+### Goal
+
+Publish the release surface only through an explicit release workflow. This is
+outside routine swarm implementation and product-proof work.
+
+### Non-Goals
+
+- No automatic publish from product-proof receipts.
+- No tag, signing, Cargo-token, or release-workflow mutation without explicit
+  release authorization.
+- No public install claim until the post-publish install receipt passes.
+
+### Rollback
+
+If a release or publish operation happens, do not rewrite public history. Use
+the release incident process and publish a corrective release if needed.
+
+## Work Item: crates-io-cli-install-receipt
+
+Status: blocked
+Linked proposal: ../../docs/proposals/ADZE-PROP-0005-release-promotion-readiness.md
+Linked spec: ../../docs/specs/ADZE-SPEC-0011-product-proof-and-support-tiers.md
+Linked ADR: ../../docs/adr/ADZE-ADR-0001-adze-document-one-parse-truth.md
+Blocks: objective-completion
+Blocked by: explicit-release-publish-workflow
+
+### Goal
+
+Close the remaining published first-use receipt gap only after the CLI release
+surface exists on crates.io. Until then, the product proof remains limited to
+repo-built CLI quickstarts, downstream fixtures, local package verification, and
+claim-boundary checks.
+
+### Current Receipt
+
+On 2026-05-20, `cargo info adze-cli` was run outside the workspace and reported:
+
+```text
+error: could not find `adze-cli` in registry `https://github.com/rust-lang/crates.io-index`
+```
+
+This confirms the `cargo install adze-cli` path is still a release-surface
+target, not current product proof.
+
+### Production Delta
+
+Source-of-truth status only until an explicit release/publish workflow runs.
+
+### Non-Goals
+
+- No crate publish from this work item.
+- No release tag.
+- No signing, Cargo-token, or release-workflow mutation.
+- No README claim that `cargo install adze-cli` is the supported quickstart
+  until the install receipt passes.
+
+### Proof Commands
+
+Pre-publish boundary:
+
+```bash
+cargo info adze-cli
+just package-local adze-cli
+cargo run -q -p xtask -- verify-crates-io-install adze-cli --bin adze --version X.Y.Z --locked --dry-run
+```
+
+Post-publish receipt:
+
+```bash
+cargo run -q -p xtask -- verify-crates-io-install adze-cli --bin adze --version X.Y.Z --locked
+```
+
+### Rollback
+
+Revert only the source-of-truth receipt update. If a release or publish
+operation has happened, use the release incident process instead of rewriting
+public history.


### PR DESCRIPTION
## Summary

Syncs the release install-gap and release-preflight receipts from `adze-swarm` into public `adze` after `adze-swarm` PRs #313 and #314.

## Linked artifacts

- Proposal: `ADZE-PROP-0005-release-promotion-readiness`
- Spec: `ADZE-SPEC-0011-product-proof-and-support-tiers`
- ADR: `ADZE-ADR-0001-adze-document-one-parse-truth`
- Plan: `plans/product-gap-burn-down/implementation-plan.md`
- Active goal items: `release-publish-decision-preflight`, `explicit-release-publish-workflow`, `crates-io-cli-install-receipt`

## Production delta

- Updates public status/source-of-truth docs to match the current `adze-swarm` release-preflight truth.
- Records that `cargo info adze-cli` still cannot find `adze-cli` in crates.io.
- Records that package-local and publishability preflight receipts passed.
- Leaves the actual release/publish workflow blocked and explicit.

## Non-goals

- No runtime behavior change.
- No crate publish.
- No release tag.
- No signing, Cargo-token, or release workflow change.
- No support-tier promotion.
- No `cargo install adze-cli` quickstart claim.

## Source-of-truth impact

- Public `adze` regains the same status truth as `adze-swarm` for the residual product-trust campaign.
- Stable README claims remain unchanged.
- The install receipt gap remains open until a real crates.io install receipt exists.

## User impact

Keeps the public repo honest about the first-use boundary: local downstream quickstarts are proven, but published CLI install remains release-surface work.

## Agent impact

Prevents future agents from treating local package verification as permission to claim or publish `cargo install adze-cli`.

## Proof commands

```bash
cargo info adze-cli
just package-local adze-cli
cargo run -q -p xtask -- verify-crates-io-install adze-cli --bin adze --version X.Y.Z --locked --dry-run
just check-publishable
cargo run -q -p xtask -- check-active-goal --mode blocking
cargo run -q -p xtask -- check-doc-artifacts --mode blocking
git diff --check
```

## Rollback

Revert this status-sync PR. If a real publish or release operation later happens, use the release incident process instead of rewriting public history.