### PR TITLE
docs(status): sync paused product trust handoff

### DIFF
--- a/.adze/goals/active.toml
+++ b/.adze/goals/active.toml
@@ -1,6 +1,6 @@
 id = "adze-residual-product-trust-hardening"
 title = "Adze Residual Product Trust Hardening"
-status = "active"
+status = "paused"
 owner = "runtime/product"
 created = "2026-05-19"
 
@@ -9,6 +9,13 @@ Burn down the remaining product-trust gaps that surfaced after the public
 promotion execution closeout. Keep work in adze-swarm, keep public adze as the
 release/public-intake surface, and either prove or explicitly bound every
 remaining product claim before public promotion.
+"""
+
+pause_reason = """
+All routine swarm product-proof work in this lane is complete. The remaining
+items require explicit human release/publish authorization before any tag,
+crate publish, Cargo-token, signing, or crates.io install-receipt work can
+proceed.
 """
 
 end_state = [

--- a/docs/status/NOW_NEXT_LATER.md
+++ b/docs/status/NOW_NEXT_LATER.md
@@ -1,7 +1,7 @@
 # Now / Next / Later
 
 **Last updated:** 2026-05-20
-**Status:** **Residual product trust hardening active** — `adze-swarm` remains the operating repo for follow-up product-proof work, public promotion PR #795 has merged into public `adze`, and the remaining blockers in [`PRODUCT_OBJECTIVE_AUDIT.md`](./PRODUCT_OBJECTIVE_AUDIT.md) must stay explicitly proved or bounded before any tag, publish, or release-workflow work. Toolkit excellence is complete with closeout recorded in [`../../plans/toolkit-excellence/closeout.md`](../../plans/toolkit-excellence/closeout.md). Release promotion readiness is closed out in [`../../plans/release-promotion/closeout.md`](../../plans/release-promotion/closeout.md).
+**Status:** **Residual product trust hardening paused pending explicit release/publish authorization** — `adze-swarm` remains the operating repo for follow-up product-proof work, public promotion PR #795 has merged into public `adze`, public status sync PR #797 has synced the latest install-gap receipts, and the remaining blockers in [`PRODUCT_OBJECTIVE_AUDIT.md`](./PRODUCT_OBJECTIVE_AUDIT.md) must stay explicitly proved or bounded before any tag, publish, or release-workflow work. Toolkit excellence is complete with closeout recorded in [`../../plans/toolkit-excellence/closeout.md`](../../plans/toolkit-excellence/closeout.md). Release promotion readiness is closed out in [`../../plans/release-promotion/closeout.md`](../../plans/release-promotion/closeout.md). Current handoff: [`../../plans/product-gap-burn-down/handoff.md`](../../plans/product-gap-burn-down/handoff.md).
 
 Adze status and rolling execution plan. For recurring pain points, see [`docs/status/FRICTION_LOG.md`](./FRICTION_LOG.md). For API stability guarantees per crate, see [`docs/status/API_STABILITY.md`](./API_STABILITY.md). For support-tier proof commands, see [`docs/status/SUPPORT_TIERS.md`](./SUPPORT_TIERS.md).
 
@@ -102,6 +102,9 @@ Adze status and rolling execution plan. For recurring pain points, see [`docs/st
       `adze-cli` is not present in crates.io. The active goal now carries a
       blocked `crates-io-cli-install-receipt` item so agents do not confuse
       local package verification with a registry install receipt.
+- [x] Residual product-trust lane paused with no ready routine swarm work. The
+      remaining active-manifest items are blocked on explicit release/publish
+      authorization and the post-publish crates.io install receipt.
 
 ### Operational tail
 - [x] [Issue #269](https://github.com/EffortlessMetrics/adze/issues/269): pure-rust benchmark-compilation tail is removed from routine PRs; benchmark compile/performance signal remains in explicit performance and benchmark lanes.

--- a/docs/status/PRODUCT_OBJECTIVE_AUDIT.md
+++ b/docs/status/PRODUCT_OBJECTIVE_AUDIT.md
@@ -203,11 +203,16 @@ Do not mark the product objective complete while any of these are true:
 
 ## Next Concrete Actions
 
-1. Refresh public `main` locally before any tag, publish, or release-workflow
-   work. Public promotion PR #795 has merged, but it did not publish crates or
-   prove registry installation.
-2. Run the crates.io install receipt after publish and before any doc claims
-   `cargo install adze-cli` as the supported quickstart. The current local
-   package receipt and verifier dry run are publish-readiness evidence only.
+The product-trust lane is paused in
+[`../../plans/product-gap-burn-down/handoff.md`](../../plans/product-gap-burn-down/handoff.md)
+because the remaining work requires explicit human release/publish
+authorization.
+
+1. If release/publish is authorized, refresh public `main`, rerun release
+   preflight, follow `docs/reference/PUBLISH_CHECKLIST.md`, then run the
+   crates.io install receipt after publish and before any doc claims
+   `cargo install adze-cli` as the supported quickstart.
+2. If no release/publish authorization exists, do not tag, publish, mutate
+   signing/Cargo-token workflows, or claim `cargo install adze-cli`.
 3. Consider promoting `ci-product-stable` only after advisory receipts are
    consistently green and branch-protection policy is updated deliberately.

--- a/plans/product-gap-burn-down/handoff.md
+++ b/plans/product-gap-burn-down/handoff.md
@@ -1,0 +1,79 @@
+# Product Gap Burn-Down Handoff
+
+Status: paused
+Owner: runtime/product
+Created: 2026-05-20
+Active goal: ../../.adze/goals/active.toml
+Plan: ./implementation-plan.md
+Support-tier impact: no tier changes
+Policy impact: no branch-protection, release, publish, signing, or Cargo-token change
+
+## State
+
+The residual product-trust lane has no ready routine swarm work.
+
+Completed proof work includes:
+
+- release-facing wording boundary sweep;
+- focused external-scanner recovery proof;
+- product objective audit refresh;
+- public promotion blocker watch and public promotion merge;
+- crates.io install-gap source-of-truth receipt;
+- release/publish decision preflight receipt.
+
+The remaining active-manifest items are blocked:
+
+- `explicit-release-publish-workflow`;
+- `crates-io-cli-install-receipt`.
+
+## Why Paused
+
+The remaining work requires an explicit human release/publish decision. Agents
+must not infer that local package verification, publishability checks, dry-run
+install command shape, public promotion, or green CI grants permission to tag,
+publish crates, mutate signing or Cargo-token workflows, or claim
+`cargo install adze-cli`.
+
+## Latest Receipts
+
+```bash
+cargo info adze-cli
+just package-local adze-cli
+cargo run -q -p xtask -- verify-crates-io-install adze-cli --bin adze --version X.Y.Z --locked --dry-run
+just check-publishable
+cargo run -q -p xtask -- check-active-goal --mode blocking
+cargo run -q -p xtask -- check-doc-artifacts --mode blocking
+git diff --check
+```
+
+Observed results:
+
+- `cargo info adze-cli` reported that `adze-cli` is not present in crates.io.
+- `just package-local adze-cli` passed for the local CLI package.
+- The crates.io install verifier dry run printed the post-publish command
+  shape and did not contact crates.io.
+- `just check-publishable` passed for the release surface.
+- Source-of-truth checks passed.
+
+## Resume Conditions
+
+Resume this lane only when one of these is true:
+
+- a human explicitly authorizes release/publish execution;
+- a new product-proof gap is discovered that does not require release/publish
+  authorization;
+- a support-tier, README, or release-facing claim changes and needs a fresh
+  proof-boundary audit.
+
+## Next Authorized Release Step
+
+If release/publish is authorized, start from current public `adze/main`, refresh
+both PR queues, verify public and swarm trees, rerun the release preflight, and
+follow `docs/reference/PUBLISH_CHECKLIST.md` plus the release incident rules in
+`plans/release-promotion/public-promotion-pr-plan.md`.
+
+The post-publish install receipt remains:
+
+```bash
+cargo run -q -p xtask -- verify-crates-io-install adze-cli --bin adze --version X.Y.Z --locked
+```

--- a/plans/product-gap-burn-down/implementation-plan.md
+++ b/plans/product-gap-burn-down/implementation-plan.md
@@ -1,6 +1,6 @@
 # Product Gap Burn-Down Plan
 
-Status: active
+Status: paused
 Owner: runtime/product
 Created: 2026-05-19
 Linked proposal:
@@ -24,6 +24,13 @@ Burn down the remaining blockers named in
 `docs/status/PRODUCT_OBJECTIVE_AUDIT.md` without broadening public claims. This
 plan owns the next execution queue after the completed toolkit excellence and
 release-promotion readiness campaigns.
+
+## Handoff State
+
+The routine swarm work for this lane is paused. The current active manifest has
+no ready work items: the release/publish preflight is complete, and the only
+remaining items are blocked on explicit human release/publish authorization and
+the post-publish crates.io install receipt.
 
 ## Operating Rules
 


### PR DESCRIPTION
## Summary

Syncs the paused residual product-trust handoff from `adze-swarm` into public `adze` after `adze-swarm` PR #315.

## Linked artifacts

- Proposal: `ADZE-PROP-0005-release-promotion-readiness`
- Spec: `ADZE-SPEC-0011-product-proof-and-support-tiers`
- ADR: `ADZE-ADR-0001-adze-document-one-parse-truth`
- Plan: `plans/product-gap-burn-down/implementation-plan.md`
- Handoff: `plans/product-gap-burn-down/handoff.md`

## Production delta

- Marks the residual product-trust active manifest paused in public status truth.
- Adds the product-gap handoff that records why no routine swarm work remains.
- Keeps release/publish and crates.io install receipt items blocked.

## Non-goals

- No runtime behavior change.
- No crate publish.
- No release tag.
- No signing, Cargo-token, or release workflow change.
- No support-tier promotion.
- No `cargo install adze-cli` quickstart claim.

## Source-of-truth impact

- Public `adze` regains the same paused lane state as `adze-swarm`.
- Stable README claims remain unchanged.
- The install receipt gap remains open until a real crates.io install receipt exists.

## User impact

Keeps public status honest: local package/downstream proof exists, but the remaining work needs explicit release/publish authorization before any published install claim.

## Agent impact

Prevents future agents from inventing ready work when the active manifest has only blocked release/install items.

## Proof commands

```bash
cargo run -q -p xtask -- check-active-goal --mode blocking
cargo run -q -p xtask -- check-doc-artifacts --mode blocking
git diff --check
```

## Rollback

Revert this status-sync PR. Do not use rollback to imply release/publish authorization.